### PR TITLE
NOISSUE - Simplify MQTT topic regexp

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -99,7 +99,7 @@ nats.subscribe('channel.*', function (msg) {
 aedes.authorizePublish = function (client, packet, publish) {
     // Topics are in the form `channels/<channel_id>/messages`
     // Subtopic's are in the form `channels/<channel_id>/messages/<subtopic>`
-    var channel = /^channels\/(.+?)\/messages\/?(.+?)?$/.exec(packet.topic);
+    var channel = /^channels\/(.+?)\/messages\/?.*$/.exec(packet.topic);
     if (!channel) {
         logger.warn('unknown topic');
         publish(4); // Bad username or password


### PR DESCRIPTION
Current regexp makes 2 selection groups, while
capturing just the first group (the only one of
interest) into variable.

This PR simplifies the regexp and avoids capturing
secound group.

Signed-off-by: drasko <drasko.draskovic@gmail.com>