### PR TITLE
NOISSUE - Influxdb batch add

### DIFF
--- a/cmd/influxdb-writer/main.go
+++ b/cmd/influxdb-writer/main.go
@@ -12,7 +12,9 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
+	"time"
 
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	influxdata "github.com/influxdata/influxdb/client/v2"
@@ -27,32 +29,38 @@ import (
 const (
 	queue = "influxdb-writer"
 
-	defNatsURL   = nats.DefaultURL
-	defPort      = "8180"
-	defPointName = "messages"
-	defDBName    = "mainflux"
-	defDBHost    = "localhost"
-	defDBPort    = "8086"
-	defDBUser    = "mainflux"
-	defDBPass    = "mainflux"
+	defNatsURL      = nats.DefaultURL
+	defPort         = "8180"
+	defBatchSize    = 5000
+	defBatchTimeout = 5
+	defPointName    = "messages"
+	defDBName       = "mainflux"
+	defDBHost       = "localhost"
+	defDBPort       = "8086"
+	defDBUser       = "mainflux"
+	defDBPass       = "mainflux"
 
-	envNatsURL = "MF_NATS_URL"
-	envPort    = "MF_INFLUX_WRITER_PORT"
-	envDBName  = "MF_INFLUX_WRITER_DB_NAME"
-	envDBHost  = "MF_INFLUX_WRITER_DB_HOST"
-	envDBPort  = "MF_INFLUX_WRITER_DB_PORT"
-	envDBUser  = "MF_INFLUX_WRITER_DB_USER"
-	envDBPass  = "MF_INFLUX_WRITER_DB_PASS"
+	envNatsURL      = "MF_NATS_URL"
+	envPort         = "MF_INFLUX_WRITER_PORT"
+	envBatchSize    = "MF_INFLUX_WRITER_BATCH_SIZE"
+	envBatchTimeout = "MF_INFLUX_WRITER_BATCH_TIMEOUT"
+	envDBName       = "MF_INFLUX_WRITER_DB_NAME"
+	envDBHost       = "MF_INFLUX_WRITER_DB_HOST"
+	envDBPort       = "MF_INFLUX_WRITER_DB_PORT"
+	envDBUser       = "MF_INFLUX_WRITER_DB_USER"
+	envDBPass       = "MF_INFLUX_WRITER_DB_PASS"
 )
 
 type config struct {
-	NatsURL string
-	Port    string
-	DBName  string
-	DBHost  string
-	DBPort  string
-	DBUser  string
-	DBPass  string
+	NatsURL      string
+	Port         string
+	BatchSize    int
+	BatchTimeout int
+	DBName       string
+	DBHost       string
+	DBPort       string
+	DBUser       string
+	DBPass       string
 }
 
 func main() {
@@ -73,7 +81,7 @@ func main() {
 	}
 	defer client.Close()
 
-	repo, err := influxdb.New(client, cfg.DBName)
+	repo, err := influxdb.New(client, cfg.DBName, cfg.BatchSize, time.Duration(cfg.BatchTimeout)*time.Second)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to create InfluxDB writer: %s", err))
 		os.Exit(1)
@@ -110,6 +118,8 @@ func loadConfigs() (config, influxdata.HTTPConfig) {
 		DBUser:  mainflux.Env(envDBUser, defDBUser),
 		DBPass:  mainflux.Env(envDBPass, defDBPass),
 	}
+	cfg.BatchSize = parseInt(mainflux.Env(envBatchSize, ""), defBatchSize)
+	cfg.BatchTimeout = parseInt(mainflux.Env(envBatchTimeout, ""), defBatchTimeout)
 
 	clientCfg := influxdata.HTTPConfig{
 		Addr:     fmt.Sprintf("http://%s:%s", cfg.DBHost, cfg.DBPort),
@@ -118,6 +128,14 @@ func loadConfigs() (config, influxdata.HTTPConfig) {
 	}
 
 	return cfg, clientCfg
+}
+
+func parseInt(val string, def int) int {
+	ret, err := strconv.Atoi(val)
+	if err != nil {
+		return def
+	}
+	return ret
 }
 
 func makeMetrics() (*kitprometheus.Counter, *kitprometheus.Summary) {

--- a/cmd/influxdb-writer/main.go
+++ b/cmd/influxdb-writer/main.go
@@ -81,7 +81,8 @@ func main() {
 	}
 	defer client.Close()
 
-	repo, err := influxdb.New(client, cfg.DBName, cfg.BatchSize, time.Duration(cfg.BatchTimeout)*time.Second)
+	timeout := time.Duration(cfg.BatchTimeout) * time.Second
+	repo, err := influxdb.New(client, cfg.DBName, cfg.BatchSize, timeout)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to create InfluxDB writer: %s", err))
 		os.Exit(1)
@@ -160,6 +161,6 @@ func makeMetrics() (*kitprometheus.Counter, *kitprometheus.Summary) {
 
 func startHTTPService(port string, logger log.Logger, errs chan error) {
 	p := fmt.Sprintf(":%s", port)
-	logger.Info(fmt.Sprintf("Influxdb writer service started, exposed port %s", p))
+	logger.Info(fmt.Sprintf("InfluxDB writer service started, exposed port %s", p))
 	errs <- http.ListenAndServe(p, influxdb.MakeHandler())
 }

--- a/cmd/influxdb-writer/main.go
+++ b/cmd/influxdb-writer/main.go
@@ -33,7 +33,6 @@ const (
 	defPort         = "8180"
 	defBatchSize    = "5000"
 	defBatchTimeout = "5"
-	defPointName    = "messages"
 	defDBName       = "mainflux"
 	defDBHost       = "localhost"
 	defDBPort       = "8086"
@@ -119,6 +118,7 @@ func loadConfigs(logger log.Logger) (config, influxdata.HTTPConfig) {
 		DBUser:  mainflux.Env(envDBUser, defDBUser),
 		DBPass:  mainflux.Env(envDBPass, defDBPass),
 	}
+
 	var err error
 	cfg.BatchSize, err = strconv.Atoi(mainflux.Env(envBatchSize, defBatchSize))
 	if err != nil {

--- a/docker/addons/influxdb-writer/docker-compose.yml
+++ b/docker/addons/influxdb-writer/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     environment:
       MF_NATS_URL: nats://nats:4222
       MF_INFLUX_WRITER_PORT: 8900
+      MF_INFLUX_WRITER_BATCH_SIZE: 5000
+      MF_INFLUX_WRITER_BATCH_TIMEOUT: 5
       MF_INFLUX_WRITER_DB_NAME: mainflux
       MF_INFLUX_WRITER_DB_HOST: mainflux-influxdb
       MF_INFLUX_WRITER_DB_PORT: 8086

--- a/k8s/addons/influxdb/writer.yml
+++ b/k8s/addons/influxdb/writer.yml
@@ -12,8 +12,8 @@ spec:
         component: influxdb-writer
     spec:
       containers:
-      - name: mainflux-influxdb
-        image: mainflux/influxdb:latest
+      - name: mainflux-influxdb-writer
+        image: mainflux/influxdb-writer:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8900
@@ -22,6 +22,10 @@ spec:
             value: "nats://nats:4222"
           - name: MF_INFLUX_WRITER_PORT
             value: "8900"
+          - name: MF_INFLUX_WRITER_BATCH_SIZE
+            value: "5000"
+          - name: MF_INFLUX_WRITER_BATCH_TIMEOUT
+            value: "5"
           - name: MF_INFLUX_WRITER_DB_NAME
             value: "mainflux"
           - name: MF_INFLUX_WRITER_DB_HOST

--- a/readers/influxdb/messages_test.go
+++ b/readers/influxdb/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	influxdata "github.com/influxdata/influxdb/client/v2"
 	"github.com/mainflux/mainflux"
@@ -40,7 +41,7 @@ func TestReadAll(t *testing.T) {
 	client, err := influxdata.NewHTTPClient(clientCfg)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB client expected to succeed: %s.\n", err))
 
-	writer, err := writer.New(client, testDB)
+	writer, err := writer.New(client, testDB, 1, time.Second)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB writer expected to succeed: %s.\n", err))
 
 	messages := []mainflux.Message{}

--- a/writers/README.md
+++ b/writers/README.md
@@ -4,7 +4,13 @@ Writers provide an implementation of various `message writers`.
 Message writers are services that consume normalized (in `SenML` format)
 Mainflux messages and store them in specific data store.
 
+Writers are optional services and are treated as a plugins. In order to
+run writer services, core services must be up and running. For more info
+on the platform core services with its dependencies, please check out
+the [Docker Compose][compose] file.
+
 For an in-depth explanation of the usage of `writers`, as well as thorough
 understanding of Mainflux, please check out the [official documentation][doc].
 
 [doc]: http://mainflux.readthedocs.io
+[compose]: ../docker/docker-compose.yml

--- a/writers/influxdb/README.md
+++ b/writers/influxdb/README.md
@@ -8,15 +8,17 @@ The service is configured using the environment variables presented in the
 following table. Note that any unset variables will be replaced with their
 default values.
 
-| Variable                  | Description                       | Default               |
-|---------------------------|-----------------------------------|-----------------------|
-| MF_NATS_URL               | NATS instance URL                 | nats://localhost:4222 |
-| MF_INFLUX_WRITER_PORT     | Service HTTP port                 | 8180                  |
-| MF_INFLUX_WRITER_DB_NAME  | InfluxDB database name            | mainflux              |
-| MF_INFLUX_WRITER_DB_HOST  | InfluxDB host                     | localhost             |
-| MF_INFLUX_WRITER_DB_PORT  | Default port of InfluxDB database | 8086                  |
-| MF_INFLUX_WRITER_DB_USER  | Default user of InfluxDB database | mainflux              |
-| MF_INFLUX_WRITER_DB_PASS  | Default password of InfluxDB user | mainflux              |
+| Variable                       | Description                                 | Default               |
+|--------------------------------|---------------------------------------------|-----------------------|
+| MF_NATS_URL                    | NATS instance URL                           | nats://localhost:4222 |
+| MF_INFLUX_WRITER_PORT          | Service HTTP port                           | 8180                  |
+| MF_INFLUX_WRITER_BATCH_SIZE    | Size of the writer points batch             | 5000                  |
+| MF_INFLUX_WRITER_BATCH_TIMEOUT | Time interval in seconds to flush the batch | 1 second              |
+| MF_INFLUX_WRITER_DB_NAME       | InfluxDB database name                      | mainflux              |
+| MF_INFLUX_WRITER_DB_HOST       | InfluxDB host                               | localhost             |
+| MF_INFLUX_WRITER_DB_PORT       | Default port of InfluxDB database           | 8086                  |
+| MF_INFLUX_WRITER_DB_USER       | Default user of InfluxDB database           | mainflux              |
+| MF_INFLUX_WRITER_DB_PASS       | Default password of InfluxDB user           | mainflux              |
 
 ## Deployment
 
@@ -31,6 +33,8 @@ default values.
     environment:
       MF_NATS_URL: [NATS instance URL]
       MF_INFLUX_WRITER_PORT: [Service HTTP port]
+      MF_INFLUX_WRITER_BATCH_SIZE: [Size of the batch of the points]
+      MF_INFLUX_WRITER_BATCH_TIMEOUT: [Time interval in seconds for writing batch to the database]
       MF_INFLUX_WRITER_DB_NAME: [InfluxDB name]
       MF_INFLUX_WRITER_DB_HOST: [InfluxDB host]
       MF_INFLUX_WRITER_DB_PORT: [InfluxDB port]
@@ -56,7 +60,7 @@ make influxdb
 make install
 
 # Set the environment variables and run the service
-MF_NATS_URL=[NATS instance URL] MF_INFLUX_WRITER_PORT=[Service HTTP port] MF_INFLUX_WRITER_DB_NAME=[InfluxDB database name] MF_INFLUX_WRITER_DB_HOST=[InfluxDB database host] MF_INFLUX_WRITER_DB_PORT=[InfluxDB database port] MF_INFLUX_WRITER_DB_USER=[InfluxDB admin user] MF_INFLUX_WRITER_DB_PASS=[InfluxDB admin password] $GOBIN/mainflux-influxdb
+MF_NATS_URL=[NATS instance URL] MF_INFLUX_WRITER_PORT=[Service HTTP port] MF_INFLUX_WRITER_BATCH_SIZE=[Size of the writer points batch] MF_INFLUX_WRITER_BATCH_TIMEOUT=[Time interval to flush the batch] MF_INFLUX_WRITER_DB_NAME=[InfluxDB database name] MF_INFLUX_WRITER_DB_HOST=[InfluxDB database host] MF_INFLUX_WRITER_DB_PORT=[InfluxDB database port] MF_INFLUX_WRITER_DB_USER=[InfluxDB admin user] MF_INFLUX_WRITER_DB_PASS=[InfluxDB admin password] $GOBIN/mainflux-influxdb
 
 ```
 
@@ -65,13 +69,13 @@ MF_NATS_URL=[NATS instance URL] MF_INFLUX_WRITER_PORT=[Service HTTP port] MF_INF
 This service can be deployed using docker containers.
 Docker compose file is available in `<project_root>/docker/addons/influxdb-writer/docker-compose.yml`. Besides database
 and writer service, it contains [Grafana platform](https://grafana.com/) which can be used for database
-exploration and data visualization and analytics. In order to run all Mainflux core services, as well as mentioned optional ones, execute following command:
+exploration and data visualization and analytics. In order to run Mainflux InfluxDB writer, execute the following command:
 
 ```bash
-docker-compose -f docker/docker-compose.yml -f docker/addons/influxdb-writer/docker-compose.yml up -d
+docker-compose -f docker/addons/influxdb-writer/docker-compose.yml up -d
 ```
 
-_Please note that order matters here. You need to start core services before additional ones, i. e. core services compose file needs to be the first param of the command. Since all services need to be in the same network and writer services are dependent of core ones, you need to start all of them using single command._
+_Please note that you need to start core services before the additional ones._
 
 ## Usage
 

--- a/writers/influxdb/README.md
+++ b/writers/influxdb/README.md
@@ -33,8 +33,8 @@ default values.
     environment:
       MF_NATS_URL: [NATS instance URL]
       MF_INFLUX_WRITER_PORT: [Service HTTP port]
-      MF_INFLUX_WRITER_BATCH_SIZE: [Size of the batch of the points]
-      MF_INFLUX_WRITER_BATCH_TIMEOUT: [Time interval in seconds for writing batch to the database]
+      MF_INFLUX_WRITER_BATCH_SIZE: [Size of the writer points batch]
+      MF_INFLUX_WRITER_BATCH_TIMEOUT: [Time interval in seconds to flush the batch]
       MF_INFLUX_WRITER_DB_NAME: [InfluxDB name]
       MF_INFLUX_WRITER_DB_HOST: [InfluxDB host]
       MF_INFLUX_WRITER_DB_PORT: [InfluxDB port]
@@ -60,7 +60,7 @@ make influxdb
 make install
 
 # Set the environment variables and run the service
-MF_NATS_URL=[NATS instance URL] MF_INFLUX_WRITER_PORT=[Service HTTP port] MF_INFLUX_WRITER_BATCH_SIZE=[Size of the writer points batch] MF_INFLUX_WRITER_BATCH_TIMEOUT=[Time interval to flush the batch] MF_INFLUX_WRITER_DB_NAME=[InfluxDB database name] MF_INFLUX_WRITER_DB_HOST=[InfluxDB database host] MF_INFLUX_WRITER_DB_PORT=[InfluxDB database port] MF_INFLUX_WRITER_DB_USER=[InfluxDB admin user] MF_INFLUX_WRITER_DB_PASS=[InfluxDB admin password] $GOBIN/mainflux-influxdb
+MF_NATS_URL=[NATS instance URL] MF_INFLUX_WRITER_PORT=[Service HTTP port] MF_INFLUX_WRITER_BATCH_SIZE=[Size of the writer points batch] MF_INFLUX_WRITER_BATCH_TIMEOUT=[Time interval in seconds to flush the batch] MF_INFLUX_WRITER_DB_NAME=[InfluxDB database name] MF_INFLUX_WRITER_DB_HOST=[InfluxDB database host] MF_INFLUX_WRITER_DB_PORT=[InfluxDB database port] MF_INFLUX_WRITER_DB_USER=[InfluxDB admin user] MF_INFLUX_WRITER_DB_PASS=[InfluxDB admin password] $GOBIN/mainflux-influxdb
 
 ```
 

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -61,9 +61,11 @@ func (repo *influxRepo) save() error {
 	defer repo.mu.Unlock()
 	bp, _ := influxdata.NewBatchPoints(repo.cfg)
 	bp.AddPoints(repo.batch)
+
 	if err := repo.client.Write(bp); err != nil {
 		return err
 	}
+
 	repo.batch = []*influxdata.Point{}
 	return nil
 }
@@ -74,6 +76,7 @@ func (repo *influxRepo) Save(msg mainflux.Message) error {
 	if err != nil {
 		return err
 	}
+
 	repo.add(pt)
 	return nil
 }
@@ -82,6 +85,7 @@ func (repo *influxRepo) add(pt *influxdata.Point) {
 	repo.mu.Lock()
 	repo.batch = append(repo.batch, pt)
 	repo.mu.Unlock()
+
 	if len(repo.batch)%repo.batchSize == 0 {
 		repo.save()
 	}
@@ -92,6 +96,7 @@ func (repo *influxRepo) tagsOf(msg *mainflux.Message) tags {
 	update := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
 	channel := strconv.FormatUint(msg.Channel, 10)
 	publisher := strconv.FormatUint(msg.Publisher, 10)
+
 	return tags{
 		"Channel":    channel,
 		"Publisher":  publisher,

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -9,6 +9,7 @@ package influxdb
 
 import (
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/mainflux/mainflux/writers"
@@ -22,34 +23,68 @@ const pointName = "messages"
 var _ writers.MessageRepository = (*influxRepo)(nil)
 
 type influxRepo struct {
-	database string
-	client   influxdata.Client
+	client    influxdata.Client
+	batch     []*influxdata.Point
+	batchSize int
+	mu        sync.Mutex
+	tick      <-chan time.Time
+	cfg       influxdata.BatchPointsConfig
 }
 
 type fields map[string]interface{}
 type tags map[string]string
 
 // New returns new InfluxDB writer.
-func New(client influxdata.Client, database string) (writers.MessageRepository, error) {
-	return &influxRepo{database, client}, nil
+func New(client influxdata.Client, database string, batchSize int, batchTimeout time.Duration) (writers.MessageRepository, error) {
+	repo := &influxRepo{
+		client: client,
+		cfg: influxdata.BatchPointsConfig{
+			Database: database,
+		},
+		batchSize: batchSize,
+		batch:     []*influxdata.Point{},
+	}
+
+	repo.tick = time.NewTicker(batchTimeout).C
+	go func() {
+		for {
+			<-repo.tick
+			repo.save()
+		}
+	}()
+
+	return repo, nil
+}
+
+func (repo *influxRepo) save() error {
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	bp, _ := influxdata.NewBatchPoints(repo.cfg)
+	bp.AddPoints(repo.batch)
+	if err := repo.client.Write(bp); err != nil {
+		return err
+	}
+	repo.batch = []*influxdata.Point{}
+	return nil
 }
 
 func (repo *influxRepo) Save(msg mainflux.Message) error {
-	bp, err := influxdata.NewBatchPoints(influxdata.BatchPointsConfig{
-		Database: repo.database,
-	})
-	if err != nil {
-		return err
-	}
-
 	tags, fields := repo.tagsOf(&msg), repo.fieldsOf(&msg)
 	pt, err := influxdata.NewPoint(pointName, tags, fields, time.Now())
 	if err != nil {
 		return err
 	}
+	repo.add(pt)
+	return nil
+}
 
-	bp.AddPoint(pt)
-	return repo.client.Write(bp)
+func (repo *influxRepo) add(pt *influxdata.Point) {
+	repo.mu.Lock()
+	repo.batch = append(repo.batch, pt)
+	repo.mu.Unlock()
+	if len(repo.batch)%repo.batchSize == 0 {
+		repo.save()
+	}
 }
 
 func (repo *influxRepo) tagsOf(msg *mainflux.Message) tags {

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -70,6 +70,9 @@ func (repo *influxRepo) save() error {
 		return err
 	}
 
+	// It would be nice to reset ticker at this point, which
+	// implies creating a new ticker and goroutine. It would
+	// introduce unnecessary complexity with no justified benefits.
 	repo.batch = []*influxdata.Point{}
 	return nil
 }

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -30,10 +30,12 @@ var (
 	streamsSize   = 250
 	client        influxdata.Client
 	q             = fmt.Sprintf("SELECT * FROM test..messages\n")
-	clientCfg     = influxdata.HTTPConfig{
+
+	clientCfg = influxdata.HTTPConfig{
 		Username: "test",
 		Password: "test",
 	}
+
 	msg = mainflux.Message{
 		Channel:     45,
 		Publisher:   2580,
@@ -73,13 +75,13 @@ func TestSave(t *testing.T) {
 	client, err := influxdata.NewHTTPClient(clientCfg)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB client expected to succeed: %s.\n", err))
 
+	// Set batch size to 1 to simulate single point insert.
 	repo, err := writer.New(client, testDB, 1, saveTimeout)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB repo expected to succeed: %s.\n", err))
 
 	err = repo.Save(msg)
 	assert.Nil(t, err, fmt.Sprintf("Save operation expected to succeed: %s.\n", err))
 
-	time.Sleep(1 * time.Second)
 	row, err := queryDB(q)
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
 
@@ -102,7 +104,7 @@ func TestBatchSave(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
 	time.Sleep(time.Second)
 	count := len(row)
-	// Add one because of previous test.
+	// Add one because of previous the test.
 	size := streamsSize - (streamsSize % saveBatchSize) + 1
 	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
 
@@ -112,7 +114,7 @@ func TestBatchSave(t *testing.T) {
 	row, err = queryDB(q)
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
 	count = len(row)
-	// Add one because of previous test.
+	// Add one because of previous the test.
 	size = streamsSize + 1
 	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
 }

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	influxdata "github.com/influxdata/influxdb/client/v2"
-	"github.com/influxdata/influxdb/models"
 	"github.com/mainflux/mainflux"
 	log "github.com/mainflux/mainflux/logger"
 	writer "github.com/mainflux/mainflux/writers/influxdb"
@@ -22,36 +22,19 @@ import (
 )
 
 var (
-	port      string
-	testLog   = log.New(os.Stdout)
-	testDB    = "test"
-	client    influxdata.Client
-	clientCfg = influxdata.HTTPConfig{
+	port          string
+	testLog       = log.New(os.Stdout)
+	testDB        = "test"
+	saveTimeout   = 5 * time.Second
+	saveBatchSize = 20
+	streamsSize   = 250
+	client        influxdata.Client
+	q             = fmt.Sprintf("SELECT * FROM test..messages\n")
+	clientCfg     = influxdata.HTTPConfig{
 		Username: "test",
 		Password: "test",
 	}
-)
-
-// This is utility function to query the database.
-func queryDB(cmd string) ([]models.Row, error) {
-	q := influxdata.Query{
-		Command:  cmd,
-		Database: testDB,
-	}
-	response, err := client.Query(q)
-	if err != nil {
-		return nil, err
-	}
-	if response.Error() != nil {
-		return nil, response.Error()
-	}
-	// There is only one query, so only one result and
-	// all data are stored in the same series.
-	return response.Results[0].Series, nil
-}
-
-func TestSave(t *testing.T) {
-	msg := mainflux.Message{
+	msg = mainflux.Message{
 		Channel:     45,
 		Publisher:   2580,
 		Protocol:    "http",
@@ -66,21 +49,70 @@ func TestSave(t *testing.T) {
 		UpdateTime:  5456565466,
 		Link:        "link",
 	}
+)
 
-	q := fmt.Sprintf("SELECT * FROM test..messages\n")
+// This is utility function to query the database.
+func queryDB(cmd string) ([][]interface{}, error) {
+	q := influxdata.Query{
+		Command:  cmd,
+		Database: testDB,
+	}
+	response, err := client.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error() != nil {
+		return nil, response.Error()
+	}
+	// There is only one query, so only one result and
+	// all data are stored in the same series.
+	return response.Results[0].Series[0].Values, nil
+}
 
+func TestSave(t *testing.T) {
 	client, err := influxdata.NewHTTPClient(clientCfg)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB client expected to succeed: %s.\n", err))
 
-	repo, err := writer.New(client, testDB)
+	repo, err := writer.New(client, testDB, 1, saveTimeout)
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB repo expected to succeed: %s.\n", err))
 
 	err = repo.Save(msg)
 	assert.Nil(t, err, fmt.Sprintf("Save operation expected to succeed: %s.\n", err))
 
+	time.Sleep(1 * time.Second)
 	row, err := queryDB(q)
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
 
 	count := len(row)
 	assert.Equal(t, 1, count, fmt.Sprintf("Expected to have 1 value, found %d instead.\n", count))
+}
+
+func TestBatchSave(t *testing.T) {
+	client, err := influxdata.NewHTTPClient(clientCfg)
+	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB client expected to succeed: %s.\n", err))
+
+	repo, err := writer.New(client, testDB, saveBatchSize, saveTimeout)
+	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB repo expected to succeed: %s.\n", err))
+
+	for i := 0; i < streamsSize; i++ {
+		repo.Save(msg)
+	}
+
+	row, err := queryDB(q)
+	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
+	time.Sleep(time.Second)
+	count := len(row)
+	// Add one because of previous test.
+	size := streamsSize - (streamsSize % saveBatchSize) + 1
+	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
+
+	// Sleep for `saveBatchTime` to trigger timer and check if data is saved.
+	time.Sleep(saveTimeout)
+
+	row, err = queryDB(q)
+	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
+	count = len(row)
+	// Add one because of previous test.
+	size = streamsSize + 1
+	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
 }

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -25,7 +25,7 @@ var (
 	port          string
 	testLog       = log.New(os.Stdout)
 	testDB        = "test"
-	saveTimeout   = 5 * time.Second
+	saveTimeout   = 2 * time.Second
 	saveBatchSize = 20
 	streamsSize   = 250
 	client        influxdata.Client
@@ -102,19 +102,18 @@ func TestBatchSave(t *testing.T) {
 
 	row, err := queryDB(q)
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
-	time.Sleep(time.Second)
 	count := len(row)
-	// Add one because of previous the test.
+	// Add one because of the previous test.
 	size := streamsSize - (streamsSize % saveBatchSize) + 1
 	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
 
-	// Sleep for `saveBatchTime` to trigger timer and check if data is saved.
+	// Sleep for `saveBatchTime` to trigger ticker and check if the reset of the data is saved.
 	time.Sleep(saveTimeout)
 
 	row, err = queryDB(q)
 	assert.Nil(t, err, fmt.Sprintf("Querying InfluxDB to retrieve data count expected to succeed: %s.\n", err))
 	count = len(row)
-	// Add one because of previous the test.
+	// Add one because of the previous test.
 	size = streamsSize + 1
 	assert.Equal(t, size, count, fmt.Sprintf("Expected to have %d value, found %d instead.\n", size, count))
 }


### PR DESCRIPTION
**Summary:**
Add batch write to InfluxDB writer. Since the official Go InfluxDB client currently supports only batch point add, batch size is increased in order to improve performance. Batch size, as well as the time interval for flushing the batch, can be configured using corresponding env variables.