### PR TITLE
NOISSUE - Add Identify gRPC method

### DIFF
--- a/http/mocks/things.go
+++ b/http/mocks/things.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/things"
-
 	"google.golang.org/grpc"
 )
 
@@ -32,4 +31,8 @@ func (tc thingsClient) CanAccess(ctx context.Context, req *mainflux.AccessReq, o
 	}
 
 	return &mainflux.Identity{Value: id}, nil
+}
+
+func (tc thingsClient) Identify(ctx context.Context, req *mainflux.Token, opts ...grpc.CallOption) (*mainflux.Identity, error) {
+	return nil, nil
 }

--- a/internal.proto
+++ b/internal.proto
@@ -4,10 +4,11 @@ package mainflux;
 
 service ThingsService {
     rpc CanAccess(AccessReq) returns (Identity) {}
+    rpc Identify(Token) returns (Identity) {}
 }
 
 service UsersService {
-    rpc Identify(Token) returns (mainflux.Identity) {}
+    rpc Identify(Token) returns (Identity) {}
 }
 
 message AccessReq {

--- a/things/api/grpc/client.go
+++ b/things/api/grpc/client.go
@@ -17,25 +17,24 @@ type grpcClient struct {
 
 // NewClient returns new gRPC client instance.
 func NewClient(conn *grpc.ClientConn) mainflux.ThingsServiceClient {
-	cae := kitgrpc.NewClient(
-		conn,
-		"mainflux.ThingsService",
-		"CanAccess",
-		encodeCanAccessRequest,
-		decodeIdentityResponse,
-		mainflux.Identity{},
-	).Endpoint()
-
-	ie := kitgrpc.NewClient(
-		conn,
-		"mainflux.ThingsService",
-		"Identify",
-		encodeIdentifyRequest,
-		decodeIdentityResponse,
-		mainflux.Identity{},
-	).Endpoint()
-
-	return &grpcClient{cae, ie}
+	return &grpcClient{
+		canAccess: kitgrpc.NewClient(
+			conn,
+			"mainflux.ThingsService",
+			"CanAccess",
+			encodeCanAccessRequest,
+			decodeIdentityResponse,
+			mainflux.Identity{},
+		).Endpoint(),
+		identify: kitgrpc.NewClient(
+			conn,
+			"mainflux.ThingsService",
+			"Identify",
+			encodeIdentifyRequest,
+			decodeIdentityResponse,
+			mainflux.Identity{},
+		).Endpoint(),
+	}
 }
 
 func (client grpcClient) CanAccess(ctx context.Context, req *mainflux.AccessReq, _ ...grpc.CallOption) (*mainflux.Identity, error) {
@@ -65,7 +64,7 @@ func encodeCanAccessRequest(_ context.Context, grpcReq interface{}) (interface{}
 
 func encodeIdentifyRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
 	req := grpcReq.(identifyReq)
-	return &mainflux.Token{Value: req.thingKey}, nil
+	return &mainflux.Token{Value: req.key}, nil
 }
 
 func decodeIdentityResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {

--- a/things/api/grpc/client.go
+++ b/things/api/grpc/client.go
@@ -17,10 +17,12 @@ type grpcClient struct {
 
 // NewClient returns new gRPC client instance.
 func NewClient(conn *grpc.ClientConn) mainflux.ThingsServiceClient {
+	svcName := "mainflux.ThingsService"
+
 	return &grpcClient{
 		canAccess: kitgrpc.NewClient(
 			conn,
-			"mainflux.ThingsService",
+			svcName,
 			"CanAccess",
 			encodeCanAccessRequest,
 			decodeIdentityResponse,
@@ -28,7 +30,7 @@ func NewClient(conn *grpc.ClientConn) mainflux.ThingsServiceClient {
 		).Endpoint(),
 		identify: kitgrpc.NewClient(
 			conn,
-			"mainflux.ThingsService",
+			svcName,
 			"Identify",
 			encodeIdentifyRequest,
 			decodeIdentityResponse,

--- a/things/api/grpc/client.go
+++ b/things/api/grpc/client.go
@@ -12,20 +12,30 @@ var _ mainflux.ThingsServiceClient = (*grpcClient)(nil)
 
 type grpcClient struct {
 	canAccess endpoint.Endpoint
+	identify  endpoint.Endpoint
 }
 
 // NewClient returns new gRPC client instance.
 func NewClient(conn *grpc.ClientConn) mainflux.ThingsServiceClient {
-	endpoint := kitgrpc.NewClient(
+	cae := kitgrpc.NewClient(
 		conn,
 		"mainflux.ThingsService",
 		"CanAccess",
 		encodeCanAccessRequest,
-		decodeCanAccessResponse,
+		decodeIdentityResponse,
 		mainflux.Identity{},
 	).Endpoint()
 
-	return &grpcClient{endpoint}
+	ie := kitgrpc.NewClient(
+		conn,
+		"mainflux.ThingsService",
+		"Identify",
+		encodeIdentifyRequest,
+		decodeIdentityResponse,
+		mainflux.Identity{},
+	).Endpoint()
+
+	return &grpcClient{cae, ie}
 }
 
 func (client grpcClient) CanAccess(ctx context.Context, req *mainflux.AccessReq, _ ...grpc.CallOption) (*mainflux.Identity, error) {
@@ -34,8 +44,18 @@ func (client grpcClient) CanAccess(ctx context.Context, req *mainflux.AccessReq,
 		return nil, err
 	}
 
-	ar := res.(accessRes)
-	return &mainflux.Identity{Value: ar.id}, ar.err
+	ir := res.(identityRes)
+	return &mainflux.Identity{Value: ir.id}, ir.err
+}
+
+func (client grpcClient) Identify(ctx context.Context, req *mainflux.Token, _ ...grpc.CallOption) (*mainflux.Identity, error) {
+	res, err := client.identify(ctx, identifyReq{req.GetValue()})
+	if err != nil {
+		return nil, err
+	}
+
+	ir := res.(identityRes)
+	return &mainflux.Identity{Value: ir.id}, ir.err
 }
 
 func encodeCanAccessRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
@@ -43,7 +63,12 @@ func encodeCanAccessRequest(_ context.Context, grpcReq interface{}) (interface{}
 	return &mainflux.AccessReq{Token: req.thingKey, ChanID: req.chanID}, nil
 }
 
-func decodeCanAccessResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
+func encodeIdentifyRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(identifyReq)
+	return &mainflux.Token{Value: req.thingKey}, nil
+}
+
+func decodeIdentityResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
 	res := grpcRes.(*mainflux.Identity)
-	return accessRes{res.GetValue(), nil}, nil
+	return identityRes{res.GetValue(), nil}, nil
 }

--- a/things/api/grpc/endpoint.go
+++ b/things/api/grpc/endpoint.go
@@ -24,7 +24,7 @@ func canAccessEndpoint(svc things.Service) endpoint.Endpoint {
 func identifyEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(identifyReq)
-		id, err := svc.Identify(req.thingKey)
+		id, err := svc.Identify(req.key)
 		if err != nil {
 			return identityRes{id: "", err: err}, err
 		}

--- a/things/api/grpc/endpoint.go
+++ b/things/api/grpc/endpoint.go
@@ -15,8 +15,19 @@ func canAccessEndpoint(svc things.Service) endpoint.Endpoint {
 
 		id, err := svc.CanAccess(req.thingKey, req.chanID)
 		if err != nil {
-			return accessRes{"", err}, err
+			return identityRes{id: "", err: err}, err
 		}
-		return accessRes{id, nil}, nil
+		return identityRes{id: id, err: nil}, nil
+	}
+}
+
+func identifyEndpoint(svc things.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(identifyReq)
+		id, err := svc.Identify(req.thingKey)
+		if err != nil {
+			return identityRes{id: "", err: err}, err
+		}
+		return identityRes{id: id, err: nil}, nil
 	}
 }

--- a/things/api/grpc/endpoint_test.go
+++ b/things/api/grpc/endpoint_test.go
@@ -84,7 +84,7 @@ func TestIdentify(t *testing.T) {
 	svc := newService(map[string]string{token: email})
 	startGRPCServer(svc, port)
 
-	th, _ := svc.AddThing(token, thing)
+	sth, _ := svc.AddThing(token, thing)
 
 	usersAddr := fmt.Sprintf("localhost:%d", port)
 	conn, _ := grpc.Dial(usersAddr, grpc.WithInsecure())
@@ -97,7 +97,7 @@ func TestIdentify(t *testing.T) {
 		id   string
 		code codes.Code
 	}{
-		"identify existing thing":     {th.Key, th.ID, codes.OK},
+		"identify existing thing":     {sth.Key, sth.ID, codes.OK},
 		"identify non-existent thing": {wrong, "", codes.PermissionDenied},
 	}
 

--- a/things/api/grpc/endpoint_test.go
+++ b/things/api/grpc/endpoint_test.go
@@ -79,3 +79,33 @@ func TestCanAccess(t *testing.T) {
 		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", desc, tc.code, e.Code()))
 	}
 }
+
+func TestIdentify(t *testing.T) {
+	svc := newService(map[string]string{token: email})
+	startGRPCServer(svc, port)
+
+	th, _ := svc.AddThing(token, thing)
+
+	usersAddr := fmt.Sprintf("localhost:%d", port)
+	conn, _ := grpc.Dial(usersAddr, grpc.WithInsecure())
+	cli := grpcapi.NewClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cases := map[string]struct {
+		key  string
+		id   string
+		code codes.Code
+	}{
+		"identify existing thing":     {th.Key, th.ID, codes.OK},
+		"identify non-existent thing": {wrong, "", codes.PermissionDenied},
+	}
+
+	for desc, tc := range cases {
+		id, err := cli.Identify(ctx, &mainflux.Token{Value: tc.key})
+		e, ok := status.FromError(err)
+		assert.True(t, ok, "OK expected to be true")
+		assert.Equal(t, tc.id, id.GetValue(), fmt.Sprintf("%s: expected %s got %s", desc, tc.id, id.GetValue()))
+		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", desc, tc.code, e.Code()))
+	}
+}

--- a/things/api/grpc/requests.go
+++ b/things/api/grpc/requests.go
@@ -16,3 +16,7 @@ func (req accessReq) validate() error {
 	}
 	return nil
 }
+
+type identifyReq struct {
+	thingKey string
+}

--- a/things/api/grpc/requests.go
+++ b/things/api/grpc/requests.go
@@ -18,5 +18,5 @@ func (req accessReq) validate() error {
 }
 
 type identifyReq struct {
-	thingKey string
+	key string
 }

--- a/things/api/grpc/responses.go
+++ b/things/api/grpc/responses.go
@@ -1,6 +1,6 @@
 package grpc
 
-type accessRes struct {
+type identityRes struct {
 	id  string
 	err error
 }

--- a/things/api/grpc/server.go
+++ b/things/api/grpc/server.go
@@ -18,21 +18,22 @@ type grpcServer struct {
 
 // NewServer returns new ThingsServiceServer instance.
 func NewServer(svc things.Service) mainflux.ThingsServiceServer {
-	cah := kitgrpc.NewServer(
-		canAccessEndpoint(svc),
-		decodeCanAccessRequest,
-		encodeIdentityResponse,
-	)
-	ih := kitgrpc.NewServer(
-		identifyEndpoint(svc),
-		decodeIdentifyRequest,
-		encodeIdentityResponse,
-	)
-	return &grpcServer{canAccess: cah, identify: ih}
+	return &grpcServer{
+		canAccess: kitgrpc.NewServer(
+			canAccessEndpoint(svc),
+			decodeCanAccessRequest,
+			encodeIdentityResponse,
+		),
+		identify: kitgrpc.NewServer(
+			identifyEndpoint(svc),
+			decodeIdentifyRequest,
+			encodeIdentityResponse,
+		),
+	}
 }
 
-func (s *grpcServer) CanAccess(ctx context.Context, req *mainflux.AccessReq) (*mainflux.Identity, error) {
-	_, res, err := s.canAccess.ServeGRPC(ctx, req)
+func (gs *grpcServer) CanAccess(ctx context.Context, req *mainflux.AccessReq) (*mainflux.Identity, error) {
+	_, res, err := gs.canAccess.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
@@ -40,8 +41,8 @@ func (s *grpcServer) CanAccess(ctx context.Context, req *mainflux.AccessReq) (*m
 	return res.(*mainflux.Identity), nil
 }
 
-func (s *grpcServer) Identify(ctx context.Context, req *mainflux.Token) (*mainflux.Identity, error) {
-	_, res, err := s.identify.ServeGRPC(ctx, req)
+func (gs *grpcServer) Identify(ctx context.Context, req *mainflux.Token) (*mainflux.Identity, error) {
+	_, res, err := gs.identify.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}

--- a/things/api/grpc/server.go
+++ b/things/api/grpc/server.go
@@ -12,24 +12,40 @@ import (
 var _ mainflux.ThingsServiceServer = (*grpcServer)(nil)
 
 type grpcServer struct {
-	handler kitgrpc.Handler
+	canAccess kitgrpc.Handler
+	identify  kitgrpc.Handler
 }
 
 // NewServer returns new ThingsServiceServer instance.
 func NewServer(svc things.Service) mainflux.ThingsServiceServer {
-	handler := kitgrpc.NewServer(
+	cah := kitgrpc.NewServer(
 		canAccessEndpoint(svc),
 		decodeCanAccessRequest,
-		encodeCanAccessResponse,
+		encodeIdentityResponse,
 	)
-	return &grpcServer{handler}
+	ih := kitgrpc.NewServer(
+		identifyEndpoint(svc),
+		decodeIdentifyRequest,
+		encodeIdentityResponse,
+	)
+	return &grpcServer{canAccess: cah, identify: ih}
 }
 
 func (s *grpcServer) CanAccess(ctx context.Context, req *mainflux.AccessReq) (*mainflux.Identity, error) {
-	_, res, err := s.handler.ServeGRPC(ctx, req)
+	_, res, err := s.canAccess.ServeGRPC(ctx, req)
 	if err != nil {
 		return nil, encodeError(err)
 	}
+
+	return res.(*mainflux.Identity), nil
+}
+
+func (s *grpcServer) Identify(ctx context.Context, req *mainflux.Token) (*mainflux.Identity, error) {
+	_, res, err := s.identify.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, encodeError(err)
+	}
+
 	return res.(*mainflux.Identity), nil
 }
 
@@ -38,8 +54,13 @@ func decodeCanAccessRequest(_ context.Context, grpcReq interface{}) (interface{}
 	return accessReq{req.GetToken(), req.GetChanID()}, nil
 }
 
-func encodeCanAccessResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
-	res := grpcRes.(accessRes)
+func decodeIdentifyRequest(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*mainflux.Token)
+	return identifyReq{req.GetValue()}, nil
+}
+
+func encodeIdentityResponse(_ context.Context, grpcRes interface{}) (interface{}, error) {
+	res := grpcRes.(identityRes)
 	return &mainflux.Identity{Value: res.id}, encodeError(res.err)
 }
 

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -190,3 +190,16 @@ func (lm *loggingMiddleware) CanAccess(key string, id string) (pub string, err e
 
 	return lm.svc.CanAccess(key, id)
 }
+
+func (lm *loggingMiddleware) Identify(key string) (id string, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method identify for key %s and publisher %s took %s to complete", key, id, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.Identify(key)
+}

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -143,3 +143,12 @@ func (ms *metricsMiddleware) CanAccess(key string, id string) (string, error) {
 
 	return ms.svc.CanAccess(key, id)
 }
+
+func (ms *metricsMiddleware) Identify(key string) (string, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "identify").Add(1)
+		ms.latency.With("method", "identify").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.Identify(key)
+}

--- a/things/channels.go
+++ b/things/channels.go
@@ -20,12 +20,12 @@ type ChannelRepository interface {
 	// returned to indicate operation failure.
 	Update(Channel) error
 
-	// One retrieves the channel having the provided identifier, that is owned
+	// RetrieveByID retrieves the channel having the provided identifier, that is owned
 	// by the specified user.
-	One(string, string) (Channel, error)
+	RetrieveByID(string, string) (Channel, error)
 
-	// All retrieves the subset of channels owned by the specified user.
-	All(string, int, int) []Channel
+	// RetrieveAll retrieves the subset of channels owned by the specified user.
+	RetrieveAll(string, int, int) []Channel
 
 	// Remove removes the channel having the provided identifier, that is owned
 	// by the specified user.

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -95,7 +95,7 @@ func (crm *channelRepositoryMock) Connect(owner, chanID, thingID string) error {
 		return err
 	}
 
-	thing, err := crm.things.One(owner, thingID)
+	thing, err := crm.things.RetrieveByID(owner, thingID)
 	if err != nil {
 		return err
 	}

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -49,7 +49,7 @@ func (crm *channelRepositoryMock) Update(channel things.Channel) error {
 	return nil
 }
 
-func (crm *channelRepositoryMock) One(owner, id string) (things.Channel, error) {
+func (crm *channelRepositoryMock) RetrieveByID(owner, id string) (things.Channel, error) {
 	if c, ok := crm.channels[key(owner, id)]; ok {
 		return c, nil
 	}
@@ -57,7 +57,7 @@ func (crm *channelRepositoryMock) One(owner, id string) (things.Channel, error) 
 	return things.Channel{}, things.ErrNotFound
 }
 
-func (crm *channelRepositoryMock) All(owner string, offset, limit int) []things.Channel {
+func (crm *channelRepositoryMock) RetrieveAll(owner string, offset, limit int) []things.Channel {
 	// This obscure way to examine map keys is enforced by the key structure
 	// itself (see mocks/commons.go).
 	prefix := fmt.Sprintf("%s-", owner)
@@ -90,7 +90,7 @@ func (crm *channelRepositoryMock) Remove(owner, id string) error {
 }
 
 func (crm *channelRepositoryMock) Connect(owner, chanID, thingID string) error {
-	channel, err := crm.One(owner, chanID)
+	channel, err := crm.RetrieveByID(owner, chanID)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (crm *channelRepositoryMock) Connect(owner, chanID, thingID string) error {
 }
 
 func (crm *channelRepositoryMock) Disconnect(owner, chanID, thingID string) error {
-	channel, err := crm.One(owner, chanID)
+	channel, err := crm.RetrieveByID(owner, chanID)
 	if err != nil {
 		return err
 	}

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -94,3 +94,12 @@ func (trm *thingRepositoryMock) Remove(owner, id string) error {
 	delete(trm.things, key(owner, id))
 	return nil
 }
+
+func (trm *thingRepositoryMock) Identify(key string) (string, error) {
+	for _, thing := range trm.things {
+		if thing.Key == key {
+			return thing.ID, nil
+		}
+	}
+	return "", things.ErrNotFound
+}

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -47,7 +47,7 @@ func (trm *thingRepositoryMock) Update(thing things.Thing) error {
 	return nil
 }
 
-func (trm *thingRepositoryMock) One(owner, id string) (things.Thing, error) {
+func (trm *thingRepositoryMock) RetrieveByID(owner, id string) (things.Thing, error) {
 	if c, ok := trm.things[key(owner, id)]; ok {
 		return c, nil
 	}
@@ -55,7 +55,7 @@ func (trm *thingRepositoryMock) One(owner, id string) (things.Thing, error) {
 	return things.Thing{}, things.ErrNotFound
 }
 
-func (trm *thingRepositoryMock) All(owner string, offset, limit int) []things.Thing {
+func (trm *thingRepositoryMock) RetrieveAll(owner string, offset, limit int) []things.Thing {
 	// This obscure way to examine map keys is enforced by the key structure
 	// itself (see mocks/commons.go).
 	prefix := fmt.Sprintf("%s-", owner)
@@ -95,7 +95,7 @@ func (trm *thingRepositoryMock) Remove(owner, id string) error {
 	return nil
 }
 
-func (trm *thingRepositoryMock) Identify(key string) (string, error) {
+func (trm *thingRepositoryMock) RetrieveByKey(key string) (string, error) {
 	for _, thing := range trm.things {
 		if thing.Key == key {
 			return thing.ID, nil

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -58,7 +58,7 @@ func (cr channelRepository) Update(channel things.Channel) error {
 	return nil
 }
 
-func (cr channelRepository) One(owner, id string) (things.Channel, error) {
+func (cr channelRepository) RetrieveByID(owner, id string) (things.Channel, error) {
 	q := `SELECT name FROM channels WHERE id = $1 AND owner = $2`
 	channel := things.Channel{ID: id, Owner: owner}
 	if err := cr.db.QueryRow(q, id, owner).Scan(&channel.Name); err != nil {
@@ -93,7 +93,7 @@ func (cr channelRepository) One(owner, id string) (things.Channel, error) {
 	return channel, nil
 }
 
-func (cr channelRepository) All(owner string, offset, limit int) []things.Channel {
+func (cr channelRepository) RetrieveAll(owner string, offset, limit int) []things.Channel {
 	q := `SELECT id, name FROM channels WHERE owner = $1 ORDER BY id LIMIT $2 OFFSET $3`
 	items := []things.Channel{}
 

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -64,7 +64,7 @@ func TestSingleChannelRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		_, err := chanRepo.One(tc.owner, tc.ID)
+		_, err := chanRepo.RetrieveByID(tc.owner, tc.ID)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }
@@ -92,7 +92,7 @@ func TestMultiChannelRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		size := len(chanRepo.All(tc.owner, tc.offset, tc.limit))
+		size := len(chanRepo.RetrieveAll(tc.owner, tc.offset, tc.limit))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", desc, tc.size, size))
 	}
 }
@@ -110,7 +110,7 @@ func TestChannelRemoval(t *testing.T) {
 			t.Fatalf("#%d: failed to remove channel due to: %s", i, err)
 		}
 
-		if _, err := chanRepo.One(email, chanID); err != things.ErrNotFound {
+		if _, err := chanRepo.RetrieveByID(email, chanID); err != things.ErrNotFound {
 			t.Fatalf("#%d: expected %s got %s", i, things.ErrNotFound, err)
 		}
 	}

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -52,7 +52,7 @@ func (tr thingRepository) Update(thing things.Thing) error {
 	return nil
 }
 
-func (tr thingRepository) One(owner, id string) (things.Thing, error) {
+func (tr thingRepository) RetrieveByID(owner, id string) (things.Thing, error) {
 	q := `SELECT name, type, key, payload FROM things WHERE id = $1 AND owner = $2`
 	thing := things.Thing{ID: id, Owner: owner}
 	err := tr.db.
@@ -70,7 +70,7 @@ func (tr thingRepository) One(owner, id string) (things.Thing, error) {
 	return thing, nil
 }
 
-func (tr thingRepository) All(owner string, offset, limit int) []things.Thing {
+func (tr thingRepository) RetrieveAll(owner string, offset, limit int) []things.Thing {
 	q := `SELECT id, name, type, key, payload FROM things WHERE owner = $1 ORDER BY id LIMIT $2 OFFSET $3`
 	items := []things.Thing{}
 
@@ -99,7 +99,7 @@ func (tr thingRepository) Remove(owner, id string) error {
 	return nil
 }
 
-func (tr thingRepository) Identify(key string) (string, error) {
+func (tr thingRepository) RetrieveByKey(key string) (string, error) {
 	q := `SELECT id FROM things WHERE key = $1`
 	var id string
 	if err := tr.db.QueryRow(q, key).Scan(&id); err != nil {

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -70,6 +70,19 @@ func (tr thingRepository) RetrieveByID(owner, id string) (things.Thing, error) {
 	return thing, nil
 }
 
+func (tr thingRepository) RetrieveByKey(key string) (string, error) {
+	q := `SELECT id FROM things WHERE key = $1`
+	var id string
+	if err := tr.db.QueryRow(q, key).Scan(&id); err != nil {
+		if err == sql.ErrNoRows {
+			return "", things.ErrNotFound
+		}
+		return "", err
+	}
+
+	return id, nil
+}
+
 func (tr thingRepository) RetrieveAll(owner string, offset, limit int) []things.Thing {
 	q := `SELECT id, name, type, key, payload FROM things WHERE owner = $1 ORDER BY id LIMIT $2 OFFSET $3`
 	items := []things.Thing{}
@@ -97,17 +110,4 @@ func (tr thingRepository) Remove(owner, id string) error {
 	q := `DELETE FROM things WHERE id = $1 AND owner = $2`
 	tr.db.Exec(q, id, owner)
 	return nil
-}
-
-func (tr thingRepository) RetrieveByKey(key string) (string, error) {
-	q := `SELECT id FROM things WHERE key = $1`
-	var id string
-	if err := tr.db.QueryRow(q, key).Scan(&id); err != nil {
-		if err == sql.ErrNoRows {
-			return "", things.ErrNotFound
-		}
-		return "", err
-	}
-
-	return id, nil
 }

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -98,3 +98,16 @@ func (tr thingRepository) Remove(owner, id string) error {
 	tr.db.Exec(q, id, owner)
 	return nil
 }
+
+func (tr thingRepository) Identify(key string) (string, error) {
+	q := `SELECT id FROM things WHERE key = $1`
+	var id string
+	if err := tr.db.QueryRow(q, key).Scan(&id); err != nil {
+		if err == sql.ErrNoRows {
+			return "", things.ErrNotFound
+		}
+		return "", err
+	}
+
+	return id, nil
+}

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -140,3 +140,30 @@ func TestThingRemoval(t *testing.T) {
 		}
 	}
 }
+
+func TestThingIdentify(t *testing.T) {
+	email := "thing-identify@example.com"
+	idp := uuid.New()
+	thingRepo := postgres.NewThingRepository(db, testLog)
+	thing := things.Thing{
+		ID:    idp.ID(),
+		Owner: email,
+		Key:   idp.ID(),
+	}
+	thingRepo.Save(thing)
+
+	cases := map[string]struct {
+		key string
+		id  string
+		err error
+	}{
+		"identify existing thing":     {thing.Key, thing.ID, nil},
+		"identify non-existent thing": {wrong, "", things.ErrNotFound},
+	}
+
+	for desc, tc := range cases {
+		id, err := thingRepo.Identify(tc.key)
+		assert.Equal(t, tc.id, id, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.id, id))
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
+	}
+}

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -83,6 +83,33 @@ func TestSingleThingRetrieval(t *testing.T) {
 	}
 }
 
+func TestThingRetrieveByKey(t *testing.T) {
+	email := "thing-retrieved-by-key@example.com"
+	idp := uuid.New()
+	thingRepo := postgres.NewThingRepository(db, testLog)
+	thing := things.Thing{
+		ID:    idp.ID(),
+		Owner: email,
+		Key:   idp.ID(),
+	}
+	thingRepo.Save(thing)
+
+	cases := map[string]struct {
+		key string
+		id  string
+		err error
+	}{
+		"retrieve existing thing by key":     {thing.Key, thing.ID, nil},
+		"retrieve non-existent thing by key": {wrong, "", things.ErrNotFound},
+	}
+
+	for desc, tc := range cases {
+		id, err := thingRepo.RetrieveByKey(tc.key)
+		assert.Equal(t, tc.id, id, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.id, id))
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
+	}
+}
+
 func TestMultiThingRetrieval(t *testing.T) {
 	email := "thing-multi-retrieval@example.com"
 	idp := uuid.New()
@@ -138,32 +165,5 @@ func TestThingRemoval(t *testing.T) {
 		if _, err := thingRepo.RetrieveByID(email, thing.ID); err != things.ErrNotFound {
 			t.Fatalf("#%d: expected %s got %s", i, things.ErrNotFound, err)
 		}
-	}
-}
-
-func TestThingRetrieveByKey(t *testing.T) {
-	email := "thing-retrieved-by-key@example.com"
-	idp := uuid.New()
-	thingRepo := postgres.NewThingRepository(db, testLog)
-	thing := things.Thing{
-		ID:    idp.ID(),
-		Owner: email,
-		Key:   idp.ID(),
-	}
-	thingRepo.Save(thing)
-
-	cases := map[string]struct {
-		key string
-		id  string
-		err error
-	}{
-		"retrieve existing thing by key":     {thing.Key, thing.ID, nil},
-		"retrieve non-existent thing by key": {wrong, "", things.ErrNotFound},
-	}
-
-	for desc, tc := range cases {
-		id, err := thingRepo.RetrieveByKey(tc.key)
-		assert.Equal(t, tc.id, id, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.id, id))
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -78,7 +78,7 @@ func TestSingleThingRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		_, err := thingRepo.One(tc.owner, tc.ID)
+		_, err := thingRepo.RetrieveByID(tc.owner, tc.ID)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }
@@ -112,7 +112,7 @@ func TestMultiThingRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		n := len(thingRepo.All(tc.owner, tc.offset, tc.limit))
+		n := len(thingRepo.RetrieveAll(tc.owner, tc.offset, tc.limit))
 		assert.Equal(t, tc.size, n, fmt.Sprintf("%s: expected %d got %d\n", desc, tc.size, n))
 	}
 }
@@ -135,14 +135,14 @@ func TestThingRemoval(t *testing.T) {
 			t.Fatalf("#%d: failed to remove thing due to: %s", i, err)
 		}
 
-		if _, err := thingRepo.One(email, thing.ID); err != things.ErrNotFound {
+		if _, err := thingRepo.RetrieveByID(email, thing.ID); err != things.ErrNotFound {
 			t.Fatalf("#%d: expected %s got %s", i, things.ErrNotFound, err)
 		}
 	}
 }
 
-func TestThingIdentify(t *testing.T) {
-	email := "thing-identify@example.com"
+func TestThingRetrieveByKey(t *testing.T) {
+	email := "thing-retrieved-by-key@example.com"
 	idp := uuid.New()
 	thingRepo := postgres.NewThingRepository(db, testLog)
 	thing := things.Thing{
@@ -157,12 +157,12 @@ func TestThingIdentify(t *testing.T) {
 		id  string
 		err error
 	}{
-		"identify existing thing":     {thing.Key, thing.ID, nil},
-		"identify non-existent thing": {wrong, "", things.ErrNotFound},
+		"retrieve existing thing by key":     {thing.Key, thing.ID, nil},
+		"retrieve non-existent thing by key": {wrong, "", things.ErrNotFound},
 	}
 
 	for desc, tc := range cases {
-		id, err := thingRepo.Identify(tc.key)
+		id, err := thingRepo.RetrieveByKey(tc.key)
 		assert.Equal(t, tc.id, id, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.id, id))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}

--- a/things/service.go
+++ b/things/service.go
@@ -213,7 +213,7 @@ func (ts *thingsService) ViewChannel(key, id string) (Channel, error) {
 		return Channel{}, ErrUnauthorizedAccess
 	}
 
-	return ts.channels.One(res.GetValue(), id)
+	return ts.channels.RetrieveByID(res.GetValue(), id)
 }
 
 func (ts *thingsService) ListChannels(key string, offset, limit int) ([]Channel, error) {
@@ -225,7 +225,7 @@ func (ts *thingsService) ListChannels(key string, offset, limit int) ([]Channel,
 		return nil, ErrUnauthorizedAccess
 	}
 
-	return ts.channels.All(res.GetValue(), offset, limit), nil
+	return ts.channels.RetrieveAll(res.GetValue(), offset, limit), nil
 }
 
 func (ts *thingsService) RemoveChannel(key, id string) error {

--- a/things/service.go
+++ b/things/service.go
@@ -76,6 +76,9 @@ type Service interface {
 	// CanAccess determines whether the channel can be accessed using the
 	// provided key and returns thing's id if access is allowed.
 	CanAccess(string, string) (string, error)
+
+	// Identify returns thing ID for given thing key.
+	Identify(string) (string, error)
 }
 
 var _ Service = (*thingsService)(nil)
@@ -268,4 +271,13 @@ func (ts *thingsService) CanAccess(key, channel string) (string, error) {
 	}
 
 	return thingID, nil
+}
+
+func (ts *thingsService) Identify(key string) (string, error) {
+	id, err := ts.things.Identify(key)
+	if err != nil {
+		return "", ErrUnauthorizedAccess
+	}
+
+	return id, nil
 }

--- a/things/service.go
+++ b/things/service.go
@@ -144,7 +144,7 @@ func (ts *thingsService) ViewThing(key, id string) (Thing, error) {
 		return Thing{}, ErrUnauthorizedAccess
 	}
 
-	return ts.things.One(res.GetValue(), id)
+	return ts.things.RetrieveByID(res.GetValue(), id)
 }
 
 func (ts *thingsService) ListThings(key string, offset, limit int) ([]Thing, error) {
@@ -156,7 +156,7 @@ func (ts *thingsService) ListThings(key string, offset, limit int) ([]Thing, err
 		return nil, ErrUnauthorizedAccess
 	}
 
-	return ts.things.All(res.GetValue(), offset, limit), nil
+	return ts.things.RetrieveAll(res.GetValue(), offset, limit), nil
 }
 
 func (ts *thingsService) RemoveThing(key, id string) error {
@@ -274,7 +274,7 @@ func (ts *thingsService) CanAccess(key, channel string) (string, error) {
 }
 
 func (ts *thingsService) Identify(key string) (string, error) {
-	id, err := ts.things.Identify(key)
+	id, err := ts.things.RetrieveByKey(key)
 	if err != nil {
 		return "", ErrUnauthorizedAccess
 	}

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -326,3 +326,24 @@ func TestCanAccess(t *testing.T) {
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }
+
+func TestIdentify(t *testing.T) {
+	svc := newService(map[string]string{token: email})
+
+	th, _ := svc.AddThing(token, thing)
+
+	cases := map[string]struct {
+		key string
+		id  string
+		err error
+	}{
+		"identify existing thing":     {th.Key, th.ID, nil},
+		"identify non-existent thing": {token, "", things.ErrUnauthorizedAccess},
+	}
+
+	for desc, tc := range cases {
+		id, err := svc.Identify(tc.key)
+		assert.Equal(t, tc.id, id, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.id, id))
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
+	}
+}

--- a/things/things.go
+++ b/things/things.go
@@ -37,17 +37,17 @@ type ThingRepository interface {
 	// returned to indicate operation failure.
 	Update(Thing) error
 
-	// One retrieves the thing having the provided identifier, that is owned
+	// RetrieveByID retrieves the thing having the provided identifier, that is owned
 	// by the specified user.
-	One(string, string) (Thing, error)
+	RetrieveByID(string, string) (Thing, error)
 
-	// All retrieves the subset of things owned by the specified user.
-	All(string, int, int) []Thing
+	// RetrieveAll retrieves the subset of things owned by the specified user.
+	RetrieveAll(string, int, int) []Thing
 
 	// Remove removes the thing having the provided identifier, that is owned
 	// by the specified user.
 	Remove(string, string) error
 
-	// Identify returns thing ID for given thing key.
-	Identify(string) (string, error)
+	// RetrieveByKey returns thing ID for given thing key.
+	RetrieveByKey(string) (string, error)
 }

--- a/things/things.go
+++ b/things/things.go
@@ -41,13 +41,13 @@ type ThingRepository interface {
 	// by the specified user.
 	RetrieveByID(string, string) (Thing, error)
 
+	// RetrieveByKey returns thing ID for given thing key.
+	RetrieveByKey(string) (string, error)
+
 	// RetrieveAll retrieves the subset of things owned by the specified user.
 	RetrieveAll(string, int, int) []Thing
 
 	// Remove removes the thing having the provided identifier, that is owned
 	// by the specified user.
 	Remove(string, string) error
-
-	// RetrieveByKey returns thing ID for given thing key.
-	RetrieveByKey(string) (string, error)
 }

--- a/things/things.go
+++ b/things/things.go
@@ -47,4 +47,7 @@ type ThingRepository interface {
 	// Remove removes the thing having the provided identifier, that is owned
 	// by the specified user.
 	Remove(string, string) error
+
+	// Identify returns thing ID for given thing key.
+	Identify(string) (string, error)
 }

--- a/users/mocks/users.go
+++ b/users/mocks/users.go
@@ -32,7 +32,7 @@ func (urm *userRepositoryMock) Save(user users.User) error {
 	return nil
 }
 
-func (urm *userRepositoryMock) One(email string) (users.User, error) {
+func (urm *userRepositoryMock) RetrieveByID(email string) (users.User, error) {
 	urm.mu.Lock()
 	defer urm.mu.Unlock()
 

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -34,7 +34,7 @@ func (ur userRepository) Save(user users.User) error {
 	return nil
 }
 
-func (ur userRepository) One(email string) (users.User, error) {
+func (ur userRepository) RetrieveByID(email string) (users.User, error) {
 	q := `SELECT password FROM users WHERE email = $1`
 
 	user := users.User{}

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -44,7 +44,7 @@ func TestSingleUserRetrieval(t *testing.T) {
 	}
 
 	for desc, tc := range cases {
-		_, err := repo.One(tc.email)
+		_, err := repo.RetrieveByID(tc.email)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 }

--- a/users/service.go
+++ b/users/service.go
@@ -61,7 +61,7 @@ func (svc usersService) Register(user User) error {
 }
 
 func (svc usersService) Login(user User) (string, error) {
-	dbUser, err := svc.users.One(user.Email)
+	dbUser, err := svc.users.RetrieveByID(user.Email)
 	if err != nil {
 		return "", ErrUnauthorizedAccess
 	}

--- a/users/users.go
+++ b/users/users.go
@@ -28,6 +28,6 @@ type UserRepository interface {
 	// operation failure.
 	Save(User) error
 
-	// One retrieves user by its unique identifier (i.e. email).
-	One(string) (User, error)
+	// RetrieveByID retrieves user by its unique identifier (i.e. email).
+	RetrieveByID(string) (User, error)
 }

--- a/ws/mocks/things.go
+++ b/ws/mocks/things.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/things"
+
 	"google.golang.org/grpc"
 )
 
@@ -31,4 +32,8 @@ func (tc thingsClient) CanAccess(ctx context.Context, req *mainflux.AccessReq, o
 	}
 
 	return &mainflux.Identity{Value: id}, nil
+}
+
+func (tc thingsClient) Identify(ctx context.Context, req *mainflux.Token, opts ...grpc.CallOption) (*mainflux.Identity, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Add `Identify` gRPC method that is needed for MQTT. Add tests for `Identify`.