### PR TITLE
NOISSUE- Add dedicated env vars for event sourcing

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       MF_THINGS_DB_PASS: mainflux
       MF_THINGS_DB: things
       MF_THINGS_CACHE_URL: things-redis:6379
+      MF_THINGS_ES_URL: things-redis:6379
       MF_THINGS_HTTP_PORT: 8182
       MF_THINGS_GRPC_PORT: 8183
       MF_USERS_URL: users:8181

--- a/things/README.md
+++ b/things/README.md
@@ -34,6 +34,9 @@ default values.
 | MF_THINGS_CACHE_URL        | Cache database URL                                                     | localhost:6379 |
 | MF_THINGS_CACHE_PASS       | Cache database password                                                |                |
 | MF_THINGS_CACHE_DB         | Cache instance that should be used                                     | 0              |
+| MF_THINGS_ES_URL           | Event store URL                                                        | localhost:6379 |
+| MF_THINGS_ES_PASS          | Event store password                                                   |                |
+| MF_THINGS_ES_DB            | Event store instance that should be used                               | 0              |
 | MF_THINGS_HTTP_PORT        | Things service HTTP port                                               | 8180           |
 | MF_THINGS_GRPC_PORT        | Things service gRPC port                                               | 8181           |
 | MF_THINGS_SERVER_CERT      | Path to server certificate in pem format                               | 8181           |
@@ -69,6 +72,9 @@ services:
       MF_THINGS_CACHE_URL: [Cache database URL]
       MF_THINGS_CACHE_PASS: [Cache database password]
       MF_THINGS_CACHE_DB: [Cache instance that should be used]
+      MF_THINGS_ES_URL: [Event store URL]
+      MF_THINGS_ES_PASS: [Event store password]
+      MF_THINGS_ES_DB: [Event store instance that should be used]
       MF_THINGS_HTTP_PORT: [Service HTTP port]
       MF_THINGS_GRPC_PORT: [Service gRPC port]
       MF_THINGS_SERVER_CERT: [String path to server cert in pem format]
@@ -92,7 +98,7 @@ make things
 make install
 
 # set the environment variables and run the service
-MF_THINGS_LOG_LEVEL=[Things log level] MF_THINGS_DB_HOST=[Database host address] MF_THINGS_DB_PORT=[Database host port] MF_THINGS_DB_USER=[Database user] MF_THINGS_DB_PASS=[Database password] MF_THINGS_DB=[Name of the database used by the service] MF_THINGS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_THINGS_DB_SSL_CERT=[Path to the PEM encoded certificate file] MF_THINGS_DB_SSL_KEY=[Path to the PEM encoded key file] MF_THINGS_DB_SSL_ROOT_CERT=[Path to the PEM encoded root certificate file] MF_HTTP_ADAPTER_CA_CERTS=[Path to trusted CAs in PEM format] MF_THINGS_CACHE_URL=[Cache database URL] MF_THINGS_CACHE_PASS=[Cache database password] MF_THINGS_CACHE_DB=[Cache instance that should be used] MF_THINGS_HTTP_PORT=[Service HTTP port] MF_THINGS_GRPC_PORT=[Service gRPC port] MF_USERS_URL=[Users service URL] MF_THINGS_SERVER_CERT=[Path to server certificate] MF_THINGS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-things
+MF_THINGS_LOG_LEVEL=[Things log level] MF_THINGS_DB_HOST=[Database host address] MF_THINGS_DB_PORT=[Database host port] MF_THINGS_DB_USER=[Database user] MF_THINGS_DB_PASS=[Database password] MF_THINGS_DB=[Name of the database used by the service] MF_THINGS_DB_SSL_MODE=[SSL mode to connect to the database with] MF_THINGS_DB_SSL_CERT=[Path to the PEM encoded certificate file] MF_THINGS_DB_SSL_KEY=[Path to the PEM encoded key file] MF_THINGS_DB_SSL_ROOT_CERT=[Path to the PEM encoded root certificate file] MF_HTTP_ADAPTER_CA_CERTS=[Path to trusted CAs in PEM format] MF_THINGS_CACHE_URL=[Cache database URL] MF_THINGS_CACHE_PASS=[Cache database password] MF_THINGS_CACHE_DB=[Cache instance that should be used] MF_THINGS_ES_URL=[Event store URL] MF_THINGS_ES_PASS=[Event store password] MF_THINGS_ES_DB=[Event store instance that should be used] MF_THINGS_HTTP_PORT=[Service HTTP port] MF_THINGS_GRPC_PORT=[Service gRPC port] MF_USERS_URL=[Users service URL] MF_THINGS_SERVER_CERT=[Path to server certificate] MF_THINGS_SERVER_KEY=[Path to server key] $GOBIN/mainflux-things
 ```
 
 Setting `MF_THINGS_CA_CERTS` expects a file in PEM format of trusted CAs. This will enable TLS against the Users gRPC endpoint trusting only those CAs that are provided.


### PR DESCRIPTION
Add dedicated env vars for event sourcing in `things` service.