### PR TITLE
NOISSUE - Fix channel closing bug in WebSocket adapter

### DIFF
--- a/ws/api/logging.go
+++ b/ws/api/logging.go
@@ -36,7 +36,7 @@ func (lm *loggingMiddleware) Publish(msg mainflux.RawMessage) (err error) {
 	return lm.svc.Publish(msg)
 }
 
-func (lm *loggingMiddleware) Subscribe(chanID uint64, channel ws.Channel) (err error) {
+func (lm *loggingMiddleware) Subscribe(chanID uint64, channel *ws.Channel) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method subscribe to channel %d took %s to complete", chanID, time.Since(begin))
 		if err != nil {

--- a/ws/api/metrics.go
+++ b/ws/api/metrics.go
@@ -36,6 +36,6 @@ func (mm *metricsMiddleware) Publish(msg mainflux.RawMessage) error {
 	return mm.svc.Publish(msg)
 }
 
-func (mm *metricsMiddleware) Subscribe(chanID uint64, channel ws.Channel) error {
+func (mm *metricsMiddleware) Subscribe(chanID uint64, channel *ws.Channel) error {
 	return mm.svc.Subscribe(chanID, channel)
 }

--- a/ws/api/transport.go
+++ b/ws/api/transport.go
@@ -50,30 +50,18 @@ func MakeHandler(svc ws.Service, cc mainflux.ThingsServiceClient, l log.Logger) 
 func handshake(svc ws.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		sub, err := authorize(r)
-		if err == errNotFound {
-			logger.Warn(fmt.Sprintf("Invalid channel id: %s", err))
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
 		if err != nil {
 			switch err {
 			case errNotFound:
 				logger.Warn(fmt.Sprintf("Invalid channel id: %s", err))
 				w.WriteHeader(http.StatusNotFound)
 				return
+			case things.ErrUnauthorizedAccess:
+				w.WriteHeader(http.StatusForbidden)
+				return
 			default:
 				logger.Warn(fmt.Sprintf("Failed to authorize: %s", err))
-				e, ok := status.FromError(err)
-				if ok {
-					switch e.Code() {
-					case codes.PermissionDenied:
-						w.WriteHeader(http.StatusForbidden)
-					default:
-						w.WriteHeader(http.StatusServiceUnavailable)
-					}
-					return
-				}
-				w.WriteHeader(http.StatusForbidden)
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 		}
@@ -87,7 +75,10 @@ func handshake(svc ws.Service) http.HandlerFunc {
 		sub.conn = conn
 
 		// Subscribe to channel
-		channel := ws.Channel{make(chan mainflux.RawMessage), make(chan bool)}
+		channel := ws.Channel{
+			Messages: make(chan mainflux.RawMessage),
+			Closed:   make(chan bool),
+		}
 		sub.channel = channel
 		if err := svc.Subscribe(sub.chanID, sub.channel); err != nil {
 			logger.Warn(fmt.Sprintf("Failed to subscribe to NATS subject: %s", err))
@@ -122,6 +113,10 @@ func authorize(r *http.Request) (subscription, error) {
 
 	id, err := auth.CanAccess(ctx, &mainflux.AccessReq{Token: authKey, ChanID: chanID})
 	if err != nil {
+		e, ok := status.FromError(err)
+		if ok && e.Code() == codes.PermissionDenied {
+			return subscription{}, things.ErrUnauthorizedAccess
+		}
 		return subscription{}, err
 	}
 

--- a/ws/api/transport_test.go
+++ b/ws/api/transport_test.go
@@ -26,11 +26,11 @@ const (
 
 var (
 	msg     = []byte(`[{"n":"current","t":-5,"v":1.2}]`)
-	channel = ws.Channel{make(chan mainflux.RawMessage), make(chan bool)}
+	channel = ws.NewChannel()
 )
 
 func newService() ws.Service {
-	subs := map[uint64]ws.Channel{chanID: channel}
+	subs := map[uint64]*ws.Channel{chanID: channel}
 	pubsub := mocks.NewService(subs, broker.ErrConnectionClosed)
 	return ws.New(pubsub)
 }

--- a/ws/mocks/messages.go
+++ b/ws/mocks/messages.go
@@ -10,13 +10,13 @@ import (
 var _ ws.Service = (*mockService)(nil)
 
 type mockService struct {
-	subscriptions map[uint64]ws.Channel
+	subscriptions map[uint64]*ws.Channel
 	pubError      error
 	mutex         sync.Mutex
 }
 
 // NewService returns mock message publisher.
-func NewService(subs map[uint64]ws.Channel, pubError error) ws.Service {
+func NewService(subs map[uint64]*ws.Channel, pubError error) ws.Service {
 	return &mockService{subs, pubError, sync.Mutex{}}
 }
 
@@ -30,7 +30,7 @@ func (svc *mockService) Publish(msg mainflux.RawMessage) error {
 	return nil
 }
 
-func (svc *mockService) Subscribe(chanID uint64, channel ws.Channel) error {
+func (svc *mockService) Subscribe(chanID uint64, channel *ws.Channel) error {
 	svc.mutex.Lock()
 	defer svc.mutex.Unlock()
 	if _, ok := svc.subscriptions[chanID]; !ok {


### PR DESCRIPTION
Fix channel closing bug by adding `closed` flag and mutex.