### PR TITLE
NOISSUE - Add HTTP adapter API test

### DIFF
--- a/http/api/transport_test.go
+++ b/http/api/transport_test.go
@@ -1,0 +1,110 @@
+package api_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mainflux/mainflux"
+	adapter "github.com/mainflux/mainflux/http"
+	"github.com/mainflux/mainflux/http/api"
+	"github.com/mainflux/mainflux/http/mocks"
+	manager "github.com/mainflux/mainflux/manager/client"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	id           = "123e4567-e89b-12d3-a456-000000000001"
+	token        = "auth_token"
+	invalidToken = "invalid_token"
+	msg          = `[{"n":"current","t":-1,"v":1.6}]`
+)
+
+func newService() mainflux.MessagePublisher {
+	pub := mocks.NewPublisher()
+	return adapter.New(pub)
+}
+
+func newHTTPServer(pub mainflux.MessagePublisher, mc manager.ManagerClient) *httptest.Server {
+	mux := api.MakeHandler(pub, mc)
+	return httptest.NewServer(mux)
+}
+
+func newManagerServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "invalid_token" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func newManagerClient(url string) manager.ManagerClient {
+	return manager.NewClient(url)
+}
+
+type testRequest struct {
+	client      *http.Client
+	method      string
+	url         string
+	contentType string
+	token       string
+	body        io.Reader
+}
+
+func (tr testRequest) make() (*http.Response, error) {
+	req, err := http.NewRequest(tr.method, tr.url, tr.body)
+	if err != nil {
+		return nil, err
+	}
+	if tr.token != "" {
+		req.Header.Set("Authorization", tr.token)
+	}
+	if tr.contentType != "" {
+		req.Header.Set("Content-Type", tr.contentType)
+	}
+	return tr.client.Do(req)
+}
+
+func TestPublish(t *testing.T) {
+	mcServer := newManagerServer()
+	defer mcServer.Close()
+	mc := newManagerClient(mcServer.URL)
+
+	pub := newService()
+	ts := newHTTPServer(pub, mc)
+	defer ts.Close()
+	client := ts.Client()
+
+	cases := map[string]struct {
+		chanID      string
+		msg         string
+		contentType string
+		auth        string
+		status      int
+	}{
+		"publish message":                                  {id, msg, "application/senml+json", token, http.StatusAccepted},
+		"publish message with no authorization token":      {id, msg, "application/senml+json", "", http.StatusForbidden},
+		"publish message with invalid authorization token": {id, msg, "application/senml+json", invalidToken, http.StatusForbidden},
+		"publish message with no content type":             {id, msg, "", token, http.StatusAccepted},
+		"publish message with invalid channel id":          {"1", msg, "application/senml+json", token, http.StatusNotFound},
+	}
+
+	for desc, tc := range cases {
+		req := testRequest{
+			client:      client,
+			method:      http.MethodPost,
+			url:         fmt.Sprintf("%s/channels/%s/messages", ts.URL, tc.chanID),
+			contentType: tc.contentType,
+			token:       tc.auth,
+			body:        strings.NewReader(tc.msg),
+		}
+		res, err := req.make()
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", desc, tc.status, res.StatusCode))
+	}
+}

--- a/http/mocks/publisher.go
+++ b/http/mocks/publisher.go
@@ -1,0 +1,16 @@
+package mocks
+
+import "github.com/mainflux/mainflux"
+
+var _ (mainflux.MessagePublisher) = (*mockPublisher)(nil)
+
+type mockPublisher struct{}
+
+// NewPublisher returns mock message publisher.
+func NewPublisher() mainflux.MessagePublisher {
+	return mockPublisher{}
+}
+
+func (pub mockPublisher) Publish(msg mainflux.RawMessage) error {
+	return nil
+}

--- a/manager/api/transport_test.go
+++ b/manager/api/transport_test.go
@@ -20,6 +20,7 @@ const (
 	contentType  = "application/json; charset=utf-8"
 	invalidEmail = "userexample.com"
 	wrongID      = "123e4567-e89b-12d3-a456-000000000042"
+	id           = "123e4567-e89b-12d3-a456-000000000001"
 )
 
 var (
@@ -178,14 +179,15 @@ func TestAddClient(t *testing.T) {
 		contentType string
 		auth        string
 		status      int
+		location    string
 	}{
-		{"add valid client", data, contentType, user.Email, http.StatusCreated},
-		{"add client with invalid data", invalidData, contentType, user.Email, http.StatusBadRequest},
-		{"add client with invalid auth token", data, contentType, "invalid_token", http.StatusForbidden},
-		{"add client with invalid request format", "}", contentType, user.Email, http.StatusBadRequest},
-		{"add client with empty JSON request", "{}", contentType, user.Email, http.StatusBadRequest},
-		{"add client with empty request", "", contentType, user.Email, http.StatusBadRequest},
-		{"add client with missing content type", data, "", user.Email, http.StatusUnsupportedMediaType},
+		{"add valid client", data, contentType, user.Email, http.StatusCreated, fmt.Sprintf("/clients/%s", id)},
+		{"add client with invalid data", invalidData, contentType, user.Email, http.StatusBadRequest, ""},
+		{"add client with invalid auth token", data, contentType, "invalid_token", http.StatusForbidden, ""},
+		{"add client with invalid request format", "}", contentType, user.Email, http.StatusBadRequest, ""},
+		{"add client with empty JSON request", "{}", contentType, user.Email, http.StatusBadRequest, ""},
+		{"add client with empty request", "", contentType, user.Email, http.StatusBadRequest, ""},
+		{"add client with missing content type", data, "", user.Email, http.StatusUnsupportedMediaType, ""},
 	}
 
 	for _, tc := range cases {
@@ -199,7 +201,10 @@ func TestAddClient(t *testing.T) {
 		}
 		res, err := req.make()
 		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+
+		location := res.Header.Get("Location")
 		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", tc.desc, tc.status, res.StatusCode))
+		assert.Equal(t, tc.location, location, fmt.Sprintf("%s: expected location %s got %s", tc.desc, tc.location, location))
 	}
 }
 
@@ -388,13 +393,14 @@ func TestCreateChannel(t *testing.T) {
 		contentType string
 		auth        string
 		status      int
+		location    string
 	}{
-		{"create new channel", data, contentType, user.Email, http.StatusCreated},
-		{"create new channel with invalid token", data, contentType, invalidEmail, http.StatusForbidden},
-		{"create new channel with invalid data format", "{", contentType, user.Email, http.StatusBadRequest},
-		{"create new channel with empty JSON request", "{}", contentType, user.Email, http.StatusCreated},
-		{"create new channel with empty request", "", contentType, user.Email, http.StatusBadRequest},
-		{"create new channel with missing content type", data, "", user.Email, http.StatusUnsupportedMediaType},
+		{"create new channel", data, contentType, user.Email, http.StatusCreated, fmt.Sprintf("/channels/%s", id)},
+		{"create new channel with invalid token", data, contentType, invalidEmail, http.StatusForbidden, ""},
+		{"create new channel with invalid data format", "{", contentType, user.Email, http.StatusBadRequest, ""},
+		{"create new channel with empty JSON request", "{}", contentType, user.Email, http.StatusCreated, "/channels/123e4567-e89b-12d3-a456-000000000002"},
+		{"create new channel with empty request", "", contentType, user.Email, http.StatusBadRequest, ""},
+		{"create new channel with missing content type", data, "", user.Email, http.StatusUnsupportedMediaType, ""},
 	}
 
 	for _, tc := range cases {
@@ -408,7 +414,10 @@ func TestCreateChannel(t *testing.T) {
 		}
 		res, err := req.make()
 		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+
+		location := res.Header.Get("Location")
 		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", tc.desc, tc.status, res.StatusCode))
+		assert.Equal(t, tc.location, location, fmt.Sprintf("%s: expected location %s got %s", tc.desc, tc.location, location))
 	}
 }
 


### PR DESCRIPTION
Add HTTP adapter API tests. Fix Manager API tests by adding assertion
of `Location` header value in some cases.

Signed-off-by: Aleksandar Novakovic <anovakovic01@gmail.com>