### PR TITLE
Rename NATS subjects for HTTP & normalizer

### DIFF
--- a/http/nats/publisher.go
+++ b/http/nats/publisher.go
@@ -2,12 +2,12 @@
 package nats
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/mainflux/mainflux"
 	broker "github.com/nats-io/go-nats"
 )
-
-const topic string = "src.http"
 
 var _ mainflux.MessagePublisher = (*natsPublisher)(nil)
 
@@ -26,5 +26,6 @@ func (pub *natsPublisher) Publish(msg mainflux.RawMessage) error {
 		return err
 	}
 
-	return pub.nc.Publish(topic, data)
+	subject := fmt.Sprintf("channel.%s", msg.Channel)
+	return pub.nc.Publish(subject, data)
 }

--- a/normalizer/normalizer.go
+++ b/normalizer/normalizer.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	queue   string = "normalizers"
-	subject string = "src.*"
+	subject string = "channel.*"
 	output  string = "normalized"
 )
 


### PR DESCRIPTION
This pull request resolves #204.

Due to the latest messaging design changes, subjects used to publish and consume messages from by HTTP adapter and normalizer, respectively, had to be renamed.