### PR TITLE
MF-454 - Use message Time field as a time for InfluxDB points

### DIFF
--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -10,6 +10,7 @@ package cassandra_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mainflux/mainflux"
 	readers "github.com/mainflux/mainflux/readers/cassandra"
@@ -41,6 +42,7 @@ func TestReadAll(t *testing.T) {
 	writer := writers.New(session)
 
 	messages := []mainflux.Message{}
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields
@@ -58,6 +60,7 @@ func TestReadAll(t *testing.T) {
 		case 5:
 			msg.ValueSum = &mainflux.SumValue{Value: 45}
 		}
+		msg.Time = float64(now + int64(i))
 
 		err := writer.Save(msg)
 		require.Nil(t, err, fmt.Sprintf("failed to store message to Cassandra: %s", err))

--- a/readers/influxdb/messages.go
+++ b/readers/influxdb/messages.go
@@ -68,10 +68,12 @@ func parseValues(value interface{}, name string, msg *mainflux.Message) {
 			if err != nil {
 				return
 			}
+
 			msg.ValueSum = &mainflux.SumValue{Value: valSum}
 		}
 		return
 	}
+
 	if strings.HasSuffix(strings.ToLower(name), "value") {
 		switch value.(type) {
 		case bool:
@@ -81,12 +83,14 @@ func parseValues(value interface{}, name string, msg *mainflux.Message) {
 			if err != nil {
 				return
 			}
+
 			msg.Value = &mainflux.Message_FloatValue{num}
 		case string:
 			if strings.HasPrefix(name, "string") {
 				msg.Value = &mainflux.Message_StringValue{value.(string)}
 				return
 			}
+
 			if strings.HasPrefix(name, "data") {
 				msg.Value = &mainflux.Message_DataValue{value.(string)}
 			}
@@ -119,10 +123,12 @@ func parseMessage(names []string, fields []interface{}) mainflux.Message {
 				if err != nil {
 					continue
 				}
+
 				v := float64(t.Unix())
 				msgField.SetFloat(v)
 				continue
 			}
+
 			val, _ := strconv.ParseFloat(fields[i].(string), 64)
 			msgField.SetFloat(val)
 		}

--- a/readers/influxdb/messages.go
+++ b/readers/influxdb/messages.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mainflux/mainflux/readers"
 
@@ -22,9 +23,6 @@ type influxRepository struct {
 	client   influxdata.Client
 }
 
-type fields map[string]interface{}
-type tags map[string]string
-
 // New returns new InfluxDB reader.
 func New(client influxdata.Client, database string) (readers.MessageRepository, error) {
 	return &influxRepository{database, client}, nil
@@ -35,7 +33,7 @@ func (repo *influxRepository) ReadAll(chanID, offset, limit uint64) []mainflux.M
 		limit = maxLimit
 	}
 
-	cmd := fmt.Sprintf(`SELECT * from messages WHERE Channel='%d' LIMIT %d OFFSET %d`, chanID, limit, offset)
+	cmd := fmt.Sprintf(`SELECT * from messages WHERE channel='%d' LIMIT %d OFFSET %d`, chanID, limit, offset)
 	q := influxdata.Query{
 		Command:  cmd,
 		Database: repo.database,
@@ -51,6 +49,7 @@ func (repo *influxRepository) ReadAll(chanID, offset, limit uint64) []mainflux.M
 	if len(resp.Results) < 1 || len(resp.Results[0].Series) < 1 {
 		return ret
 	}
+
 	result := resp.Results[0].Series[0]
 	for _, v := range result.Values {
 		ret = append(ret, parseMessage(result.Columns, v))
@@ -63,7 +62,7 @@ func (repo *influxRepository) ReadAll(chanID, offset, limit uint64) []mainflux.M
 // results in form of rows and columns, this obscure message conversion is needed
 // to return actual []mainflux.Message from the query result.
 func parseValues(value interface{}, name string, msg *mainflux.Message) {
-	if name == "ValueSum" && value != nil {
+	if name == "valueSum" && value != nil {
 		if sum, ok := value.(json.Number); ok {
 			valSum, err := sum.Float64()
 			if err != nil {
@@ -73,7 +72,7 @@ func parseValues(value interface{}, name string, msg *mainflux.Message) {
 		}
 		return
 	}
-	if strings.HasSuffix(name, "Value") {
+	if strings.HasSuffix(strings.ToLower(name), "value") {
 		switch value.(type) {
 		case bool:
 			msg.Value = &mainflux.Message_BoolValue{value.(bool)}
@@ -82,15 +81,13 @@ func parseValues(value interface{}, name string, msg *mainflux.Message) {
 			if err != nil {
 				return
 			}
-
 			msg.Value = &mainflux.Message_FloatValue{num}
 		case string:
-			if strings.HasPrefix(name, "String") {
+			if strings.HasPrefix(name, "string") {
 				msg.Value = &mainflux.Message_StringValue{value.(string)}
 				return
 			}
-
-			if strings.HasPrefix(name, "Data") {
+			if strings.HasPrefix(name, "data") {
 				msg.Value = &mainflux.Message_DataValue{value.(string)}
 			}
 		}
@@ -102,7 +99,7 @@ func parseMessage(names []string, fields []interface{}) mainflux.Message {
 	v := reflect.ValueOf(&m).Elem()
 	for i, name := range names {
 		parseValues(fields[i], name, &m)
-		msgField := v.FieldByName(name)
+		msgField := v.FieldByName(strings.Title(name))
 		if !msgField.IsValid() {
 			continue
 		}
@@ -117,6 +114,15 @@ func parseMessage(names []string, fields []interface{}) mainflux.Message {
 			u, _ := strconv.ParseUint(fields[i].(string), 10, 64)
 			msgField.SetUint(u)
 		case float64:
+			if name == "time" {
+				t, err := time.Parse(time.RFC3339, fields[i].(string))
+				if err != nil {
+					continue
+				}
+				v := float64(t.Unix())
+				msgField.SetFloat(v)
+				continue
+			}
 			val, _ := strconv.ParseFloat(fields[i].(string), 64)
 			msgField.SetFloat(val)
 		}

--- a/readers/influxdb/messages_test.go
+++ b/readers/influxdb/messages_test.go
@@ -92,8 +92,8 @@ func TestReadAll(t *testing.T) {
 		"read message page for existing channel": {
 			chanID:   chanID,
 			offset:   0,
-			limit:    1,
-			messages: messages[0:1],
+			limit:    10,
+			messages: messages[0:10],
 		},
 		"read message page for too large limit": {
 			chanID:   chanID,

--- a/readers/influxdb/messages_test.go
+++ b/readers/influxdb/messages_test.go
@@ -42,7 +42,7 @@ var (
 		Value:      &mainflux.Message_FloatValue{5},
 		ValueSum:   &mainflux.SumValue{Value: 45},
 		Time:       123456,
-		UpdateTime: 1234567,
+		UpdateTime: 1234,
 		Link:       "link",
 	}
 )
@@ -55,6 +55,7 @@ func TestReadAll(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new InfluxDB writer expected to succeed: %s.\n", err))
 
 	messages := []mainflux.Message{}
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields
@@ -72,6 +73,7 @@ func TestReadAll(t *testing.T) {
 		case 5:
 			msg.ValueSum = &mainflux.SumValue{Value: 45}
 		}
+		msg.Time = float64(now + int64(i))
 
 		err := writer.Save(msg)
 		require.Nil(t, err, fmt.Sprintf("failed to store message to InfluxDB: %s", err))
@@ -90,8 +92,8 @@ func TestReadAll(t *testing.T) {
 		"read message page for existing channel": {
 			chanID:   chanID,
 			offset:   0,
-			limit:    10,
-			messages: messages[0:10],
+			limit:    1,
+			messages: messages[0:1],
 		},
 		"read message page for too large limit": {
 			chanID:   chanID,
@@ -115,6 +117,6 @@ func TestReadAll(t *testing.T) {
 
 	for desc, tc := range cases {
 		result := reader.ReadAll(tc.chanID, tc.offset, tc.limit)
-		assert.ElementsMatch(t, tc.messages, result, fmt.Sprintf("%s: expected %v got %v", desc, tc.messages, result))
+		assert.ElementsMatch(t, tc.messages, result, fmt.Sprintf("%s: expected: %v \n-------------\n got: %v", desc, tc.messages, result))
 	}
 }

--- a/readers/mongodb/messages_test.go
+++ b/readers/mongodb/messages_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	readers "github.com/mainflux/mainflux/readers/mongodb"
 	writers "github.com/mainflux/mainflux/writers/mongodb"
@@ -48,10 +49,10 @@ func TestReadAll(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
 
 	db := client.Database(testDB)
-
 	writer := writers.New(db)
 
 	messages := []mainflux.Message{}
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields
@@ -69,6 +70,7 @@ func TestReadAll(t *testing.T) {
 		case 5:
 			msg.ValueSum = &mainflux.SumValue{Value: 45}
 		}
+		msg.Time = float64(now + int64(i))
 
 		err := writer.Save(msg)
 		require.Nil(t, err, fmt.Sprintf("failed to store message to Cassandra: %s", err))

--- a/writers/cassandra/messages_test.go
+++ b/writers/cassandra/messages_test.go
@@ -10,6 +10,7 @@ package cassandra_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/writers/cassandra"
@@ -34,6 +35,7 @@ func TestSave(t *testing.T) {
 	session, err := cassandra.Connect([]string{addr}, keyspace)
 	require.Nil(t, err, fmt.Sprintf("failed to connect to Cassandra: %s", err))
 
+	now := time.Now().Unix()
 	repo := cassandra.New(session)
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
@@ -52,6 +54,7 @@ func TestSave(t *testing.T) {
 		case 5:
 			msg.ValueSum = &mainflux.SumValue{Value: 45}
 		}
+		msg.Time = float64(now + int64(i))
 
 		err = repo.Save(msg)
 		assert.Nil(t, err, fmt.Sprintf("expected no error, got %s", err))

--- a/writers/cassandra/messages_test.go
+++ b/writers/cassandra/messages_test.go
@@ -35,8 +35,8 @@ func TestSave(t *testing.T) {
 	session, err := cassandra.Connect([]string{addr}, keyspace)
 	require.Nil(t, err, fmt.Sprintf("failed to connect to Cassandra: %s", err))
 
-	now := time.Now().Unix()
 	repo := cassandra.New(session)
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -123,23 +123,25 @@ func (repo *influxRepo) Save(msg mainflux.Message) error {
 }
 
 func (repo *influxRepo) tagsOf(msg *mainflux.Message) tags {
-	updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
 	channel := strconv.FormatUint(msg.Channel, 10)
 	publisher := strconv.FormatUint(msg.Publisher, 10)
 
 	return tags{
-		"channel":    channel,
-		"publisher":  publisher,
+		"channel":   channel,
+		"publisher": publisher,
+	}
+}
+
+func (repo *influxRepo) fieldsOf(msg *mainflux.Message) fields {
+	updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
+	ret := fields{
 		"protocol":   msg.Protocol,
 		"name":       msg.Name,
 		"unit":       msg.Unit,
 		"link":       msg.Link,
 		"updateTime": updateTime,
 	}
-}
 
-func (repo *influxRepo) fieldsOf(msg *mainflux.Message) fields {
-	ret := fields{}
 	switch msg.Value.(type) {
 	case *mainflux.Message_FloatValue:
 		ret["value"] = msg.GetFloatValue()

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -137,13 +137,13 @@ func (repo *influxRepo) tagsOf(msg *mainflux.Message) tags {
 	publisher := strconv.FormatUint(msg.Publisher, 10)
 
 	return tags{
-		"Channel":    channel,
-		"Publisher":  publisher,
-		"Protocol":   msg.Protocol,
-		"Name":       msg.Name,
-		"Unit":       msg.Unit,
-		"Link":       msg.Link,
-		"UpdateTime": updateTime,
+		"channel":    channel,
+		"publisher":  publisher,
+		"protocol":   msg.Protocol,
+		"name":       msg.Name,
+		"unit":       msg.Unit,
+		"link":       msg.Link,
+		"updateTime": updateTime,
 	}
 }
 
@@ -151,17 +151,17 @@ func (repo *influxRepo) fieldsOf(msg *mainflux.Message) fields {
 	ret := fields{}
 	switch msg.Value.(type) {
 	case *mainflux.Message_FloatValue:
-		ret["Value"] = msg.GetFloatValue()
+		ret["value"] = msg.GetFloatValue()
 	case *mainflux.Message_StringValue:
-		ret["StringValue"] = msg.GetStringValue()
+		ret["stringValue"] = msg.GetStringValue()
 	case *mainflux.Message_DataValue:
-		ret["DataValue"] = msg.GetDataValue()
+		ret["dataValue"] = msg.GetDataValue()
 	case *mainflux.Message_BoolValue:
-		ret["BoolValue"] = msg.GetBoolValue()
+		ret["boolValue"] = msg.GetBoolValue()
 	}
 
 	if msg.ValueSum != nil {
-		ret["ValueSum"] = msg.GetValueSum().GetValue()
+		ret["valueSum"] = msg.GetValueSum().GetValue()
 	}
 
 	return ret

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -9,7 +9,6 @@ package influxdb
 
 import (
 	"errors"
-	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -28,9 +27,6 @@ var (
 	errZeroValueSize    = errors.New("zero value batch size")
 	errZeroValueTimeout = errors.New("zero value batch timeout")
 	errNilBatch         = errors.New("nil batch")
-	// According to SenML specification (https://tools.ietf.org/html/rfc8428#page-10), time greater than or
-	// equal to timeBound is absolute, and values less than timeBound are relative to the current time.
-	timeBound = math.Pow(2, 28)
 )
 
 type influxRepo struct {
@@ -116,12 +112,7 @@ func (repo *influxRepo) savePoint(point *influxdata.Point) error {
 
 func (repo *influxRepo) Save(msg mainflux.Message) error {
 	tags, fields := repo.tagsOf(&msg), repo.fieldsOf(&msg)
-	timestamp := int64(msg.Time)
-	// Time less than timeBound is relative to the current time.
-	if msg.Time < timeBound {
-		timestamp += time.Now().Unix()
-	}
-	t := time.Unix(timestamp, 0)
+	t := time.Unix(int64(msg.Time), 0)
 
 	pt, err := influxdata.NewPoint(pointName, tags, fields, t)
 	if err != nil {

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -47,7 +47,6 @@ var (
 		Unit:       "km",
 		Value:      &mainflux.Message_FloatValue{24},
 		ValueSum:   &mainflux.SumValue{Value: 22},
-		Time:       13451312,
 		UpdateTime: 5456565466,
 		Link:       "link",
 	}
@@ -145,6 +144,7 @@ func TestSave(t *testing.T) {
 		row, err := queryDB(dropMsgs)
 		require.Nil(t, err, fmt.Sprintf("Cleaning data from InfluxDB expected to succeed: %s.\n", err))
 
+		now := time.Now().Unix()
 		for i := 0; i < tc.msgsNum; i++ {
 			// Mix possible values as well as value sum.
 			count := i % valueFields
@@ -162,6 +162,7 @@ func TestSave(t *testing.T) {
 			case 5:
 				msg.ValueSum = &mainflux.SumValue{Value: 45}
 			}
+			msg.Time = float64(now + int64(i))
 
 			err := tc.repo.Save(msg)
 			assert.Nil(t, err, fmt.Sprintf("Save operation expected to succeed: %s.\n", err))

--- a/writers/mongodb/messages_test.go
+++ b/writers/mongodb/messages_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,8 @@ func TestSave(t *testing.T) {
 
 	db := client.Database(testDB)
 	repo := mongodb.New(db)
+
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields
@@ -70,6 +73,7 @@ func TestSave(t *testing.T) {
 		case 5:
 			msg.ValueSum = &mainflux.SumValue{Value: 45}
 		}
+		msg.Time = float64(now + int64(i))
 
 		err = repo.Save(msg)
 	}


### PR DESCRIPTION
Signed-off-by: Dusan Borovcanin <dusan.borovcanin@mainflux.com>

### What does this do?
Use time from received message to set time value in InfluxDB.  

### Which issue(s) does this PR fix/relate to?
This pull request closes #454.

### Notes
This pull request slightly modifies the way messages are saved in InfluxDB. Field "Time" is removed and replaced by default "time" column of InfluxDB. Previously, "time" kept information about timestamp when the message is saved in the database, so that info is no longer persistent in InfluxDB. However, this information can be found in service logs if needed. This also means that the size of tag set of the single point is slightly reduced.