### PR TITLE
MF-429 -Enabled MQTT subtopic's

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -111,7 +111,7 @@ aedes.authorizePublish = function (client, packet, publish) {
             chanID: channelId
         },
         // Parse unlimited subtopics
-        baseLength = 3, // First few elements which represents the base part of topic.
+        baseLength = 3, // First 3 elements which represents the base part of topic.
         elements = packet.topic.split('/').slice(baseLength),
         baseTopic = 'channel.' + channelId;
      // Remove empty elements

--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -142,7 +142,6 @@ aedes.authorizePublish = function (client, packet, publish) {
             }
         };
 
-    console.log("Here it is the filan NATS topic:", channelTopic)
     things.CanAccess(accessReq, onAuthorize);
 };
 

--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -98,7 +98,8 @@ nats.subscribe('channel.*', function (msg) {
 
 aedes.authorizePublish = function (client, packet, publish) {
     // Topics are in the form `channels/<channel_id>/messages`
-    var channel = /^channels\/(.+?)\/messages$/.exec(packet.topic);
+    // Subtopic's are in the form `channels/<channel_id>/messages/<subtopic>`
+    var channel = /^channels\/(.+?)\/messages\/?(.+?)?$/.exec(packet.topic);
     if (!channel) {
         logger.warn('unknown topic');
         publish(4); // Bad username or password
@@ -109,6 +110,18 @@ aedes.authorizePublish = function (client, packet, publish) {
             token: client.password,
             chanID: channelId
         },
+        // Parse unlimited subtopics
+        baseLength = 3, // First few elements which represents the base part of topic.
+        elements = packet.topic.split('/').slice(baseLength),
+        baseTopic = 'channel.' + channelId;
+     // Remove empty elements
+    for (var i = 0; i < elements.length; i++) {
+      if (elements[i] === '') {
+        elements.pop(i)
+      }
+    }
+    var channelTopic = elements.length ? baseTopic + '.' + elements.join('.') : baseTopic,
+
         onAuthorize = function (err, res) {
             var rawMsg;
             if (!err) {
@@ -120,7 +133,7 @@ aedes.authorizePublish = function (client, packet, publish) {
                     Protocol: 'mqtt',
                     Payload: packet.payload
                 });
-                nats.publish('channel.' + channelId, rawMsg);
+                nats.publish(channelTopic, rawMsg);
 
                 publish(0);
             } else {
@@ -129,14 +142,21 @@ aedes.authorizePublish = function (client, packet, publish) {
             }
         };
 
+    console.log("Here it is the filan NATS topic:", channelTopic)
     things.CanAccess(accessReq, onAuthorize);
 };
 
 
 aedes.authorizeSubscribe = function (client, packet, subscribe) {
     // Topics are in the form `channels/<channel_id>/messages`
-    var channel = /^channels\/(.+?)\/messages$/.exec(packet.topic),
-        channelId = channel[1],
+    // Subtopic's are in the form `channels/<channel_id>/messages/<subtopic>`
+    var channel = /^channels\/(.+?)\/messages\/?(.+?)?$/.exec(packet.topic);
+    if (!channel) {
+      logger.warn('unknown topic');
+      subscribe(4, packet); // Bad username or password
+      return;
+    }
+    var channelId = channel[1],
         accessReq = {
             token: client.password,
             chanID: channelId

--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -114,7 +114,7 @@ aedes.authorizePublish = function (client, packet, publish) {
         baseLength = 3, // First 3 elements which represents the base part of topic.
         elements = packet.topic.split('/').slice(baseLength),
         baseTopic = 'channel.' + channelId;
-     // Remove empty elements
+    // Remove empty elements
     for (var i = 0; i < elements.length; i++) {
       if (elements[i] === '') {
         elements.pop(i)

--- a/normalizer/nats/pubsub.go
+++ b/normalizer/nats/pubsub.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	queue         = "normalizers"
-	input         = "channel.*"
+	input         = "channel.>"
 	outputUnknown = "out.unknown"
 	senML         = "application/senml+json"
 )


### PR DESCRIPTION
### What does this do?
It enables MQTT subtopic's on multi level  regarding to #429 feature request.
### Which issue(s) does this PR fix/relate to ?
Resolves #429 

### List any changes that modify/break current functionality
No breaking changes.
### Have you included tests for your changes?
No
### Did you document any new/modified functionality?
No
### Notes
**Subtopics are supported only for MQTT to MQTT communication or if you connect directly to NATS topics**. Using other protocols or mixing it with MQTT is limited to general topic only `/messages` without subtopics. Issues to support other protocol adapters will be opened.
