### PR TITLE
change the order of message table and remove the time to live

### DIFF
--- a/writer/cassandra/init.go
+++ b/writer/cassandra/init.go
@@ -25,7 +25,7 @@ var tables []string = []string{
 		ut double,
 		l text,
 		PRIMARY KEY ((channel), id)
-	) WITH default_time_to_live = 86400`,
+	) WITH CLUSTERING ORDER BY (id DESC)`,
 }
 
 // Connect establishes connection to the Cassandra cluster.


### PR DESCRIPTION
Change the order of table, so the query can get the latest result.
Remove the time to live on the table, as the data need be kept for longer time.