### PR TITLE
NOISSUE - Fix pagination response for empty page

### DIFF
--- a/sdk/go/channels_test.go
+++ b/sdk/go/channels_test.go
@@ -211,7 +211,7 @@ func TestChannels(t *testing.T) {
 			offset:   110,
 			limit:    5,
 			err:      nil,
-			response: nil,
+			response: []sdk.Channel{},
 		},
 		{
 			desc:     "get a list of channels with invalid args (zero limit) and invalid token",
@@ -318,7 +318,7 @@ func TestChannelsByThing(t *testing.T) {
 			offset:   110,
 			limit:    5,
 			err:      nil,
-			response: nil,
+			response: []sdk.Channel{},
 		},
 		{
 			desc:     "get a list of channels by thing with invalid args (zero limit) and invalid token",

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -249,7 +249,7 @@ func TestThings(t *testing.T) {
 			offset:   110,
 			limit:    5,
 			err:      nil,
-			response: nil,
+			response: []sdk.Thing{},
 		},
 		{
 			desc:     "get a list of things with invalid args (zero limit) and invalid token",
@@ -359,7 +359,7 @@ func TestThingsByChannel(t *testing.T) {
 			offset:   110,
 			limit:    5,
 			err:      nil,
-			response: nil,
+			response: []sdk.Thing{},
 		},
 		{
 			desc:     "get a list of things by channel with invalid args (zero limit) and invalid token",

--- a/things/api/http/endpoint.go
+++ b/things/api/http/endpoint.go
@@ -108,6 +108,7 @@ func listThingsEndpoint(svc things.Service) endpoint.Endpoint {
 				Offset: page.Offset,
 				Limit:  page.Limit,
 			},
+			Things: []viewThingRes{},
 		}
 		for _, thing := range page.Things {
 			view := viewThingRes{
@@ -144,6 +145,7 @@ func listThingsByChannelEndpoint(svc things.Service) endpoint.Endpoint {
 				Offset: page.Offset,
 				Limit:  page.Limit,
 			},
+			Things: []viewThingRes{},
 		}
 		for _, thing := range page.Things {
 			view := viewThingRes{
@@ -272,6 +274,7 @@ func listChannelsEndpoint(svc things.Service) endpoint.Endpoint {
 				Offset: page.Offset,
 				Limit:  page.Limit,
 			},
+			Channels: []viewChannelRes{},
 		}
 		// Cast channels
 		for _, channel := range page.Channels {
@@ -308,6 +311,7 @@ func listChannelsByThingEndpoint(svc things.Service) endpoint.Endpoint {
 				Offset: page.Offset,
 				Limit:  page.Limit,
 			},
+			Channels: []viewChannelRes{},
 		}
 		for _, channel := range page.Channels {
 			view := viewChannelRes{


### PR DESCRIPTION
Fix pagination response for the case when list is empty. API was returning `null` in some cases, now it will return empty list.