### PR TITLE
NOISSUE - Makefile test target, CREATE TABLE and dev guide enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ clean:
 install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 
+test:
+	GOCACHE=off go test -v -race -tags test $(shell go list ./... | grep -v 'vendor\|cmd')
+
 proto:
 	protoc --go_out=plugins=grpc:. *.proto
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -113,6 +113,13 @@ Cross-compilation for ARM with Mainflux make:
 GOOS=linux GOARCH=arm GOARM=7 make
 ```
 
+## Running tests
+To run all of the test you  can execute:
+```
+make test
+```
+Dockertest is used for the test, so to run the tests you will need the Docker deamon/service running.
+
 ## Installing
 Installing Go binaries is simple: just move them from `build` to `$GOBIN` (do not fortget to add `$GOBIN` to your `$PATH`).
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -64,6 +64,9 @@ make docker_http
 
 > N.B. Mainflux creates `FROM scratch` docker containers which as compact and small in size.
 
+> N.B. The `things-db` and `users-db` containers are built from a vanilla PostgreSQL Docker image downloaded from Docker Hub which does not persist the data when these containers are rebuilt. Thus, __rebuilding of all Docker containers with `make dockers` or rebuilding the `things-db` and `users-db` containers separately with `make docker_things-db` and `make docker_users-db` respectively, will cause data loss. All your users, things, channels and connections between them will be lost!__ As we use this setup only for development, we don't guarantee any permanent data persistence. If you need to retain the data between the container rebuilds you can attach volume to the `things-db` and `users-db` containers. Check the official docs on how to use volumes [here](https
+://docs.docker.com/storage/volumes/) and [here](https://docs.docker.com/compose/compose-file/#volumes).
+
 ### MQTT Microservice
 MQTT Microservice in Mainflux is special, as it is currently the only microservice written in NodeJS. It is not compiled,
 but node modules need to be downloaded in order to start the service:

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -39,7 +39,7 @@ func migrateDB(db *sql.DB) error {
 			{
 				Id: "things_1",
 				Up: []string{
-					`CREATE TABLE things (
+					`CREATE TABLE IF NOT EXISTS things (
 						id      BIGSERIAL,
 						owner   VARCHAR(254),
 						type    VARCHAR(10) NOT NULL,
@@ -48,13 +48,13 @@ func migrateDB(db *sql.DB) error {
 						metadata TEXT,
 						PRIMARY KEY (id, owner)
 					)`,
-					`CREATE TABLE channels (
+					`CREATE TABLE IF NOT EXISTS channels (
 						id    BIGSERIAL,
 						owner VARCHAR(254),
 						name  TEXT,
 						PRIMARY KEY (id, owner)
 					)`,
-					`CREATE TABLE connections (
+					`CREATE TABLE IF NOT EXISTS connections (
 						channel_id    BIGINT,
 						channel_owner VARCHAR(254),
 						thing_id     BIGINT,

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -39,7 +39,7 @@ func migrateDB(db *sql.DB) error {
 			{
 				Id: "users_1",
 				Up: []string{
-					`CREATE TABLE users (
+					`CREATE TABLE IF NOT EXISTS users (
 						email	 VARCHAR(254) PRIMARY KEY,
 						password CHAR(60)	  NOT NULL
 					)`,

--- a/ws/README.md
+++ b/ws/README.md
@@ -54,4 +54,4 @@ MF_THINGS_URL=[Things service URL] MF_NATS_URL=[NATS instance URL] MF_WS_ADAPTER
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yaml).
+the [WebSocket paragraph](https://mainflux.readthedocs.io/en/latest/getting-started/#websocket) in the Getting Started guide.


### PR DESCRIPTION
A collective pull request with the following changes:

* Fix for #337 
* added the discussed changes in the dev guide pull request  [here](https://github.com/mainflux/mainflux/pull/351#pullrequestreview-146745602) and [here](https://github.com/mainflux/mainflux/pull/351#issuecomment-413603565)
  * warning about the possible data loss when rebuilding the containers
  * use "CREATE TABLE IF NOT EXISTS" in the `things-db` and `users-db` containers
* added test target in the Makefile for easier running of the tests. The test target was also added when executing the`all` and  `dockers` target before building the docker images. This way we will be sure that nothing is broken when building the container images before pushing them on Docker Hub. A description for the test target was also added to the dev guide.
Note: There is no need to clear the cache before running the tests, because if some files are changed the cache will be invalidated automatically.
 