### PR TITLE
MF-314 - Investigate MQTT clustering

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -34,7 +34,14 @@ var config = {
         password: config.redis_pass,
         db: config.redis_db
     }),
+    mqRedis = require('mqemitter-redis')({
+        port: config.redis_port,
+        host: config.redis_host,
+        password: config.redis_pass,
+        db: config.redis_db
+    }),
     aedes = require('aedes')({
+        mq: mqRedis,
         persistence: aedesRedis
     }),
     things = (function() {

--- a/mqtt/package.json
+++ b/mqtt/package.json
@@ -21,6 +21,7 @@
     "bunyan": "^1.5.1",
     "grpc": "^1.11.3",
     "lodash": "^4.17.10",
+    "mqemitter-redis": "^3.0.0",
     "nats": "^0.6.8",
     "protocol-buffers": "^4.0.4",
     "request": "^2.81.0",


### PR DESCRIPTION
MQTT adapter wasn't scalable because mq emitter wasn't setup. Now
it's working as intended. You can create two different instances
and exchange messages between their clients.

This PR resolves #314.

Signed-off-by: Aleksandar Novakovic <aleksandar.novakovic@mainflux.com>