### PR TITLE
NOISSUE - Update load tests in accordance with latest architecture changes

### DIFF
--- a/load-test/README.md
+++ b/load-test/README.md
@@ -14,8 +14,9 @@ default values.
 
 | Variable | Description                              | Default               |
 |----------|------------------------------------------|-----------------------|
-| manager  | Manager service URL                      | http://localhost:8180 |
-| http     | HTTP adapter service URL                 | http://localhost:8182 |
+| users    | Users service URL                        | http://localhost:8180 |
+| clients  | Clients service URL                      | http://localhost:8182 |
+| http     | HTTP adapter service URL                 | http://localhost:8185 |
 | requests | Number of requests to be sent per second | 100                   |
 
 ## Usage

--- a/load-test/src/test/scala/com/mainflux/loadtest/simulations/Constants.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/simulations/Constants.scala
@@ -1,7 +1,8 @@
 package com.mainflux.loadtest.simulations
 
 object Constants {
-  val ManagerUrl = System.getProperty("manager", "http://localhost:8180")
-  val HttpAdapterUrl = System.getProperty("http", "http://localhost:8182")
+  val UsersUrl = System.getProperty("users", "http://localhost:8180")
+  val ClientsUrl = System.getProperty("clients", "http://localhost:8182")
+  val HttpAdapterUrl = System.getProperty("http", "http://localhost:8185")
   val RequestsPerSecond = Integer.getInteger("requests", 100)
 }

--- a/load-test/src/test/scala/com/mainflux/loadtest/simulations/CreateAndRetrieveClientSimulation.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/simulations/CreateAndRetrieveClientSimulation.scala
@@ -17,13 +17,13 @@ import com.mainflux.loadtest.simulations.Constants._
 class CreateAndRetrieveClientSimulation extends Simulation {
 
   // Register user
-  Http(s"${ManagerUrl}/users")
+  Http(s"${UsersUrl}/users")
     .postData(User)
     .header(HttpHeaderNames.ContentType, ContentType)
     .asString
 
   // Login user
-  val tokenRes = Http(s"${ManagerUrl}/tokens")
+  val tokenRes = Http(s"${UsersUrl}/tokens")
     .postData(User)
     .header(HttpHeaderNames.ContentType, ContentType)
     .asString
@@ -34,7 +34,7 @@ class CreateAndRetrieveClientSimulation extends Simulation {
 
   // Prepare testing scenario
   val httpProtocol = http
-    .baseURL(ManagerUrl)
+    .baseURL(ClientsUrl)
     .inferHtmlResources()
     .acceptHeader("*/*")
     .contentTypeHeader(ContentType)

--- a/load-test/src/test/scala/com/mainflux/loadtest/simulations/PublishSimulation.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/simulations/PublishSimulation.scala
@@ -17,13 +17,13 @@ import com.mainflux.loadtest.simulations.Constants._
 class PublishSimulation extends Simulation {
 
   // Register user
-  Http(s"${ManagerUrl}/users")
+  Http(s"${UsersUrl}/users")
     .postData(User)
     .header(HttpHeaderNames.ContentType, ContentType)
     .asString
 
   // Login user
-  val tokenRes = Http(s"${ManagerUrl}/tokens")
+  val tokenRes = Http(s"${UsersUrl}/tokens")
     .postData(User)
     .header(HttpHeaderNames.ContentType, ContentType)
     .asString
@@ -33,7 +33,7 @@ class PublishSimulation extends Simulation {
   val token = tokenCursor.downField("token").as[String].getOrElse("")
 
   // Register client
-  val clientLocation = Http(s"${ManagerUrl}/clients")
+  val clientLocation = Http(s"${ClientsUrl}/clients")
     .postData(Client)
     .header(HttpHeaderNames.Authorization, token)
     .header(HttpHeaderNames.ContentType, ContentType)
@@ -43,7 +43,7 @@ class PublishSimulation extends Simulation {
   val clientId = clientLocation.split("/")(2)
 
   // Get client key
-  val clientRes = Http(s"${ManagerUrl}/clients/${clientId}")
+  val clientRes = Http(s"${ClientsUrl}/clients/${clientId}")
     .header(HttpHeaderNames.Authorization, token)
     .header(HttpHeaderNames.ContentType, ContentType)
     .asString
@@ -53,7 +53,7 @@ class PublishSimulation extends Simulation {
   val clientKey = clientCursor.downField("key").as[String].getOrElse("")
 
   // Register channel
-  val chanLocation = Http(s"${ManagerUrl}/channels")
+  val chanLocation = Http(s"${ClientsUrl}/channels")
     .postData(Channel)
     .header(HttpHeaderNames.Authorization, token)
     .header(HttpHeaderNames.ContentType, ContentType)
@@ -63,7 +63,7 @@ class PublishSimulation extends Simulation {
   val chanId = chanLocation.split("/")(2)
 
   // Connect client to channel
-  Http(s"${ManagerUrl}/channels/${chanId}/clients/${clientId}")
+  Http(s"${ClientsUrl}/channels/${chanId}/clients/${clientId}")
     .method("PUT")
     .header(HttpHeaderNames.Authorization, token)
     .asString


### PR DESCRIPTION
Replace `manager` service with `users` and `clients` services in load tests.