### PR TITLE
NOISSUE - Dev dockers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILD_DIR = build
-SERVICES = users things http normalizer ws influxdb mongodb-writer mongodb-reader cassandra-writer cassandra-reader cli
+SERVICES = users things http normalizer ws influxdb-writer influxdb-reader mongodb-writer mongodb-reader cassandra-writer cassandra-reader cli
 DOCKERS = $(addprefix docker_,$(SERVICES))
 DOCKERS_DEV = $(addprefix docker_dev_,$(SERVICES))
 CGO_ENABLED ?= 0
@@ -28,10 +28,13 @@ clean:
 install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 
+test:
+	GOCACHE=off go test -v -race -tags test $(shell go list ./... | grep -v 'vendor\|cmd')
+
 proto:
 	protoc --go_out=plugins=grpc:. *.proto
 
-$(SERVICES): proto
+$(SERVICES):
 	$(call compile_service,$(@))
 
 $(DOCKERS):

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD_DIR = build
-SERVICES = users things http normalizer ws influxdb-writer influxdb-reader mongodb-writer mongodb-reader cassandra-writer cassandra-reader cli
+SERVICES = users things http normalizer ws influxdb mongodb-writer mongodb-reader cassandra-writer cassandra-reader cli
 DOCKERS = $(addprefix docker_,$(SERVICES))
+DOCKERS_DEV = $(addprefix docker_dev_,$(SERVICES))
 CGO_ENABLED ?= 0
 GOOS ?= linux
 
@@ -13,12 +14,12 @@ define make_docker
 endef
 
 define make_docker_dev
-	docker build --build-arg SVC_NAME=$(1) --tag=mainflux/$(1) -f docker/Dockerfile.dev ./build/
+	docker build --build-arg SVC_NAME=$(subst docker_dev_,,$(1)) --tag=mainflux/$(subst docker_dev_,,$(1)) -f docker/Dockerfile.dev ./build
 endef
 
 all: $(SERVICES) mqtt
 
-.PHONY: all $(SERVICES) dockers latest release mqtt
+.PHONY: all $(SERVICES) dockers dockers_dev latest release mqtt
 
 clean:
 	rm -rf ${BUILD_DIR}
@@ -27,13 +28,10 @@ clean:
 install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 
-test:
-	GOCACHE=off go test -v -race -tags test $(shell go list ./... | grep -v 'vendor\|cmd')
-
 proto:
 	protoc --go_out=plugins=grpc:. *.proto
 
-$(SERVICES):
+$(SERVICES): proto
 	$(call compile_service,$(@))
 
 $(DOCKERS):
@@ -43,10 +41,10 @@ dockers: $(DOCKERS)
 	docker build --tag=mainflux/dashflux -f dashflux/docker/Dockerfile dashflux
 	docker build --tag=mainflux/mqtt -f mqtt/Dockerfile .
 
-dockers_dev:
-	for svc in $(SERVICES); do \
-		$(call make_docker_dev,$$svc); \
-	done
+$(DOCKERS_DEV):
+	$(call make_docker_dev,$(@))
+
+dockers_dev: $(DOCKERS_DEV)
 
 mqtt:
 	cd mqtt && npm install

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ define compile_service
 endef
 
 define make_docker
-	docker build --build-arg SVC_NAME=$(subst docker_,,$(1)) --tag=mainflux/$(subst docker_,,$(1)) -f docker/Dockerfile .
+	docker build --no-cache --build-arg SVC_NAME=$(subst docker_,,$(1)) --tag=mainflux/$(subst docker_,,$(1)) -f docker/Dockerfile .
+endef
+
+define make_docker_dev
+	docker build --build-arg SVC_NAME=$(1) --tag=mainflux/$(1) -f docker/Dockerfile.dev ./build/
 endef
 
 all: $(SERVICES) mqtt
@@ -38,6 +42,11 @@ $(DOCKERS):
 dockers: $(DOCKERS)
 	docker build --tag=mainflux/dashflux -f dashflux/docker/Dockerfile dashflux
 	docker build --tag=mainflux/mqtt -f mqtt/Dockerfile .
+
+dockers_dev:
+	for svc in $(SERVICES); do \
+		$(call make_docker_dev,$$svc); \
+	done
 
 mqtt:
 	cd mqtt && npm install

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM scratch
+ARG SVC_NAME
+COPY mainflux-$SVC_NAME /exe
+ENTRYPOINT ["/exe"]

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -66,7 +66,7 @@ make docker_http
 
 > N.B. The `things-db` and `users-db` containers are built from a vanilla PostgreSQL docker image downloaded from docker hub which does not persist the data when these containers are rebuilt. Thus, __rebuilding of all docker containers with `make dockers` or rebuilding the `things-db` and `users-db` containers separately with `make docker_things-db` and `make docker_users-db` respectively, will cause data loss. All your users, things, channels and connections between them will be lost!__ As we use this setup only for development, we don't guarantee any permanent data persistence. If you need to retain the data between the container rebuilds you can attach volume to the `things-db` and `users-db` containers. Check the official docs on how to use volumes [here](https://docs.docker.com/storage/volumes/) and [here](https://docs.docker.com/compose/compose-file/#volumes).
 
-#### Building Docker images for development:
+#### Building Docker images for development
 
 In order to speed up build process, you can use commands such as:
 
@@ -80,7 +80,7 @@ or individually with
 make docker_dev_<microservice_name>
 ```
 
-Commands `make dockers` and `make dockers_dev` are similar. The main difference is that building images in the development mode is done on the local machine, rather than an intermediate image, which makes building images much faster. Before running this command, corresponding binary needs to be built in order to make changes visible. This can be done using `make` or `make <service_name>` command. Commands `make dockers_dev` and `make_docker_dev <service_name>` should be used only for development to speed up the process of image building. **For deployment images, commands from section above should be used.**
+Commands `make dockers` and `make dockers_dev` are similar. The main difference is that building images in the development mode is done on the local machine, rather than an intermediate image, which makes building images much faster. Before running this command, corresponding binary needs to be built in order to make changes visible. This can be done using `make` or `make <service_name>` command. Commands `make dockers_dev` and `make docker_dev_<service_name>` should be used only for development to speed up the process of image building. **For deployment images, commands from section above should be used.**
 
 ### MQTT Microservice
 The MQTT Microservice in Mainflux is special, as it is currently the only microservice written in NodeJS. It is not compiled, but node modules need to be downloaded in order to start the service:

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -66,6 +66,22 @@ make docker_http
 
 > N.B. The `things-db` and `users-db` containers are built from a vanilla PostgreSQL docker image downloaded from docker hub which does not persist the data when these containers are rebuilt. Thus, __rebuilding of all docker containers with `make dockers` or rebuilding the `things-db` and `users-db` containers separately with `make docker_things-db` and `make docker_users-db` respectively, will cause data loss. All your users, things, channels and connections between them will be lost!__ As we use this setup only for development, we don't guarantee any permanent data persistence. If you need to retain the data between the container rebuilds you can attach volume to the `things-db` and `users-db` containers. Check the official docs on how to use volumes [here](https://docs.docker.com/storage/volumes/) and [here](https://docs.docker.com/compose/compose-file/#volumes).
 
+#### Building Docker images for development:
+
+In order to speed up build process, you can use commands such as:
+
+```bash
+make dockers_dev
+```
+
+or individually with
+
+```bash
+make docker_dev_<microservice_name>
+```
+
+Commands `make dockers` and `make dockers_dev` are similar. The main difference is that building images in the development mode is done on the local machine, rather than an intermediate image, which makes building images much faster. Before running this command, corresponding binary needs to be built in order to make changes visible. This can be done using `make` or `make <service_name>` command. Commands `make dockers_dev` and `make_docker_dev <service_name>` should be used only for development to speed up the process of image building. **For deployment images, commands from section above should be used.**
+
 ### MQTT Microservice
 The MQTT Microservice in Mainflux is special, as it is currently the only microservice written in NodeJS. It is not compiled, but node modules need to be downloaded in order to start the service:
 


### PR DESCRIPTION
**Summary:**
This pull request provides building Docker images locally `for development purposes`. This is done in order to make building images much faster.
Building images for deployment is set not to use cache.