### PR TITLE
MF-400 - Improve MQTT broker logging

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -10,7 +10,7 @@ var http = require('http'),
     logging = require('aedes-logging');
 
 // pass a proto file as a buffer/string or pass a parsed protobuf-schema object
-var logger = bunyan.createLogger({name: "mqtt"}),
+var logger = bunyan.createLogger({name: "mqtt", pinoOptions: {level: 30}}),
     config = {
         log_level: process.env.MF_MQTT_ADAPTER_LOG_LEVEL || 'error',
         mqtt_port: Number(process.env.MF_MQTT_ADAPTER_PORT) || 1883,


### PR DESCRIPTION
### What does this do?
Sets log level for `aedes` logger, in order to remove heartbeat log.

### Which issue(s) does this PR fix/relate to?
Resolves #400.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No.
