### PR TITLE
NOISSUE - Add CoAP adapter version endpoint

### DIFF
--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -84,7 +84,7 @@ func main() {
 	go func() {
 		p := fmt.Sprintf(":%d", cfg.Port)
 		logger.Info(fmt.Sprintf("CoAP adapter service started, exposed port %d", cfg.Port))
-		errs <- api.ListenAndServe(svc, cc, p, api.MakeHandler(svc))
+		errs <- api.ListenAndServe(svc, cc, p, api.MakeHandler(p, svc))
 	}()
 
 	go func() {

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -84,7 +84,7 @@ func main() {
 	go func() {
 		p := fmt.Sprintf(":%d", cfg.Port)
 		logger.Info(fmt.Sprintf("CoAP adapter service started, exposed port %d", cfg.Port))
-		errs <- api.ListenAndServe(svc, cc, p, api.MakeHandler(p, svc))
+		errs <- api.ListenAndServe(svc, cc, p)
 	}()
 
 	go func() {

--- a/coap/api/server.go
+++ b/coap/api/server.go
@@ -121,7 +121,9 @@ func serve(svc coap.Service, conn *net.UDPConn, data []byte, addr *net.UDPAddr, 
 }
 
 // ListenAndServe binds to the given address and serve requests forever.
-func ListenAndServe(svc coap.Service, csc mainflux.ClientsServiceClient, addr string, rh gocoap.Handler) error {
+func ListenAndServe(svc coap.Service, csc mainflux.ClientsServiceClient, addr string) error {
+
+	handler := makeHandler(addr, svc)
 	auth = csc
 	uaddr, err := net.ResolveUDPAddr(network, addr)
 	if err != nil {
@@ -145,6 +147,6 @@ func ListenAndServe(svc coap.Service, csc mainflux.ClientsServiceClient, addr st
 		}
 		tmp := make([]byte, nr)
 		copy(tmp, buf)
-		go serve(svc, conn, tmp, addr, rh)
+		go serve(svc, conn, tmp, addr, handler)
 	}
 }

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -56,8 +56,7 @@ func version(port string) {
 	http.ListenAndServe(port, b)
 }
 
-// MakeHandler function return new CoAP server with GET, POST and NOT_FOUND handlers.
-func MakeHandler(port string, svc coap.Service) gocoap.Handler {
+func makeHandler(port string, svc coap.Service) gocoap.Handler {
 	go version(port)
 
 	r := mux.NewRouter()

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
+	"github.com/go-zoo/bone"
 	"github.com/mainflux/mainflux/coap"
 	"github.com/mainflux/mainflux/coap/nats"
 
@@ -48,8 +50,16 @@ func NotFoundHandler(l *net.UDPConn, a *net.UDPAddr, m *gocoap.Message) *gocoap.
 	return nil
 }
 
+func version(port string) {
+	b := bone.New()
+	b.GetFunc("/version", mainflux.Version("CoAP"))
+	http.ListenAndServe(port, b)
+}
+
 // MakeHandler function return new CoAP server with GET, POST and NOT_FOUND handlers.
-func MakeHandler(svc coap.Service) gocoap.Handler {
+func MakeHandler(port string, svc coap.Service) gocoap.Handler {
+	go version(port)
+
 	r := mux.NewRouter()
 	r.Handle("/channels/{id}/messages", gocoap.FuncHandler(receive(svc))).Methods(gocoap.POST)
 	r.Handle("/channels/{id}/messages", gocoap.FuncHandler(observe(svc))).Methods(gocoap.GET)


### PR DESCRIPTION
Add simple http server which is used to health check version of CoAP adapter.

Signed-off-by: Dušan Borovčanin <dusan.borovcanin@mainflux.com>