### PR TITLE
MF-448 - Add option to connect to DB with verify-ca and verify-full

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -37,60 +37,69 @@ import (
 )
 
 const (
-	defLogLevel   = "error"
-	defDBHost     = "localhost"
-	defDBPort     = "5432"
-	defDBUser     = "mainflux"
-	defDBPass     = "mainflux"
-	defDBName     = "things"
-	defDBSSLMode  = "disable"
-	defClientTLS  = "false"
-	defCACerts    = ""
-	defCacheURL   = "localhost:6379"
-	defCachePass  = ""
-	defCacheDB    = "0"
-	defHTTPPort   = "8180"
-	defGRPCPort   = "8181"
-	defServerCert = ""
-	defServerKey  = ""
-	defUsersURL   = "localhost:8181"
-	envLogLevel   = "MF_THINGS_LOG_LEVEL"
-	envDBHost     = "MF_THINGS_DB_HOST"
-	envDBPort     = "MF_THINGS_DB_PORT"
-	envDBUser     = "MF_THINGS_DB_USER"
-	envDBPass     = "MF_THINGS_DB_PASS"
-	envDBName     = "MF_THINGS_DB"
-	envDBSSLMode  = "MF_THINGS_DB_SSL_MODE"
-	envClientTLS  = "MF_THINGS_CLIENT_TLS"
-	envCACerts    = "MF_THINGS_CA_CERTS"
-	envCacheURL   = "MF_THINGS_CACHE_URL"
-	envCachePass  = "MF_THINGS_CACHE_PASS"
-	envCacheDB    = "MF_THINGS_CACHE_DB"
-	envHTTPPort   = "MF_THINGS_HTTP_PORT"
-	envGRPCPort   = "MF_THINGS_GRPC_PORT"
-	envUsersURL   = "MF_USERS_URL"
-	envServerCert = "MF_THINGS_SERVER_CERT"
-	envServerKey  = "MF_THINGS_SERVER_KEY"
+	defLogLevel      = "error"
+	defDBHost        = "localhost"
+	defDBPort        = "5432"
+	defDBUser        = "mainflux"
+	defDBPass        = "mainflux"
+	defDBName        = "things"
+	defDBSSLMode     = "disable"
+	defDBSSLCert     = ""
+	defDBSSLKey      = ""
+	defDBSSLRootCert = ""
+	defClientTLS     = "false"
+	defCACerts       = ""
+	defCacheURL      = "localhost:6379"
+	defCachePass     = ""
+	defCacheDB       = "0"
+	defHTTPPort      = "8180"
+	defGRPCPort      = "8181"
+	defServerCert    = ""
+	defServerKey     = ""
+	defUsersURL      = "localhost:8181"
+	envLogLevel      = "MF_THINGS_LOG_LEVEL"
+	envDBHost        = "MF_THINGS_DB_HOST"
+	envDBPort        = "MF_THINGS_DB_PORT"
+	envDBUser        = "MF_THINGS_DB_USER"
+	envDBPass        = "MF_THINGS_DB_PASS"
+	envDBName        = "MF_THINGS_DB"
+	envDBSSLMode     = "MF_THINGS_DB_SSL_MODE"
+	envDBSSLCert     = "MF_THINGS_DB_SSL_CERT"
+	envDBSSLKey      = "MF_THINGS_DB_SSL_KEY"
+	envDBSSLRootCert = "MF_THINGS_DB_SSL_ROOT_CERT"
+	envClientTLS     = "MF_THINGS_CLIENT_TLS"
+	envCACerts       = "MF_THINGS_CA_CERTS"
+	envCacheURL      = "MF_THINGS_CACHE_URL"
+	envCachePass     = "MF_THINGS_CACHE_PASS"
+	envCacheDB       = "MF_THINGS_CACHE_DB"
+	envHTTPPort      = "MF_THINGS_HTTP_PORT"
+	envGRPCPort      = "MF_THINGS_GRPC_PORT"
+	envUsersURL      = "MF_USERS_URL"
+	envServerCert    = "MF_THINGS_SERVER_CERT"
+	envServerKey     = "MF_THINGS_SERVER_KEY"
 )
 
 type config struct {
-	logLevel   string
-	dbHost     string
-	dbPort     string
-	dbUser     string
-	dbPass     string
-	dbName     string
-	dbSSLMode  string
-	clientTLS  bool
-	caCerts    string
-	cacheURL   string
-	cachePass  string
-	cacheDB    string
-	httpPort   string
-	grpcPort   string
-	usersURL   string
-	serverCert string
-	serverKey  string
+	logLevel      string
+	dbHost        string
+	dbPort        string
+	dbUser        string
+	dbPass        string
+	dbName        string
+	dbSSLMode     string
+	dbSSLCert     string
+	dbSSLKey      string
+	dbSSLRootCert string
+	clientTLS     bool
+	caCerts       string
+	cacheURL      string
+	cachePass     string
+	cacheDB       string
+	httpPort      string
+	grpcPort      string
+	usersURL      string
+	serverCert    string
+	serverKey     string
 }
 
 func main() {
@@ -131,23 +140,26 @@ func loadConfig() config {
 	}
 
 	return config{
-		logLevel:   mainflux.Env(envLogLevel, defLogLevel),
-		dbHost:     mainflux.Env(envDBHost, defDBHost),
-		dbPort:     mainflux.Env(envDBPort, defDBPort),
-		dbUser:     mainflux.Env(envDBUser, defDBUser),
-		dbPass:     mainflux.Env(envDBPass, defDBPass),
-		dbName:     mainflux.Env(envDBName, defDBName),
-		dbSSLMode:  mainflux.Env(envDBSSLMode, defDBSSLMode),
-		clientTLS:  tls,
-		caCerts:    mainflux.Env(envCACerts, defCACerts),
-		cacheURL:   mainflux.Env(envCacheURL, defCacheURL),
-		cachePass:  mainflux.Env(envCachePass, defCachePass),
-		cacheDB:    mainflux.Env(envCacheDB, defCacheDB),
-		httpPort:   mainflux.Env(envHTTPPort, defHTTPPort),
-		grpcPort:   mainflux.Env(envGRPCPort, defGRPCPort),
-		usersURL:   mainflux.Env(envUsersURL, defUsersURL),
-		serverCert: mainflux.Env(envServerCert, defServerCert),
-		serverKey:  mainflux.Env(envServerKey, defServerKey),
+		logLevel:      mainflux.Env(envLogLevel, defLogLevel),
+		dbHost:        mainflux.Env(envDBHost, defDBHost),
+		dbPort:        mainflux.Env(envDBPort, defDBPort),
+		dbUser:        mainflux.Env(envDBUser, defDBUser),
+		dbPass:        mainflux.Env(envDBPass, defDBPass),
+		dbName:        mainflux.Env(envDBName, defDBName),
+		dbSSLMode:     mainflux.Env(envDBSSLMode, defDBSSLMode),
+		dbSSLCert:     mainflux.Env(envDBSSLCert, defDBSSLCert),
+		dbSSLKey:      mainflux.Env(envDBSSLKey, defDBSSLKey),
+		dbSSLRootCert: mainflux.Env(envDBSSLRootCert, defDBSSLRootCert),
+		clientTLS:     tls,
+		caCerts:       mainflux.Env(envCACerts, defCACerts),
+		cacheURL:      mainflux.Env(envCacheURL, defCacheURL),
+		cachePass:     mainflux.Env(envCachePass, defCachePass),
+		cacheDB:       mainflux.Env(envCacheDB, defCacheDB),
+		httpPort:      mainflux.Env(envHTTPPort, defHTTPPort),
+		grpcPort:      mainflux.Env(envGRPCPort, defGRPCPort),
+		usersURL:      mainflux.Env(envUsersURL, defUsersURL),
+		serverCert:    mainflux.Env(envServerCert, defServerCert),
+		serverKey:     mainflux.Env(envServerKey, defServerKey),
 	}
 }
 
@@ -167,7 +179,7 @@ func connectToCache(cacheURL, cachePass string, cacheDB string, logger logger.Lo
 }
 
 func connectToDB(cfg config, logger logger.Logger) *sql.DB {
-	db, err := postgres.Connect(cfg.dbHost, cfg.dbPort, cfg.dbName, cfg.dbUser, cfg.dbPass, cfg.dbSSLMode)
+	db, err := postgres.Connect(cfg.dbHost, cfg.dbPort, cfg.dbName, cfg.dbUser, cfg.dbPass, cfg.dbSSLMode, cfg.dbSSLCert, cfg.dbSSLKey, cfg.dbSSLRootCert)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to connect to postgres: %s", err))
 		os.Exit(1)

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -34,45 +34,54 @@ import (
 )
 
 const (
-	defLogLevel   = "error"
-	defDBHost     = "localhost"
-	defDBPort     = "5432"
-	defDBUser     = "mainflux"
-	defDBPass     = "mainflux"
-	defDBName     = "users"
-	defDBSSLMode  = "disable"
-	defHTTPPort   = "8180"
-	defGRPCPort   = "8181"
-	defSecret     = "users"
-	defServerCert = ""
-	defServerKey  = ""
-	envLogLevel   = "MF_USERS_LOG_LEVEL"
-	envDBHost     = "MF_USERS_DB_HOST"
-	envDBPort     = "MF_USERS_DB_PORT"
-	envDBUser     = "MF_USERS_DB_USER"
-	envDBPass     = "MF_USERS_DB_PASS"
-	envDBName     = "MF_USERS_DB"
-	envDBSSLMode  = "MF_USERS_DB_SSL_MODE"
-	envHTTPPort   = "MF_USERS_HTTP_PORT"
-	envGRPCPort   = "MF_USERS_GRPC_PORT"
-	envSecret     = "MF_USERS_SECRET"
-	envServerCert = "MF_USERS_SERVER_CERT"
-	envServerKey  = "MF_USERS_SERVER_KEY"
+	defLogLevel      = "error"
+	defDBHost        = "localhost"
+	defDBPort        = "5432"
+	defDBUser        = "mainflux"
+	defDBPass        = "mainflux"
+	defDBName        = "users"
+	defDBSSLMode     = "disable"
+	defDBSSLCert     = ""
+	defDBSSLKey      = ""
+	defDBSSLRootCert = ""
+	defHTTPPort      = "8180"
+	defGRPCPort      = "8181"
+	defSecret        = "users"
+	defServerCert    = ""
+	defServerKey     = ""
+	envLogLevel      = "MF_USERS_LOG_LEVEL"
+	envDBHost        = "MF_USERS_DB_HOST"
+	envDBPort        = "MF_USERS_DB_PORT"
+	envDBUser        = "MF_USERS_DB_USER"
+	envDBPass        = "MF_USERS_DB_PASS"
+	envDBName        = "MF_USERS_DB"
+	envDBSSLMode     = "MF_USERS_DB_SSL_MODE"
+	envDBSSLCert     = "MF_USERS_DB_SSL_CERT"
+	envDBSSLKey      = "MF_USERS_DB_SSL_KEY"
+	envDBSSLRootCert = "MF_USERS_DB_SSL_ROOT_CERT"
+	envHTTPPort      = "MF_USERS_HTTP_PORT"
+	envGRPCPort      = "MF_USERS_GRPC_PORT"
+	envSecret        = "MF_USERS_SECRET"
+	envServerCert    = "MF_USERS_SERVER_CERT"
+	envServerKey     = "MF_USERS_SERVER_KEY"
 )
 
 type config struct {
-	LogLevel   string
-	DBHost     string
-	DBPort     string
-	DBUser     string
-	DBPass     string
-	DBName     string
-	DBSSLMode  string
-	HTTPPort   string
-	GRPCPort   string
-	Secret     string
-	ServerCert string
-	ServerKey  string
+	LogLevel      string
+	DBHost        string
+	DBPort        string
+	DBUser        string
+	DBPass        string
+	DBName        string
+	DBSSLMode     string
+	DBSSLCert     string
+	DBSSLKey      string
+	DBSSLRootCert string
+	HTTPPort      string
+	GRPCPort      string
+	Secret        string
+	ServerCert    string
+	ServerKey     string
 }
 
 func main() {
@@ -103,23 +112,26 @@ func main() {
 
 func loadConfig() config {
 	return config{
-		LogLevel:   mainflux.Env(envLogLevel, defLogLevel),
-		DBHost:     mainflux.Env(envDBHost, defDBHost),
-		DBPort:     mainflux.Env(envDBPort, defDBPort),
-		DBUser:     mainflux.Env(envDBUser, defDBUser),
-		DBPass:     mainflux.Env(envDBPass, defDBPass),
-		DBName:     mainflux.Env(envDBName, defDBName),
-		DBSSLMode:  mainflux.Env(envDBSSLMode, defDBSSLMode),
-		HTTPPort:   mainflux.Env(envHTTPPort, defHTTPPort),
-		GRPCPort:   mainflux.Env(envGRPCPort, defGRPCPort),
-		Secret:     mainflux.Env(envSecret, defSecret),
-		ServerCert: mainflux.Env(envServerCert, defServerCert),
-		ServerKey:  mainflux.Env(envServerKey, defServerKey),
+		LogLevel:      mainflux.Env(envLogLevel, defLogLevel),
+		DBHost:        mainflux.Env(envDBHost, defDBHost),
+		DBPort:        mainflux.Env(envDBPort, defDBPort),
+		DBUser:        mainflux.Env(envDBUser, defDBUser),
+		DBPass:        mainflux.Env(envDBPass, defDBPass),
+		DBName:        mainflux.Env(envDBName, defDBName),
+		DBSSLMode:     mainflux.Env(envDBSSLMode, defDBSSLMode),
+		DBSSLCert:     mainflux.Env(envDBSSLCert, defDBSSLCert),
+		DBSSLKey:      mainflux.Env(envDBSSLKey, defDBSSLKey),
+		DBSSLRootCert: mainflux.Env(envDBSSLRootCert, defDBSSLRootCert),
+		HTTPPort:      mainflux.Env(envHTTPPort, defHTTPPort),
+		GRPCPort:      mainflux.Env(envGRPCPort, defGRPCPort),
+		Secret:        mainflux.Env(envSecret, defSecret),
+		ServerCert:    mainflux.Env(envServerCert, defServerCert),
+		ServerKey:     mainflux.Env(envServerKey, defServerKey),
 	}
 }
 
 func connectToDB(cfg config, logger logger.Logger) *sql.DB {
-	db, err := postgres.Connect(cfg.DBHost, cfg.DBPort, cfg.DBName, cfg.DBUser, cfg.DBPass, cfg.DBSSLMode)
+	db, err := postgres.Connect(cfg.DBHost, cfg.DBPort, cfg.DBName, cfg.DBUser, cfg.DBPass, cfg.DBSSLMode, cfg.DBSSLCert, cfg.DBSSLKey, cfg.DBSSLRootCert)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to connect to postgres: %s", err))
 		os.Exit(1)

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -67,30 +67,30 @@ const (
 )
 
 type config struct {
-	LogLevel   string
+	logLevel   string
 	dbConfig   postgres.Config
-	HTTPPort   string
-	GRPCPort   string
-	Secret     string
-	ServerCert string
-	ServerKey  string
+	httpPort   string
+	grpcPort   string
+	secret     string
+	serverCert string
+	serverKey  string
 }
 
 func main() {
 	cfg := loadConfig()
 
-	logger, err := logger.New(os.Stdout, cfg.LogLevel)
+	logger, err := logger.New(os.Stdout, cfg.logLevel)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
 	db := connectToDB(cfg.dbConfig, logger)
 	defer db.Close()
 
-	svc := newService(db, cfg.Secret, logger)
+	svc := newService(db, cfg.secret, logger)
 	errs := make(chan error, 2)
 
-	go startHTTPServer(svc, cfg.HTTPPort, cfg.ServerCert, cfg.ServerKey, logger, errs)
-	go startGRPCServer(svc, cfg.GRPCPort, cfg.ServerCert, cfg.ServerKey, logger, errs)
+	go startHTTPServer(svc, cfg.httpPort, cfg.serverCert, cfg.serverKey, logger, errs)
+	go startGRPCServer(svc, cfg.grpcPort, cfg.serverCert, cfg.serverKey, logger, errs)
 
 	go func() {
 		c := make(chan os.Signal)
@@ -117,13 +117,13 @@ func loadConfig() config {
 	}
 
 	return config{
-		LogLevel:   mainflux.Env(envLogLevel, defLogLevel),
+		logLevel:   mainflux.Env(envLogLevel, defLogLevel),
 		dbConfig:   dbConfig,
-		HTTPPort:   mainflux.Env(envHTTPPort, defHTTPPort),
-		GRPCPort:   mainflux.Env(envGRPCPort, defGRPCPort),
-		Secret:     mainflux.Env(envSecret, defSecret),
-		ServerCert: mainflux.Env(envServerCert, defServerCert),
-		ServerKey:  mainflux.Env(envServerKey, defServerKey),
+		httpPort:   mainflux.Env(envHTTPPort, defHTTPPort),
+		grpcPort:   mainflux.Env(envGRPCPort, defGRPCPort),
+		secret:     mainflux.Env(envSecret, defSecret),
+		serverCert: mainflux.Env(envServerCert, defServerCert),
+		serverKey:  mainflux.Env(envServerKey, defServerKey),
 	}
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -486,13 +486,19 @@ By default gRPC communication is not secure.
 ### Securing PostgreSQL connections
 
 By default, Mainflux will connect to Postgres using insecure transport.
-If a secured connection is required, you can select the SSL mode.
+If a secured connection is required, you can select the SSL mode and set paths to any extra certificates and keys needed. 
 
 `MF_USERS_DB_SSL_MODE` the SSL connection mode for Users.
+`MF_USERS_DB_SSL_CERT` the path to the certificate file for Users.
+`MF_USERS_DB_SSL_KEY` the path to the key file for Users.
+`MF_USERS_DB_SSL_ROOT_CERT` the path to the root certificate file for Users.
 
 `MF_THINGS_DB_SSL_MODE` the SSL connection mode for Things.
+`MF_THINGS_DB_SSL_CERT` the path to the certificate file for Things.
+`MF_THINGS_DB_SSL_KEY` the path to the key file for Things.
+`MF_THINGS_DB_SSL_ROOT_CERT` the path to the root certificate file for Things.
 
-Currently supported modes are: `disabled` and `required`
+Supported database connection modes are: `disabled` (default), `required`, `verify-ca` and `verify-full`
 
 #### Users
 

--- a/things/README.md
+++ b/things/README.md
@@ -17,25 +17,28 @@ The service is configured using the environment variables presented in the
 following table. Note that any unset variables will be replaced with their
 default values.
 
-| Variable              | Description                                      | Default        |
-|-----------------------|--------------------------------------------------|----------------|
-| MF_THINGS_LOG_LEVEL   | Log level for Things (debug, info, warn, error)  | error          |
-| MF_THINGS_DB_HOST     | Database host address                            | localhost      |
-| MF_THINGS_DB_PORT     | Database host port                               | 5432           |
-| MF_THINGS_DB_USER     | Database user                                    | mainflux       |
-| MF_THINGS_DB_PASS     | Database password                                | mainflux       |
-| MF_THINGS_DB          | Name of the database used by the service         | things         |
-| MF_THINGS_DB_SSL_MODE | Database connection SSL mode (disable or require)| disable        |
-| MF_THINGS_CLIENT_TLS  | Flag that indicates if TLS should be turned on   | false          |
-| MF_THINGS_CA_CERTS    | Path to trusted CAs in PEM format                |                |
-| MF_THINGS_CACHE_URL   | Cache database URL                               | localhost:6379 |
-| MF_THINGS_CACHE_PASS  | Cache database password                          |                |
-| MF_THINGS_CACHE_DB    | Cache instance that should be used               | 0              |
-| MF_THINGS_HTTP_PORT   | Things service HTTP port                         | 8180           |
-| MF_THINGS_GRPC_PORT   | Things service gRPC port                         | 8181           |
-| MF_THINGS_SERVER_CERT | Path to server certificate in pem format         | 8181           |
-| MF_THINGS_SERVER_KEY  | Path to server key in pem format                 | 8181           |
-| MF_USERS_URL          | Users service URL                                | localhost:8181 |
+| Variable                   | Description                                                            | Default        |
+|----------------------------|------------------------------------------------------------------------|----------------|
+| MF_THINGS_LOG_LEVEL        | Log level for Things (debug, info, warn, error)                        | error          |
+| MF_THINGS_DB_HOST          | Database host address                                                  | localhost      |
+| MF_THINGS_DB_PORT          | Database host port                                                     | 5432           |
+| MF_THINGS_DB_USER          | Database user                                                          | mainflux       |
+| MF_THINGS_DB_PASS          | Database password                                                      | mainflux       |
+| MF_THINGS_DB               | Name of the database used by the service                               | things         |
+| MF_THINGS_DB_SSL_MODE      | Database connection SSL mode (disable, require, verify-ca, verify-full)| disable        |
+| MF_THINGS_DB_SSL_CERT      | Path to the PEM encoded certificate file                               |                |
+| MF_THINGS_DB_SSL_KEY       | Path to the PEM encoded key file                                       |                |
+| MF_THINGS_DB_SSL_ROOT_CERT | Path to the PEM encoded root certificate file                          |                |
+| MF_THINGS_CLIENT_TLS       | Flag that indicates if TLS should be turned on                         | false          |
+| MF_THINGS_CA_CERTS         | Path to trusted CAs in PEM format                                      |                |
+| MF_THINGS_CACHE_URL        | Cache database URL                                                     | localhost:6379 |
+| MF_THINGS_CACHE_PASS       | Cache database password                                                |                |
+| MF_THINGS_CACHE_DB         | Cache instance that should be used                                     | 0              |
+| MF_THINGS_HTTP_PORT        | Things service HTTP port                                               | 8180           |
+| MF_THINGS_GRPC_PORT        | Things service gRPC port                                               | 8181           |
+| MF_THINGS_SERVER_CERT      | Path to server certificate in pem format                               | 8181           |
+| MF_THINGS_SERVER_KEY       | Path to server key in pem format                                       | 8181           |
+| MF_USERS_URL               | Users service URL                                                      | localhost:8181 |
 
 ## Deployment
 
@@ -59,6 +62,9 @@ services:
       MF_THINGS_DB_PASS: [Database password]
       MF_THINGS_DB: [Name of the database used by the service]
       MF_THINGS_DB_SSL_MODE: [SSL mode to connect to the database with]
+      MF_THINGS_DB_SSL_CERT: [Path to the PEM encoded certificate file]
+      MF_THINGS_DB_SSL_KEY: [Path to the PEM encoded key file]
+      MF_THINGS_DB_SSL_ROOT_CERT: [Path to the PEM encoded root certificate file]
       MF_THINGS_CA_CERTS: [Path to trusted CAs in PEM format]
       MF_THINGS_CACHE_URL: [Cache database URL]
       MF_THINGS_CACHE_PASS: [Cache database password]
@@ -86,7 +92,7 @@ make things
 make install
 
 # set the environment variables and run the service
-MF_THINGS_LOG_LEVEL=[Things log level] MF_THINGS_DB_HOST=[Database host address] MF_THINGS_DB_PORT=[Database host port] MF_THINGS_DB_USER=[Database user] MF_THINGS_DB_PASS=[Database password] MF_THINGS_DB=[Name of the database used by the service] MF_THINGS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_HTTP_ADAPTER_CA_CERTS=[Path to trusted CAs in PEM format] MF_THINGS_CACHE_URL=[Cache database URL] MF_THINGS_CACHE_PASS=[Cache database password] MF_THINGS_CACHE_DB=[Cache instance that should be used] MF_THINGS_HTTP_PORT=[Service HTTP port] MF_THINGS_GRPC_PORT=[Service gRPC port] MF_USERS_URL=[Users service URL] MF_THINGS_SERVER_CERT=[Path to server certificate] MF_THINGS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-things
+MF_THINGS_LOG_LEVEL=[Things log level] MF_THINGS_DB_HOST=[Database host address] MF_THINGS_DB_PORT=[Database host port] MF_THINGS_DB_USER=[Database user] MF_THINGS_DB_PASS=[Database password] MF_THINGS_DB=[Name of the database used by the service] MF_THINGS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_THINGS_DB_SSL_CERT=[Path to the PEM encoded certificate file] MF_THINGS_DB_SSL_KEY=[Path to the PEM encoded key file] MF_THINGS_DB_SSL_ROOT_CERT=[Path to the PEM encoded root certificate file] MF_HTTP_ADAPTER_CA_CERTS=[Path to trusted CAs in PEM format] MF_THINGS_CACHE_URL=[Cache database URL] MF_THINGS_CACHE_PASS=[Cache database password] MF_THINGS_CACHE_DB=[Cache instance that should be used] MF_THINGS_HTTP_PORT=[Service HTTP port] MF_THINGS_GRPC_PORT=[Service gRPC port] MF_USERS_URL=[Users service URL] MF_THINGS_SERVER_CERT=[Path to server certificate] MF_THINGS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-things
 ```
 
 Setting `MF_THINGS_CA_CERTS` expects a file in PEM format of trusted CAs. This will enable TLS against the Users gRPC endpoint trusting only those CAs that are provided.

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -15,6 +15,7 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 )
 
+// Config defines the options that are used when connecting to a PostgreSQL instance
 type Config struct {
 	Host        string
 	Port        string

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -15,11 +15,23 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 )
 
+type Config struct {
+	Host        string
+	Port        string
+	User        string
+	Pass        string
+	Name        string
+	SSLMode     string
+	SSLCert     string
+	SSLKey      string
+	SSLRootCert string
+}
+
 // Connect creates a connection to the PostgreSQL instance and applies any
 // unapplied database migrations. A non-nil error is returned to indicate
 // failure.
-func Connect(host, port, name, user, pass, sslMode, sslCert, sslKey, sslRootCert string) (*sql.DB, error) {
-	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", host, port, user, name, pass, sslMode, sslCert, sslKey, sslRootCert)
+func Connect(cfg Config) (*sql.DB, error) {
+	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", cfg.Host, cfg.Port, cfg.User, cfg.Name, cfg.Pass, cfg.SSLMode, cfg.SSLCert, cfg.SSLKey, cfg.SSLRootCert)
 
 	db, err := sql.Open("postgres", url)
 	if err != nil {

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -18,8 +18,8 @@ import (
 // Connect creates a connection to the PostgreSQL instance and applies any
 // unapplied database migrations. A non-nil error is returned to indicate
 // failure.
-func Connect(host, port, name, user, pass, sslMode string) (*sql.DB, error) {
-	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s", host, port, user, name, pass, sslMode)
+func Connect(host, port, name, user, pass, sslMode, sslCert, sslKey, sslRootCert string) (*sql.DB, error) {
+	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", host, port, user, name, pass, sslMode, sslCert, sslKey, sslRootCert)
 
 	db, err := sql.Open("postgres", url)
 	if err != nil {

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -60,7 +60,19 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable", "", "", ""); err != nil {
+	dbConfig := postgres.Config{
+		Host:        "localhost",
+		Port:        port,
+		User:        "test",
+		Pass:        "test",
+		Name:        "test",
+		SSLMode:     "disable",
+		SSLCert:     "",
+		SSLKey:      "",
+		SSLRootCert: "",
+	}
+
+	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
 	defer db.Close()

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable"); err != nil {
+	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable", "", "", ""); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
 	defer db.Close()

--- a/users/README.md
+++ b/users/README.md
@@ -16,20 +16,23 @@ The service is configured using the environment variables presented in the
 following table. Note that any unset variables will be replaced with their
 default values.
 
-| Variable             | Description                                      | Default      |
-|----------------------|--------------------------------------------------|--------------|
-| MF_USERS_LOG_LEVEL   | Log level for Users (debug, info, warn, error)   | error        |
-| MF_USERS_DB_HOST     | Database host address                            | localhost    |
-| MF_USERS_DB_PORT     | Database host port                               | 5432         |
-| MF_USERS_DB_USER     | Database user                                    | mainflux     |
-| MF_USERS_DB_PASSWORD | Database password                                | mainflux     |
-| MF_USERS_DB          | Name of the database used by the service         | users        |
-| MF_USERS_DB_SSL_MODE | Database connection SSL mode (disable or require)| disable      |
-| MF_USERS_HTTP_PORT   | Users service HTTP port                          | 8180         |
-| MF_USERS_GRPC_PORT   | Users service gRPC port                          | 8181         |
-| MF_USERS_SERVER_CERT | Path to server certificate in pem format         |              |
-| MF_USERS_SERVER_KEY  | Path to server key in pem format                 |              |
-| MF_USERS_SECRET      | String used for signing tokens                   | users        |
+| Variable                  | Description                                                             | Default      |
+|---------------------------|-------------------------------------------------------------------------|--------------|
+| MF_USERS_LOG_LEVEL        | Log level for Users (debug, info, warn, error)                          | error        |
+| MF_USERS_DB_HOST          | Database host address                                                   | localhost    |
+| MF_USERS_DB_PORT          | Database host port                                                      | 5432         |
+| MF_USERS_DB_USER          | Database user                                                           | mainflux     |
+| MF_USERS_DB_PASSWORD      | Database password                                                       | mainflux     |
+| MF_USERS_DB               | Name of the database used by the service                                | users        |
+| MF_USERS_DB_SSL_MODE      | Database connection SSL mode (disable, require, verify-ca, verify-full) | disable      |
+| MF_USERS_DB_SSL_CERT      | Path to the PEM encoded certificate file                                |              |
+| MF_USERS_DB_SSL_KEY       | Path to the PEM encoded key file                                        |              |
+| MF_USERS_DB_SSL_ROOT_CERT | Path to the PEM encoded root certificate file                           |              |
+| MF_USERS_HTTP_PORT        | Users service HTTP port                                                 | 8180         |
+| MF_USERS_GRPC_PORT        | Users service gRPC port                                                 | 8181         |
+| MF_USERS_SERVER_CERT      | Path to server certificate in pem format                                |              |
+| MF_USERS_SERVER_KEY       | Path to server key in pem format                                        |              |
+| MF_USERS_SECRET           | String used for signing tokens                                          | users        |
 
 ## Deployment
 
@@ -53,6 +56,9 @@ services:
       MF_USERS_DB_PASS: [Database password]
       MF_USERS_DB: [Name of the database used by the service]
       MF_USERS_DB_SSL_MODE: [SSL mode to connect to the database with]
+      MF_USERS_DB_SSL_CERT: [Path to the PEM encoded certificate file]
+      MF_USERS_DB_SSL_KEY: [Path to the PEM encoded key file]
+      MF_USERS_DB_SSL_ROOT_CERT: [Path to the PEM encoded root certificate file]
       MF_USERS_HTTP_PORT: [Service HTTP port]
       MF_USERS_GRPC_PORT: [Service gRPC port]
       MF_USERS_SECRET: [String used for signing tokens]
@@ -75,7 +81,7 @@ make users
 make install
 
 # set the environment variables and run the service
-MF_USERS_LOG_LEVEL=[Users log level] MF_USERS_DB_HOST=[Database host address] MF_USERS_DB_PORT=[Database host port] MF_USERS_DB_USER=[Database user] MF_USERS_DB_PASS=[Database password] MF_USERS_DB=[Name of the database used by the service] MF_USERS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_USERS_HTTP_PORT=[Service HTTP port] MF_USERS_GRPC_PORT=[Service gRPC port] MF_USERS_SECRET=[String used for signing tokens] MF_USERS_SERVER_CERT=[Path to server certificate] MF_USERS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-users
+MF_USERS_LOG_LEVEL=[Users log level] MF_USERS_DB_HOST=[Database host address] MF_USERS_DB_PORT=[Database host port] MF_USERS_DB_USER=[Database user] MF_USERS_DB_PASS=[Database password] MF_USERS_DB=[Name of the database used by the service] MF_USERS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_USERS_DB_SSL_CERT=[Path to the PEM encoded certificate file] MF_USERS_DB_SSL_KEY=[Path to the PEM encoded key file] MF_USERS_DB_SSL_ROOT_CERT=[Path to the PEM encoded root certificate file] MF_USERS_HTTP_PORT=[Service HTTP port] MF_USERS_GRPC_PORT=[Service gRPC port] MF_USERS_SECRET=[String used for signing tokens] MF_USERS_SERVER_CERT=[Path to server certificate] MF_USERS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-users
 ```
 
 ## Usage

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -15,6 +15,7 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 )
 
+// Config defines the options that are used when connecting to a PostgreSQL instance
 type Config struct {
 	Host        string
 	Port        string

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -15,11 +15,23 @@ import (
 	migrate "github.com/rubenv/sql-migrate"
 )
 
+type Config struct {
+	Host        string
+	Port        string
+	User        string
+	Pass        string
+	Name        string
+	SSLMode     string
+	SSLCert     string
+	SSLKey      string
+	SSLRootCert string
+}
+
 // Connect creates a connection to the PostgreSQL instance and applies any
 // unapplied database migrations. A non-nil error is returned to indicate
 // failure.
-func Connect(host, port, name, user, pass, sslMode, sslCert, sslKey, sslRootCert string) (*sql.DB, error) {
-	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", host, port, user, name, pass, sslMode, sslCert, sslKey, sslRootCert)
+func Connect(cfg Config) (*sql.DB, error) {
+	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", cfg.Host, cfg.Port, cfg.User, cfg.Name, cfg.Pass, cfg.SSLMode, cfg.SSLCert, cfg.SSLKey, cfg.SSLRootCert)
 
 	db, err := sql.Open("postgres", url)
 	if err != nil {

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -18,8 +18,8 @@ import (
 // Connect creates a connection to the PostgreSQL instance and applies any
 // unapplied database migrations. A non-nil error is returned to indicate
 // failure.
-func Connect(host, port, name, user, pass, sslMode string) (*sql.DB, error) {
-	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s", host, port, user, name, pass, sslMode)
+func Connect(host, port, name, user, pass, sslMode, sslCert, sslKey, sslRootCert string) (*sql.DB, error) {
+	url := fmt.Sprintf("host=%s port=%s user=%s dbname=%s password=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s", host, port, user, name, pass, sslMode, sslCert, sslKey, sslRootCert)
 
 	db, err := sql.Open("postgres", url)
 	if err != nil {

--- a/users/postgres/setup_test.go
+++ b/users/postgres/setup_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable"); err != nil {
+	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable", "", "", ""); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
 	defer db.Close()

--- a/users/postgres/setup_test.go
+++ b/users/postgres/setup_test.go
@@ -53,7 +53,19 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	if db, err = postgres.Connect("localhost", port, "test", "test", "test", "disable", "", "", ""); err != nil {
+	dbConfig := postgres.Config{
+		Host:        "localhost",
+		Port:        port,
+		User:        "test",
+		Pass:        "test",
+		Name:        "test",
+		SSLMode:     "disable",
+		SSLCert:     "",
+		SSLKey:      "",
+		SSLRootCert: "",
+	}
+
+	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
 	defer db.Close()


### PR DESCRIPTION
### What does this do?
Adds the option to connect to the DBs with verify-ca and verify-full
Users can now specify any extra certs and keys they may need.

### Which issue(s) does this PR fix/relate to?
Resolves #448 

### List any changes that modify/break current functionality
None of the default behavior has changed, the default db ssl connection mode remains `disabled`

### Have you included tests for your changes?
I have updated the relevant tests. The pq library tests should cover the changes here since these are just implementing their options

### Did you document any new/modified functionality?
Yes!

### Notes
No other notes
