### PR TITLE
MF-473 -  Add metadata field to channel

### DIFF
--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -87,9 +87,10 @@ type Thing struct {
 
 // Channel represents mainflux channel.
 type Channel struct {
-	ID     string  `json:"id,omitempty"`
-	Name   string  `json:"name"`
-	Things []Thing `json:"connected,omitempty"`
+	ID       string  `json:"id,omitempty"`
+	Name     string  `json:"name"`
+	Things   []Thing `json:"connected,omitempty"`
+	Metadata string  `json:"metadata,omitempty"`
 }
 
 // SDK contains Mainflux API.

--- a/things/api/http/endpoint.go
+++ b/things/api/http/endpoint.go
@@ -164,7 +164,7 @@ func createChannelEndpoint(svc things.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		channel := things.Channel{Name: req.Name}
+		channel := things.Channel{Name: req.Name, Metadata: req.Metadata}
 		saved, err := svc.CreateChannel(req.key, channel)
 		if err != nil {
 			return nil, err
@@ -192,8 +192,9 @@ func updateChannelEndpoint(svc things.Service) endpoint.Endpoint {
 		}
 
 		channel := things.Channel{
-			ID:   id,
-			Name: req.Name,
+			ID:       id,
+			Name:     req.Name,
+			Metadata: req.Metadata,
 		}
 		if err := svc.UpdateChannel(req.key, channel); err != nil {
 			return nil, err
@@ -226,9 +227,10 @@ func viewChannelEndpoint(svc things.Service) endpoint.Endpoint {
 		}
 
 		res := viewChannelRes{
-			ID:    strconv.FormatUint(channel.ID, 10),
-			Owner: channel.Owner,
-			Name:  channel.Name,
+			ID:       strconv.FormatUint(channel.ID, 10),
+			Owner:    channel.Owner,
+			Name:     channel.Name,
+			Metadata: channel.Metadata,
 		}
 		for _, thing := range channel.Things {
 			view := viewThingRes{
@@ -263,9 +265,10 @@ func listChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 		// Cast channels
 		for _, channel := range channels {
 			cView := viewChannelRes{
-				ID:    strconv.FormatUint(channel.ID, 10),
-				Owner: channel.Owner,
-				Name:  channel.Name,
+				ID:       strconv.FormatUint(channel.ID, 10),
+				Owner:    channel.Owner,
+				Name:     channel.Name,
+				Metadata: channel.Metadata,
 			}
 
 			// Cast things

--- a/things/api/http/endpoint_test.go
+++ b/things/api/http/endpoint_test.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	thing   = things.Thing{Type: "app", Name: "test_app", Metadata: "test_metadata"}
-	channel = things.Channel{Name: "test"}
+	channel = things.Channel{Name: "test", Metadata: "test_metadata"}
 )
 
 type testRequest struct {
@@ -801,6 +801,7 @@ func TestViewChannel(t *testing.T) {
 				Metadata: sth.Metadata,
 			},
 		},
+		Metadata: sch.Metadata,
 	}
 	data := toJSON(chres)
 
@@ -877,8 +878,9 @@ func TestListChannels(t *testing.T) {
 		svc.Connect(token, sch.ID, sth.ID)
 
 		chres := channelRes{
-			ID:   strconv.FormatUint(sch.ID, 10),
-			Name: sch.Name,
+			ID:       strconv.FormatUint(sch.ID, 10),
+			Name:     sch.Name,
+			Metadata: sch.Metadata,
 			Things: []thingRes{
 				{
 					ID:       strconv.FormatUint(sth.ID, 10),
@@ -1297,7 +1299,8 @@ type thingRes struct {
 }
 
 type channelRes struct {
-	ID     string     `json:"id"`
-	Name   string     `json:"name,omitempty"`
-	Things []thingRes `json:"connected,omitempty"`
+	ID       string     `json:"id"`
+	Name     string     `json:"name,omitempty"`
+	Things   []thingRes `json:"connected,omitempty"`
+	Metadata string     `json:"metadata,omitempty"`
 }

--- a/things/api/http/requests.go
+++ b/things/api/http/requests.go
@@ -67,8 +67,9 @@ func (req updateThingReq) validate() error {
 }
 
 type createChannelReq struct {
-	key  string
-	Name string `json:"name,omitempty"`
+	key      string
+	Name     string `json:"name,omitempty"`
+	Metadata string `json:"metadata,omitempty"`
 }
 
 func (req createChannelReq) validate() error {
@@ -80,9 +81,10 @@ func (req createChannelReq) validate() error {
 }
 
 type updateChannelReq struct {
-	key  string
-	id   string
-	Name string `json:"name,omitempty"`
+	key      string
+	id       string
+	Name     string `json:"name,omitempty"`
+	Metadata string `json:"metadata,omitempty"`
 }
 
 func (req updateChannelReq) validate() error {

--- a/things/api/http/responses.go
+++ b/things/api/http/responses.go
@@ -151,10 +151,11 @@ func (res channelRes) Empty() bool {
 }
 
 type viewChannelRes struct {
-	ID     string         `json:"id"`
-	Owner  string         `json:"-"`
-	Name   string         `json:"name,omitempty"`
-	Things []viewThingRes `json:"connected,omitempty"`
+	ID       string         `json:"id"`
+	Owner    string         `json:"-"`
+	Name     string         `json:"name,omitempty"`
+	Things   []viewThingRes `json:"connected,omitempty"`
+	Metadata string         `json:"metadata,omitempty"`
 }
 
 func (res viewChannelRes) Code() int {

--- a/things/channels.go
+++ b/things/channels.go
@@ -10,10 +10,11 @@ package things
 // Channel represents a Mainflux "communication group". This group contains the
 // things that can exchange messages between eachother.
 type Channel struct {
-	ID     uint64
-	Owner  string
-	Name   string
-	Things []Thing
+	ID       uint64
+	Owner    string
+	Name     string
+	Things   []Thing
+	Metadata string
 }
 
 // ChannelRepository specifies a channel persistence API.

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -40,25 +40,26 @@ func migrateDB(db *sql.DB) error {
 				Id: "things_1",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS things (
-						id      BIGSERIAL,
-						owner   VARCHAR(254),
-						type    VARCHAR(10) NOT NULL,
-						key     CHAR(36) UNIQUE NOT NULL,
-						name    TEXT,
-						metadata TEXT,
+						id       BIGSERIAL,
+						owner    VARCHAR(254),
+						type     VARCHAR(10) NOT NULL,
+						key      CHAR(36) UNIQUE NOT NULL,
+						name     TEXT,
+						metadata JSON,
 						PRIMARY KEY (id, owner)
 					)`,
 					`CREATE TABLE IF NOT EXISTS channels (
-						id    BIGSERIAL,
-						owner VARCHAR(254),
-						name  TEXT,
+						id       BIGSERIAL,
+						owner    VARCHAR(254),
+						name     TEXT,
+						metadata JSON,
 						PRIMARY KEY (id, owner)
 					)`,
 					`CREATE TABLE IF NOT EXISTS connections (
 						channel_id    BIGINT,
 						channel_owner VARCHAR(254),
-						thing_id     BIGINT,
-						thing_owner  VARCHAR(254),
+						thing_id      BIGINT,
+						thing_owner   VARCHAR(254),
 						FOREIGN KEY (channel_id, channel_owner) REFERENCES channels (id, owner) ON DELETE CASCADE ON UPDATE CASCADE,
 						FOREIGN KEY (thing_id, thing_owner) REFERENCES things (id, owner) ON DELETE CASCADE ON UPDATE CASCADE,
 						PRIMARY KEY (channel_id, channel_owner, thing_id, thing_owner)

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -28,8 +28,27 @@ func TestThingSave(t *testing.T) {
 		Key:   uuid.New().ID(),
 	}
 
-	_, err := thingRepo.Save(thing)
-	assert.Nil(t, err, fmt.Sprintf("create new thing: expected no error got %s\n", err))
+	cases := []struct {
+		desc  string
+		thing things.Thing
+		err   error
+	}{
+		{
+			desc:  "create new thing",
+			thing: thing,
+			err:   nil,
+		},
+		{
+			desc:  "create invalid thing",
+			thing: things.Thing{Owner: email, Key: uuid.New().ID(), Metadata: "invalid"},
+			err:   things.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := thingRepo.Save(tc.thing)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
 }
 
 func TestThingUpdate(t *testing.T) {

--- a/things/redis/events.go
+++ b/things/redis/events.go
@@ -93,9 +93,10 @@ func (rte removeThingEvent) Encode() map[string]interface{} {
 }
 
 type createChannelEvent struct {
-	id    string
-	owner string
-	name  string
+	id       string
+	owner    string
+	name     string
+	metadata string
 }
 
 func (cce createChannelEvent) Encode() map[string]interface{} {
@@ -109,20 +110,34 @@ func (cce createChannelEvent) Encode() map[string]interface{} {
 		val["name"] = cce.name
 	}
 
+	if cce.metadata != "" {
+		val["metadata"] = cce.metadata
+	}
+
 	return val
 }
 
 type updateChannelEvent struct {
-	id   string
-	name string
+	id       string
+	name     string
+	metadata string
 }
 
 func (uce updateChannelEvent) Encode() map[string]interface{} {
-	return map[string]interface{}{
+	val := map[string]interface{}{
 		"id":        uce.id,
-		"name":      uce.name,
 		"operation": channelUpdate,
 	}
+
+	if uce.name != "" {
+		val["name"] = uce.name
+	}
+
+	if uce.metadata != "" {
+		val["metadata"] = uce.metadata
+	}
+
+	return val
 }
 
 type removeChannelEvent struct {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -112,9 +112,10 @@ func (es eventStore) CreateChannel(key string, channel things.Channel) (things.C
 	}
 
 	event := createChannelEvent{
-		id:    strconv.FormatUint(sch.ID, 10),
-		owner: sch.Owner,
-		name:  sch.Name,
+		id:       strconv.FormatUint(sch.ID, 10),
+		owner:    sch.Owner,
+		name:     sch.Name,
+		metadata: sch.Metadata,
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
@@ -132,8 +133,9 @@ func (es eventStore) UpdateChannel(key string, channel things.Channel) error {
 	}
 
 	event := updateChannelEvent{
-		id:   strconv.FormatUint(channel.ID, 10),
-		name: channel.Name,
+		id:       strconv.FormatUint(channel.ID, 10),
+		name:     channel.Name,
+		metadata: channel.Metadata,
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -238,19 +238,20 @@ func TestCreateChannel(t *testing.T) {
 	}{
 		{
 			desc:    "create channel successfully",
-			channel: things.Channel{Name: "a"},
+			channel: things.Channel{Name: "a", Metadata: "metadata"},
 			key:     token,
 			err:     nil,
 			event: map[string]interface{}{
 				"id":        "1",
 				"name":      "a",
+				"metadata":  "metadata",
 				"owner":     email,
 				"operation": channelCreate,
 			},
 		},
 		{
 			desc:    "create channel with invalid credentials",
-			channel: things.Channel{Name: "a"},
+			channel: things.Channel{Name: "a", Metadata: "metadata"},
 			key:     "",
 			err:     things.ErrUnauthorizedAccess,
 			event:   nil,
@@ -297,12 +298,13 @@ func TestUpdateChannel(t *testing.T) {
 	}{
 		{
 			desc:    "update channel successfully",
-			channel: things.Channel{ID: sch.ID, Name: "b"},
+			channel: things.Channel{ID: sch.ID, Name: "b", Metadata: "metadata"},
 			key:     token,
 			err:     nil,
 			event: map[string]interface{}{
 				"id":        strconv.FormatUint(sch.ID, 10),
 				"name":      "b",
+				"metadata":  "metadata",
 				"operation": channelUpdate,
 			},
 		},


### PR DESCRIPTION
### What does this do?
Adds metadata field to channels and switches metadata format to JSON.

### Which issue(s) does this PR fix/relate to?
Resolves #473.

### List any changes that modify/break current functionality
Only valid JSON can be passed as metadata value now.

### Have you included tests for your changes?
I updated existing tests.

### Did you document any new/modified functionality?
No.

