### PR TITLE
Expose the InfluxDB and Cassandra ports to host

### DIFF
--- a/docker/addons/cassandra-writer/docker-compose.yml
+++ b/docker/addons/cassandra-writer/docker-compose.yml
@@ -27,8 +27,6 @@ services:
     container_name: mainflux-cassandra-writer
     depends_on:
       - cassandra
-    expose:
-      - 8902
     restart: on-failure
     environment:
       MF_NATS_URL: nats://nats:4222

--- a/docker/addons/cassandra-writer/docker-compose.yml
+++ b/docker/addons/cassandra-writer/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     restart: on-failure
     networks:
       - docker_mainflux-base-net
+    ports:
+      - 9042:9042
 
   cassandra-writer:
     image: mainflux/cassandra-writer:latest

--- a/docker/addons/influxdb-writer/docker-compose.yml
+++ b/docker/addons/influxdb-writer/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       INFLUXDB_ADMIN_PASSWORD: mainflux
     networks:
       - docker_mainflux-base-net
+    ports:
+      - 8086:8086
 
   influxdb-writer:
     image: mainflux/influxdb-writer:latest

--- a/docker/addons/influxdb-writer/docker-compose.yml
+++ b/docker/addons/influxdb-writer/docker-compose.yml
@@ -31,8 +31,6 @@ services:
     container_name: mainflux-influxdb-writer
     depends_on:
       - influxdb
-    expose:
-      - 8900
     restart: on-failure
     environment:
       MF_NATS_URL: nats://nats:4222

--- a/docker/addons/mongodb-writer/docker-compose.yml
+++ b/docker/addons/mongodb-writer/docker-compose.yml
@@ -17,8 +17,6 @@ services:
   mongodb:
     image: mongo:3.6-jessie
     container_name: mainflux-mongodb
-    expose:
-      - 27017
     restart: on-failure
     environment:
       MONGO_INITDB_DATABASE: mainflux

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,7 +53,6 @@ services:
     depends_on:
       - users-db
     expose:
-      - 8180
       - 8181
     restart: on-failure
     environment:
@@ -95,7 +94,6 @@ services:
       - things-db
       - users
     expose:
-      - 8182
       - 8183
     restart: on-failure
     environment:
@@ -143,8 +141,6 @@ services:
     depends_on:
       - things
       - nats
-    expose:
-      - 8186
     restart: on-failure
     environment:
       MF_WS_ADAPTER_PORT: 8186
@@ -162,8 +158,6 @@ services:
       - things
       - nats
     restart: on-failure
-    expose:
-      - 8185
     environment:
       MF_HTTP_ADAPTER_PORT: 8185
       MF_NATS_URL: nats://nats:4222
@@ -207,8 +201,6 @@ services:
       - things
       - nats
     restart: on-failure
-    expose:
-      - 5683
     environment:
       MF_COAP_ADAPTER_PORT: 5683
       MF_NATS_URL: nats://nats:4222


### PR DESCRIPTION
Expose the InfluxDB's HTTP API port 8086 and  Cassandra's CQL port 9042 from the containers
to the host machine, in order to enable easier exploration of the data stored in the databases
from the host machine and development of apps which connect and use the data stored in the databases.

Fixes #437 