### PR TITLE
NOISSUE - Fix MQTT adapter by setting subscription queue

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -80,7 +80,7 @@ function startMqtt() {
     return net.createServer(aedes.handle).listen(config.mqtt_port);
 }
 
-nats.subscribe('channel.*', function (msg) {
+nats.subscribe('channel.*', {'queue':'mqtts'}, function (msg) {
     var m = message.RawMessage.decode(Buffer.from(msg)),
         packet;
     if (m && m.Protocol !== 'mqtt') {


### PR DESCRIPTION
Fix MQTT adapter by setting subscription queue instead of normal subscription to NATS.