### PR TITLE
MF-164 - Update make file in order to support new services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILD_DIR = build
-SERVICES = manager http normalizer ws
+SERVICES = users clients http normalizer ws
 DOCKERS = $(addprefix docker_,$(SERVICES))
 CGO_ENABLED ?= 0
 GOOS ?= linux
@@ -23,7 +23,7 @@ install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 
 proto:
-	protoc --go_out=. *.proto
+	protoc --go_out=plugins=grpc:. *.proto
 
 $(SERVICES): proto
 	$(call compile_service,$(@))

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-const version string = "0.2.3"
+const version string = "0.3.0"
 
 type response struct {
 	Service string `json:"service"`


### PR DESCRIPTION
Update make file in order to support users and clients services.
Update mainflux version to 0.3.0.

Signed-off-by: Aleksandar Novakovic <anovakovic01@gmail.com>