### PR TITLE
NOISSUE - Add .dockerignore to project root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+build
+dashflux
+docker
+docs
+k8s
+load-test
+metrics
+scripts

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,3 +1,0 @@
-docker-compose.yml
-nginx.conf
-ssl/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -58,7 +58,7 @@ cd -
 ###
 # CoAP
 ###
-# TODO: add coap
+MF_COAP_ADAPTER_LOG_LEVEL=info MF_COAP_ADAPTER_PORT=5683 MF_THINGS_URL=localhost:8183 $BUILD_DIR/mainflux-coap &
 
 trap cleanup EXIT
 


### PR DESCRIPTION
### What does this do?
This pull request adds `.dockerignore` to the project root.

### Notes
This PR also removes `package-lock.json` file for project root and updates `scripts/run.sh` with CoAP adapter startup command.