### PR TITLE
NOISSUE - Fixing level_test.go

### DIFF
--- a/logger/level_test.go
+++ b/logger/level_test.go
@@ -12,8 +12,8 @@ func TestUnmarshalText(t *testing.T) {
 		output Level
 		err    error
 	}{
-		"select log level Not_A_Level": {"Not_A_Level", 1, ErrInvalidLogLevel},
-		"select log level Bad_Input":   {"Bad_Input", 1, ErrInvalidLogLevel},
+		"select log level Not_A_Level": {"Not_A_Level", 0, ErrInvalidLogLevel},
+		"select log level Bad_Input":   {"Bad_Input", 0, ErrInvalidLogLevel},
 
 		"select log level debug": {"debug", Debug, nil},
 		"select log level DEBUG": {"DEBUG", Debug, nil},
@@ -25,8 +25,8 @@ func TestUnmarshalText(t *testing.T) {
 		"select log level ERROR": {"ERROR", Error, nil},
 	}
 
-	var logLevel Level
 	for desc, tc := range cases {
+		var logLevel Level
 		err := logLevel.UnmarshalText(tc.input)
 		assert.Equal(t, tc.output, logLevel, fmt.Sprintf("%s: expected %s got %d", desc, tc.output, logLevel))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %d", desc, tc.err, err))


### PR DESCRIPTION
@anovakovic01 found this.

Map order is not guaranteed and was causing issues with the test due to the pointers levels uses. So sometimes actual could be 2 or 4 for example while expected was always one.

We can fix this by moving the level def inside the for loop

Signed-off-by: Michael Finley <Michael.Finley@target.com>