### PR TITLE
NOISSUE - Move name field to InfluxDB tagset

### DIFF
--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -126,6 +126,7 @@ func (repo *influxRepo) tagsOf(msg *mainflux.Message) tags {
 	return tags{
 		"channel":   msg.Channel,
 		"publisher": msg.Publisher,
+		"name":      msg.Name,
 	}
 }
 
@@ -133,7 +134,6 @@ func (repo *influxRepo) fieldsOf(msg *mainflux.Message) fields {
 	updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
 	ret := fields{
 		"protocol":   msg.Protocol,
-		"name":       msg.Name,
 		"unit":       msg.Unit,
 		"link":       msg.Link,
 		"updateTime": updateTime,


### PR DESCRIPTION
Signed-off-by: Manuel Imperiale <manuel.imperiale@gmail.com>

### What does this do?
It add SenML message name to influx-writer tagset
### Have you included tests for your changes?
no
### Did you document any new/modified functionality?
no
