### PR TITLE
Fix normalizer output queue

### DIFF
--- a/normalizer/normalizer.go
+++ b/normalizer/normalizer.go
@@ -57,7 +57,7 @@ func (ef eventFlow) publish(msg mainflux.RawMessage) error {
 			return err
 		}
 
-		if err = ef.nc.Publish(subject, data); err != nil {
+		if err = ef.nc.Publish(output, data); err != nil {
 			ef.logger.Log("error", fmt.Sprintf("Publishing failed: %s", err))
 			return err
 		}

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-const version string = "0.1.0"
+const version string = "0.1.1"
 
 type response struct {
 	Version string


### PR DESCRIPTION
Fix normalizer output queue by changing subject to normalized.
Version updated from 0.1.0 to 0.1.1.

Signed-off-by: Aleksandar Novakovic <anovakovic01@gmail.com>