### PR TITLE
fix external_link dependency for http adaptor service

### DIFF
--- a/bin/docker/docker-compose.mainflux.yml
+++ b/bin/docker/docker-compose.mainflux.yml
@@ -72,6 +72,7 @@ services:
       - "7070:7070"
     external_links:
       - mainflux-nats:nats
+      - mainflux-manager:manager
     environment:
       - HTTP_ADAPTER_NATS_URL=nats://nats:4222
       - HTTP_ADAPTER_MANAGER_URL=http://manager:8180


### PR DESCRIPTION
Signed-off-by: kelvinji <kelvinji2009@gmail.com>

`http adaptor` service will call the API `can_access` in `manager` service by `ManagerClient`, so we need to link the `manager` container to `http adaptor` container. 