### PR TITLE
MF-540 - Add pagination in API responses for Bootstrap service

### DIFF
--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -27,6 +27,7 @@ func addEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 		}
 
 		config := bootstrap.Config{
+			MFThing:     req.ThingID,
 			ExternalID:  req.ExternalID,
 			ExternalKey: req.ExternalKey,
 			MFChannels:  channels,

--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -127,14 +127,14 @@ func listEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		configs, err := svc.List(req.key, req.filter, req.offset, req.limit)
+		page, err := svc.List(req.key, req.filter, req.offset, req.limit)
 		if err != nil {
 			return nil, err
 		}
 		switch {
 		case req.filter.Unknown:
 			res := listUnknownRes{}
-			for _, cfg := range configs {
+			for _, cfg := range page.Configs {
 				res.Configs = append(res.Configs, unknownRes{
 					ExternalID:  cfg.ExternalID,
 					ExternalKey: cfg.ExternalKey,
@@ -143,10 +143,13 @@ func listEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return res, nil
 		default:
 			res := listRes{
+				Total:   page.Total,
+				Offset:  page.Offset,
+				Limit:   page.Limit,
 				Configs: []viewRes{},
 			}
 
-			for _, cfg := range configs {
+			for _, cfg := range page.Configs {
 				var channels []channelRes
 				for _, ch := range cfg.MFChannels {
 					channels = append(channels, channelRes{

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -47,6 +47,7 @@ const (
 var (
 	addChannels = []string{"1"}
 	addReq      = struct {
+		ThingID     string   `json:"thing_id"`
 		ExternalID  string   `json:"external_id"`
 		ExternalKey string   `json:"external_key"`
 		Channels    []string `json:"channels"`
@@ -155,6 +156,10 @@ func TestAdd(t *testing.T) {
 
 	data := toJSON(addReq)
 
+	neID := addReq
+	neID.ThingID = "non-existent"
+	neData := toJSON(neID)
+
 	invalidChannels := addReq
 	invalidChannels.Channels = []string{wrongID}
 	wrongData := toJSON(invalidChannels)
@@ -197,6 +202,14 @@ func TestAdd(t *testing.T) {
 			auth:        validToken,
 			contentType: contentType,
 			status:      http.StatusConflict,
+			location:    "",
+		},
+		{
+			desc:        "add a config with non-existent ID",
+			req:         neData,
+			auth:        validToken,
+			contentType: contentType,
+			status:      http.StatusNotFound,
 			location:    "",
 		},
 		{

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -68,7 +68,7 @@ func (lm *loggingMiddleware) Update(key string, thing bootstrap.Config) (err err
 	return lm.svc.Update(key, thing)
 }
 
-func (lm *loggingMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (res []bootstrap.Config, err error) {
+func (lm *loggingMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (res bootstrap.ConfigsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list for key %s and offset %d and limit %d took %s to complete", key, offset, limit, time.Since(begin))
 		if err != nil {

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -61,7 +61,7 @@ func (mm *metricsMiddleware) Update(key string, thing bootstrap.Config) (err err
 	return mm.svc.Update(key, thing)
 }
 
-func (mm *metricsMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (saved []bootstrap.Config, err error) {
+func (mm *metricsMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (saved bootstrap.ConfigsPage, err error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "list").Add(1)
 		mm.latency.With("method", "list").Observe(time.Since(begin).Seconds())

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -121,7 +121,6 @@ type changeStateReq struct {
 }
 
 func (req changeStateReq) validate() error {
-
 	if req.key == "" {
 		return bootstrap.ErrUnauthorizedAccess
 	}

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -15,6 +15,7 @@ type apiReq interface {
 
 type addReq struct {
 	key         string
+	ThingID     string   `json:"thing_id"`
 	ExternalID  string   `json:"external_id"`
 	ExternalKey string   `json:"external_key"`
 	Channels    []string `json:"channels"`

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -23,6 +23,10 @@ type addReq struct {
 }
 
 func (req addReq) validate() error {
+	if req.key == "" {
+		return bootstrap.ErrUnauthorizedAccess
+	}
+
 	if req.ExternalID == "" || req.ExternalKey == "" {
 		return bootstrap.ErrMalformedEntity
 	}
@@ -40,6 +44,10 @@ func (req entityReq) validate() error {
 		return bootstrap.ErrUnauthorizedAccess
 	}
 
+	if req.id == "" {
+		return bootstrap.ErrMalformedEntity
+	}
+
 	return nil
 }
 
@@ -55,6 +63,10 @@ type updateReq struct {
 func (req updateReq) validate() error {
 	if req.key == "" {
 		return bootstrap.ErrUnauthorizedAccess
+	}
+
+	if req.id == "" {
+		return bootstrap.ErrMalformedEntity
 	}
 
 	// Can't explicitly update state to NewThing or Created.
@@ -76,6 +88,10 @@ type listReq struct {
 func (req listReq) validate() error {
 	if req.key == "" {
 		return bootstrap.ErrUnauthorizedAccess
+	}
+
+	if req.limit == 0 || req.limit > maxLimit {
+		return bootstrap.ErrMalformedEntity
 	}
 
 	return nil
@@ -105,8 +121,13 @@ type changeStateReq struct {
 }
 
 func (req changeStateReq) validate() error {
-	if req.id == "" || req.key == "" {
+
+	if req.key == "" {
 		return bootstrap.ErrUnauthorizedAccess
+	}
+
+	if req.id == "" {
+		return bootstrap.ErrMalformedEntity
 	}
 
 	if req.State != bootstrap.Inactive &&

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/mainflux/mainflux/bootstrap"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddReqValidation(t *testing.T) {

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mainflux/mainflux/bootstrap"
+)
+
+func TestAddReqValidation(t *testing.T) {
+	cases := []struct {
+		desc        string
+		key         string
+		externalID  string
+		externalKey string
+		err         error
+	}{
+		{
+			desc:        "empty key",
+			key:         "",
+			externalID:  "external-id",
+			externalKey: "external-key",
+			err:         bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc:        "empty external ID",
+			key:         "key",
+			externalID:  "",
+			externalKey: "external-key",
+			err:         bootstrap.ErrMalformedEntity,
+		},
+		{
+			desc:        "empty external key",
+			key:         "key",
+			externalID:  "external-id",
+			externalKey: "",
+			err:         bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := addReq{
+			key:         tc.key,
+			ExternalID:  tc.externalID,
+			ExternalKey: tc.externalKey,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestEntityReqValidation(t *testing.T) {
+	cases := []struct {
+		desc string
+		key  string
+		id   string
+		err  error
+	}{
+		{
+			desc: "empty key",
+			key:  "",
+			id:   "id",
+			err:  bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc: "empty id",
+			key:  "key",
+			id:   "",
+			err:  bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := entityReq{
+			key: tc.key,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestUpdateReqValidation(t *testing.T) {
+	cases := []struct {
+		desc  string
+		key   string
+		id    string
+		state bootstrap.State
+		err   error
+	}{
+		{
+			desc:  "empty key",
+			key:   "",
+			id:    "id",
+			state: bootstrap.State(1),
+			err:   bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc:  "empty id",
+			key:   "key",
+			id:    "",
+			state: bootstrap.State(0),
+			err:   bootstrap.ErrMalformedEntity,
+		},
+		{
+			desc:  "invalid state",
+			key:   "key",
+			id:    "id",
+			state: bootstrap.State(14),
+			err:   bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := updateReq{
+			key:   tc.key,
+			id:    tc.id,
+			State: tc.state,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestListReqValidation(t *testing.T) {
+	cases := []struct {
+		desc   string
+		offset uint64
+		key    string
+		limit  uint64
+		err    error
+	}{
+		{
+			desc:   "empty key",
+			key:    "",
+			offset: 0,
+			limit:  1,
+			err:    bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc:   "too large limit",
+			key:    "key",
+			offset: 0,
+			limit:  maxLimit + 1,
+			err:    bootstrap.ErrMalformedEntity,
+		},
+		{
+			desc:   "zero limit",
+			key:    "key",
+			offset: 0,
+			limit:  0,
+			err:    bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := listReq{
+			key:    tc.key,
+			offset: tc.offset,
+			limit:  tc.limit,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestBootstrapReqValidation(t *testing.T) {
+	cases := []struct {
+		desc      string
+		externKey string
+		externID  string
+		err       error
+	}{
+		{
+			desc:      "empty external key",
+			externKey: "",
+			externID:  "id",
+			err:       bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc:      "empty external id",
+			externKey: "key",
+			externID:  "",
+			err:       bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := bootstrapReq{
+			id:  tc.externID,
+			key: tc.externKey,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestChangeStateReqValidation(t *testing.T) {
+	cases := []struct {
+		desc  string
+		key   string
+		id    string
+		state bootstrap.State
+		err   error
+	}{
+		{
+			desc:  "empty key",
+			key:   "",
+			id:    "id",
+			state: bootstrap.State(1),
+			err:   bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc:  "empty id",
+			key:   "key",
+			id:    "",
+			state: bootstrap.State(0),
+			err:   bootstrap.ErrMalformedEntity,
+		},
+		{
+			desc:  "invalid state",
+			key:   "key",
+			id:    "id",
+			state: bootstrap.State(14),
+			err:   bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := changeStateReq{
+			key:   tc.key,
+			id:    tc.id,
+			State: tc.state,
+		}
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -46,6 +46,7 @@ func TestAddReqValidation(t *testing.T) {
 			ExternalID:  tc.externalID,
 			ExternalKey: tc.externalKey,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
@@ -76,6 +77,7 @@ func TestEntityReqValidation(t *testing.T) {
 		req := entityReq{
 			key: tc.key,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
@@ -118,6 +120,7 @@ func TestUpdateReqValidation(t *testing.T) {
 			id:    tc.id,
 			State: tc.state,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
@@ -160,6 +163,7 @@ func TestListReqValidation(t *testing.T) {
 			offset: tc.offset,
 			limit:  tc.limit,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
@@ -191,6 +195,7 @@ func TestBootstrapReqValidation(t *testing.T) {
 			id:  tc.externID,
 			key: tc.externKey,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
@@ -233,6 +238,7 @@ func TestChangeStateReqValidation(t *testing.T) {
 			id:    tc.id,
 			State: tc.state,
 		}
+
 		err := req.validate()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}

--- a/bootstrap/api/responses.go
+++ b/bootstrap/api/responses.go
@@ -11,9 +11,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mainflux/mainflux/bootstrap"
-
 	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/bootstrap"
 )
 
 var (

--- a/bootstrap/api/responses.go
+++ b/bootstrap/api/responses.go
@@ -116,6 +116,9 @@ func (res listUnknownRes) Empty() bool {
 }
 
 type listRes struct {
+	Total   uint64    `json:"total"`
+	Offset  uint64    `json:"offset"`
+	Limit   uint64    `json:"limit"`
 	Configs []viewRes `json:"configs"`
 }
 

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -17,12 +17,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mainflux/mainflux/bootstrap"
-
 	kithttp "github.com/go-kit/kit/transport/http"
-
 	"github.com/go-zoo/bone"
 	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/bootstrap"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -46,49 +46,49 @@ func MakeHandler(svc bootstrap.Service, reader bootstrap.ConfigReader) http.Hand
 	}
 	r := bone.New()
 
-	r.Post("/configs", kithttp.NewServer(
+	r.Post("/things/configs", kithttp.NewServer(
 		addEndpoint(svc),
 		decodeAddRequest,
 		encodeResponse,
 		opts...))
 
-	r.Get("/configs/:id", kithttp.NewServer(
+	r.Get("/things/configs/:id", kithttp.NewServer(
 		viewEndpoint(svc),
 		decodeEntityRequest,
 		encodeResponse,
 		opts...))
 
-	r.Put("/configs/:id", kithttp.NewServer(
+	r.Put("/things/configs/:id", kithttp.NewServer(
 		updateEndpoint(svc),
 		decodeUpdateRequest,
 		encodeResponse,
 		opts...))
 
-	r.Get("/configs", kithttp.NewServer(
+	r.Get("/things/configs", kithttp.NewServer(
 		listEndpoint(svc),
 		decodeListRequest,
 		encodeResponse,
 		opts...))
 
-	r.Get("/unknown", kithttp.NewServer(
+	r.Get("/things/unknown/configs", kithttp.NewServer(
 		listEndpoint(svc),
 		decodeUnknownRequest,
 		encodeResponse,
 		opts...))
 
-	r.Get("/bootstrap/:external_id", kithttp.NewServer(
+	r.Get("/things/bootstrap/:external_id", kithttp.NewServer(
 		bootstrapEndpoint(svc, reader),
 		decodeBootstrapRequest,
 		encodeResponse,
 		opts...))
 
-	r.Put("/state/:id", kithttp.NewServer(
+	r.Put("/things/state/:id", kithttp.NewServer(
 		stateEndpoint(svc),
 		decodeStateRequest,
 		encodeResponse,
 		opts...))
 
-	r.Delete("/configs/:id", kithttp.NewServer(
+	r.Delete("/things/configs/:id", kithttp.NewServer(
 		removeEndpoint(svc),
 		decodeEntityRequest,
 		encodeResponse,

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -64,7 +64,7 @@ type ConfigRepository interface {
 	// by the specified user.
 	RetrieveByID(string, string) (Config, error)
 
-	// RetrieveAll retrieves data about subset of Configs that are owned
+	// RetrieveAll retrieves a subset of Configs that are owned
 	// by the specific user, with given filter parameters.
 	RetrieveAll(string, Filter, uint64, uint64) ConfigsPage
 
@@ -85,7 +85,7 @@ type ConfigRepository interface {
 	// SaveUnknown saves Thing which unsuccessfully bootstrapped.
 	SaveUnknown(string, string) error
 
-	// RetrieveUnknown returns data about subset of unsuccessfully bootstrapped Things.
+	// RetrieveUnknown returns a subset of unsuccessfully bootstrapped Things.
 	RetrieveUnknown(uint64, uint64) ConfigsPage
 
 	// RemoveUnknown removes unsuccessfully bootstrapped Thing. This is done once the

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -45,6 +45,15 @@ type Filter struct {
 	PartialMatch map[string]string
 }
 
+// ConfigsPage contains page related metadata as well as list of Configs that
+// belong to this page.
+type ConfigsPage struct {
+	Total   uint64
+	Offset  uint64
+	Limit   uint64
+	Configs []Config
+}
+
 // ConfigRepository specifies a Config persistence API.
 type ConfigRepository interface {
 	// Save persists the Config. Successful operation is indicated by non-nil
@@ -55,9 +64,9 @@ type ConfigRepository interface {
 	// by the specified user.
 	RetrieveByID(string, string) (Config, error)
 
-	// RetrieveAll retrieves the subset of Configs that are owned by the specific user,
-	// with given filter parameters.
-	RetrieveAll(string, Filter, uint64, uint64) []Config
+	// RetrieveAll retrieves data about subset of Configs that are owned
+	// by the specific user, with given filter parameters.
+	RetrieveAll(string, Filter, uint64, uint64) ConfigsPage
 
 	// RetrieveByExternalID returns Config for given external ID.
 	RetrieveByExternalID(string, string) (Config, error)
@@ -76,8 +85,8 @@ type ConfigRepository interface {
 	// SaveUnknown saves Thing which unsuccessfully bootstrapped.
 	SaveUnknown(string, string) error
 
-	// RetrieveUnknown returns list of unsuccessfully bootstrapped Things.
-	RetrieveUnknown(uint64, uint64) []Config
+	// RetrieveUnknown returns data about subset of unsuccessfully bootstrapped Things.
+	RetrieveUnknown(uint64, uint64) ConfigsPage
 
 	// RemoveUnknown removes unsuccessfully bootstrapped Thing. This is done once the
 	// corresponding Config is added to the list of existing configs (Save method).

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -16,6 +16,11 @@ import (
 	"github.com/mainflux/mainflux/bootstrap"
 )
 
+const (
+	emptyState  = -1
+	notFoundIdx = -1
+)
+
 var _ bootstrap.ConfigRepository = (*configRepositoryMock)(nil)
 
 type configRepositoryMock struct {
@@ -73,7 +78,7 @@ func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter
 
 	first := uint64(offset) + 1
 	last := first + uint64(limit)
-	var state bootstrap.State = -1
+	var state bootstrap.State = emptyState
 	var name string
 	if s, ok := filter.FullMatch["state"]; ok {
 		val, _ := strconv.Atoi(s)
@@ -87,8 +92,8 @@ func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter
 	var total uint64
 	for _, v := range crm.configs {
 		id, _ := strconv.ParseUint(v.MFThing, 10, 64)
-		if (state == -1 || v.State == state) &&
-			(name == "" || strings.Index(strings.ToLower(v.Name), name) != -1) &&
+		if (state == emptyState || v.State == state) &&
+			(name == "" || strings.Index(strings.ToLower(v.Name), name) != notFoundIdx) &&
 			v.Owner == key {
 			if id >= first && id < last {
 				configs = append(configs, v)

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -64,11 +64,11 @@ func (crm *configRepositoryMock) RetrieveByID(key, id string) (bootstrap.Config,
 
 }
 
-func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter, offset, limit uint64) []bootstrap.Config {
+func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter, offset, limit uint64) bootstrap.ConfigsPage {
 	configs := make([]bootstrap.Config, 0)
 
 	if offset < 0 || limit <= 0 {
-		return configs
+		return bootstrap.ConfigsPage{}
 	}
 
 	first := uint64(offset) + 1
@@ -84,14 +84,16 @@ func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter
 		name = strings.ToLower(s)
 	}
 
+	var total uint64
 	for _, v := range crm.configs {
 		id, _ := strconv.ParseUint(v.MFThing, 10, 64)
-		if id >= first && id < last {
-			if (state == -1 || v.State == state) &&
-				(name == "" || strings.Index(strings.ToLower(v.Name), name) != -1) &&
-				v.Owner == key {
+		if (state == -1 || v.State == state) &&
+			(name == "" || strings.Index(strings.ToLower(v.Name), name) != -1) &&
+			v.Owner == key {
+			if id >= first && id < last {
 				configs = append(configs, v)
 			}
+			total++
 		}
 	}
 
@@ -99,7 +101,12 @@ func (crm *configRepositoryMock) RetrieveAll(key string, filter bootstrap.Filter
 		return configs[i].MFThing < configs[j].MFThing
 	})
 
-	return configs
+	return bootstrap.ConfigsPage{
+		Total:   total,
+		Offset:  offset,
+		Limit:   limit,
+		Configs: configs,
+	}
 }
 
 func (crm *configRepositoryMock) RetrieveByExternalID(externalKey, externalID string) (bootstrap.Config, error) {
@@ -153,8 +160,8 @@ func (crm *configRepositoryMock) ChangeState(key, id string, state bootstrap.Sta
 	return nil
 }
 
-func (crm *configRepositoryMock) RetrieveUnknown(offset, limit uint64) []bootstrap.Config {
-	res := []bootstrap.Config{}
+func (crm *configRepositoryMock) RetrieveUnknown(offset, limit uint64) bootstrap.ConfigsPage {
+	configs := []bootstrap.Config{}
 	i := uint64(0)
 	l := int(limit)
 	var keys []string
@@ -164,8 +171,8 @@ func (crm *configRepositoryMock) RetrieveUnknown(offset, limit uint64) []bootstr
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		if i >= offset && len(res) < l {
-			res = append(res, bootstrap.Config{
+		if i >= offset && len(configs) < l {
+			configs = append(configs, bootstrap.Config{
 				ExternalID:  k,
 				ExternalKey: crm.unknown[k],
 			})
@@ -173,7 +180,12 @@ func (crm *configRepositoryMock) RetrieveUnknown(offset, limit uint64) []bootstr
 		i++
 	}
 
-	return res
+	return bootstrap.ConfigsPage{
+		Total:   uint64(len(crm.unknown)),
+		Offset:  offset,
+		Limit:   limit,
+		Configs: configs,
+	}
 }
 
 func (crm *configRepositoryMock) RemoveUnknown(key, id string) error {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -141,7 +141,7 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 
 	var total uint64
 	if err := cr.db.QueryRow(q, params...).Scan(&total); err != nil {
-		cr.log.Error(fmt.Sprintf("Failed to count config due to %s", err))
+		cr.log.Error(fmt.Sprintf("Failed to count configs due to %s", err))
 		return bootstrap.ConfigsPage{}
 	}
 
@@ -277,7 +277,7 @@ func (cr configRepository) RetrieveUnknown(offset, limit uint64) bootstrap.Confi
 
 	var total uint64
 	if err := cr.db.QueryRow(q).Scan(&total); err != nil {
-		cr.log.Error(fmt.Sprintf("Failed to count config due to %s", err))
+		cr.log.Error(fmt.Sprintf("Failed to count unknown configs due to %s", err))
 		return bootstrap.ConfigsPage{}
 	}
 

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -102,11 +102,18 @@ func (cr configRepository) RetrieveByID(key, id string) (bootstrap.Config, error
 	return cfg, nil
 }
 
-func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offset, limit uint64) []bootstrap.Config {
-	rows, err := cr.retrieveAll(key, filter, offset, limit)
+func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offset, limit uint64) bootstrap.ConfigsPage {
+	search, params := cr.retrieveAll(key, filter)
+	n := len(params)
+
+	q := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state, mainflux_channels
+	 			 FROM configs %s ORDER BY mainflux_thing LIMIT $%d OFFSET $%d`
+	q = fmt.Sprintf(q, search, n+1, n+2)
+
+	rows, err := cr.db.Query(q, append(params, limit, offset)...)
 	if err != nil {
 		cr.log.Error(fmt.Sprintf("Failed to retrieve configs due to %s", err))
-		return []bootstrap.Config{}
+		return bootstrap.ConfigsPage{}
 	}
 	defer rows.Close()
 
@@ -118,12 +125,12 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 		c := bootstrap.Config{Owner: key}
 		if err := rows.Scan(&c.MFThing, &c.MFKey, &c.ExternalID, &c.ExternalKey, &name, &content, &c.State, &chs); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
-			return []bootstrap.Config{}
+			return bootstrap.ConfigsPage{}
 		}
 
 		if err := json.Unmarshal(chs, &c.MFChannels); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
-			return []bootstrap.Config{}
+			return bootstrap.ConfigsPage{}
 		}
 
 		c.Name = name.String
@@ -131,7 +138,20 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 		configs = append(configs, c)
 	}
 
-	return configs
+	q = fmt.Sprintf(`SELECT COUNT(*) FROM configs %s`, search)
+
+	var total uint64
+	if err := cr.db.QueryRow(q, params...).Scan(&total); err != nil {
+		cr.log.Error(fmt.Sprintf("Failed to count config due to %s", err))
+		return bootstrap.ConfigsPage{}
+	}
+
+	return bootstrap.ConfigsPage{
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+		Configs: configs,
+	}
 }
 
 func (cr configRepository) RetrieveByExternalID(externalKey, externalID string) (bootstrap.Config, error) {
@@ -234,12 +254,12 @@ func (cr configRepository) SaveUnknown(key, id string) error {
 	return nil
 }
 
-func (cr configRepository) RetrieveUnknown(offset, limit uint64) []bootstrap.Config {
+func (cr configRepository) RetrieveUnknown(offset, limit uint64) bootstrap.ConfigsPage {
 	q := `SELECT external_id, external_key FROM unknown_configs LIMIT $1 OFFSET $2`
 	rows, err := cr.db.Query(q, limit, offset)
 	if err != nil {
 		cr.log.Error(fmt.Sprintf("Failed to retrieve config due to %s", err))
-		return []bootstrap.Config{}
+		return bootstrap.ConfigsPage{}
 	}
 	defer rows.Close()
 
@@ -248,13 +268,26 @@ func (cr configRepository) RetrieveUnknown(offset, limit uint64) []bootstrap.Con
 		c := bootstrap.Config{}
 		if err = rows.Scan(&c.ExternalID, &c.ExternalKey); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
-			return []bootstrap.Config{}
+			return bootstrap.ConfigsPage{}
 		}
 
 		items = append(items, c)
 	}
 
-	return items
+	q = fmt.Sprintf(`SELECT COUNT(*) FROM unknown_configs`)
+
+	var total uint64
+	if err := cr.db.QueryRow(q).Scan(&total); err != nil {
+		cr.log.Error(fmt.Sprintf("Failed to count config due to %s", err))
+		return bootstrap.ConfigsPage{}
+	}
+
+	return bootstrap.ConfigsPage{
+		Total:   total,
+		Offset:  offset,
+		Limit:   limit,
+		Configs: items,
+	}
 }
 
 func (cr configRepository) RemoveUnknown(key, id string) error {
@@ -264,14 +297,13 @@ func (cr configRepository) RemoveUnknown(key, id string) error {
 	return err
 }
 
-func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter, offset, limit uint64) (*sql.Rows, error) {
-	template := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state, mainflux_channels
-				 FROM configs WHERE owner = $1 %s ORDER BY mainflux_thing LIMIT $2 OFFSET $3`
-	params := []interface{}{key, limit, offset}
+func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter) (string, []interface{}) {
+	template := `WHERE owner = $1 %s`
+	params := []interface{}{key}
 	// One empty string so that strings Join works if only one filter is applied.
 	queries := []string{""}
-	// Since key = 1, limit = 2, offset = 3, the next one is 4.
-	counter := len(params) + 1
+	// Since key is the first param, start from 2.
+	counter := 2
 	for k, v := range filter.FullMatch {
 		queries = append(queries, fmt.Sprintf("%s = $%d", k, counter))
 		params = append(params, v)
@@ -285,7 +317,7 @@ func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter, offs
 
 	f := strings.Join(queries, " AND ")
 
-	return cr.db.Query(fmt.Sprintf(template, f), params...)
+	return fmt.Sprintf(template, f), params
 }
 
 func toDBChannels(channels []bootstrap.Channel) []dbChannel {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -13,9 +13,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lib/pq"
 	"github.com/mainflux/mainflux/bootstrap"
-
-	"github.com/lib/pq" // required for DB access
 	"github.com/mainflux/mainflux/logger"
 )
 

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -171,7 +171,7 @@ func TestRetrieveAll(t *testing.T) {
 	}
 	for _, tc := range cases {
 		ret := repo.RetrieveAll(tc.owner, tc.filter, tc.offset, tc.limit)
-		size := len(ret)
+		size := len(ret.Configs)
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", tc.desc, tc.size, size))
 	}
 }
@@ -397,7 +397,7 @@ func TestRetrieveUnknown(t *testing.T) {
 	}
 	for _, tc := range cases {
 		ret := repo.RetrieveUnknown(tc.offset, tc.limit)
-		size := len(ret)
+		size := len(ret.Configs)
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected %d got %d\n", tc.desc, tc.size, size))
 	}
 }

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -97,6 +97,7 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+
 	// Check if channels exist. This is the way to prevent invalid configuration to be saved.
 	// However, channels deletion will eventually cause this; since Bootstrap service is not
 	// using events from the Things service at the moment. See #552.
@@ -119,7 +120,8 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 		channels = append(channels, newCh)
 	}
 
-	mfThing, err := bs.add(key)
+	id := cfg.MFThing
+	mfThing, err := bs.thing(key, id)
 	if err != nil {
 		return Config{}, err
 	}
@@ -129,13 +131,17 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 	cfg.State = Inactive
 	cfg.MFKey = mfThing.Key
 	cfg.MFChannels = channels
-	id, err := bs.configs.Save(cfg)
+	saved, err := bs.configs.Save(cfg)
+
 	if err != nil {
+		if id == "" {
+			bs.sdk.DeleteThing(cfg.MFThing, key)
+		}
 		return Config{}, err
 	}
 	bs.configs.RemoveUnknown(cfg.ExternalKey, cfg.ExternalID)
 
-	cfg.MFThing = id
+	cfg.MFThing = saved
 
 	return cfg, nil
 }
@@ -288,15 +294,29 @@ func (bs bootstrapService) ChangeState(key, id string, state State) error {
 	return bs.configs.ChangeState(owner, id, state)
 }
 
-func (bs bootstrapService) add(key string) (mfsdk.Thing, error) {
-	thingID, err := bs.sdk.CreateThing(mfsdk.Thing{Type: thingType}, key)
-	if err != nil {
-		return mfsdk.Thing{}, err
+// Method thing retrieves Mainflux Thing creating one if an empty ID is passed.
+func (bs bootstrapService) thing(key, id string) (mfsdk.Thing, error) {
+	thingID := id
+	var err error
+
+	if id == "" {
+		thingID, err = bs.sdk.CreateThing(mfsdk.Thing{Type: thingType}, key)
+		if err != nil {
+			return mfsdk.Thing{}, err
+		}
 	}
 
 	thing, err := bs.sdk.Thing(thingID, key)
 	if err != nil {
-		return mfsdk.Thing{}, bs.sdk.DeleteThing(thingID, key)
+		if err == mfsdk.ErrNotFound {
+			return mfsdk.Thing{}, ErrNotFound
+		}
+
+		if id != "" {
+			bs.sdk.DeleteThing(thingID, key)
+		}
+
+		return mfsdk.Thing{}, ErrThings
 	}
 
 	return thing, nil

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -55,7 +55,7 @@ type Service interface {
 	// Update updates editable fields of the provided Thing.
 	Update(string, Config) error
 
-	// List returns subset of Things with given search params that belong to the
+	// List returns subset of Configs with given search params that belong to the
 	// user identified by the given key.
 	List(string, Filter, uint64, uint64) (ConfigsPage, error)
 

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -55,13 +55,14 @@ type Service interface {
 	// Update updates editable fields of the provided Thing.
 	Update(string, Config) error
 
-	// List returns subset of Things with given state that belong to the user identified by the given key.
-	List(string, Filter, uint64, uint64) ([]Config, error)
+	// List returns subset of Things with given search params that belong to the
+	// user identified by the given key.
+	List(string, Filter, uint64, uint64) (ConfigsPage, error)
 
-	// Remove removes Thing with specified key that belongs to the user identified by the given key.
+	// Remove removes Config with specified key that belongs to the user identified by the given key.
 	Remove(string, string) error
 
-	// Bootstrap returns configuration to the Thing with provided external ID using external key.
+	// Bootstrap returns Config to the Thing with provided external ID using external key.
 	Bootstrap(string, string) (Config, error)
 
 	// ChangeState changes state of the Thing with given ID and owner.
@@ -205,10 +206,10 @@ func (bs bootstrapService) Update(key string, cfg Config) error {
 	return bs.configs.Update(cfg)
 }
 
-func (bs bootstrapService) List(key string, filter Filter, offset, limit uint64) ([]Config, error) {
+func (bs bootstrapService) List(key string, filter Filter, offset, limit uint64) (ConfigsPage, error) {
 	owner, err := bs.identify(key)
 	if err != nil {
-		return []Config{}, err
+		return ConfigsPage{}, err
 	}
 
 	if filter.Unknown {

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -267,7 +267,7 @@ func TestList(t *testing.T) {
 
 	cases := []struct {
 		desc   string
-		config []bootstrap.Config
+		config bootstrap.ConfigsPage
 		filter bootstrap.Filter
 		offset uint64
 		limit  uint64
@@ -275,8 +275,13 @@ func TestList(t *testing.T) {
 		err    error
 	}{
 		{
-			desc:   "list configs",
-			config: saved[0:10],
+			desc: "list configs",
+			config: bootstrap.ConfigsPage{
+				Total:   uint64(len(saved)),
+				Offset:  0,
+				Limit:   10,
+				Configs: saved[0:10],
+			},
 			filter: bootstrap.Filter{},
 			key:    validToken,
 			offset: 0,
@@ -284,8 +289,13 @@ func TestList(t *testing.T) {
 			err:    nil,
 		},
 		{
-			desc:   "list configs with specified name",
-			config: saved[95:96],
+			desc: "list configs with specified name",
+			config: bootstrap.ConfigsPage{
+				Total:   1,
+				Offset:  0,
+				Limit:   100,
+				Configs: saved[95:96],
+			},
 			filter: bootstrap.Filter{PartialMatch: map[string]string{"name": "95"}},
 			key:    validToken,
 			offset: 0,
@@ -294,7 +304,7 @@ func TestList(t *testing.T) {
 		},
 		{
 			desc:   "list configs unauthorized",
-			config: []bootstrap.Config{},
+			config: bootstrap.ConfigsPage{},
 			filter: bootstrap.Filter{},
 			key:    invalidToken,
 			offset: 0,
@@ -302,8 +312,13 @@ func TestList(t *testing.T) {
 			err:    bootstrap.ErrUnauthorizedAccess,
 		},
 		{
-			desc:   "list last page",
-			config: saved[95:],
+			desc: "list last page",
+			config: bootstrap.ConfigsPage{
+				Total:   uint64(len(saved)),
+				Offset:  95,
+				Limit:   10,
+				Configs: saved[95:],
+			},
 			filter: bootstrap.Filter{},
 			key:    validToken,
 			offset: 95,
@@ -311,8 +326,13 @@ func TestList(t *testing.T) {
 			err:    nil,
 		},
 		{
-			desc:   "list configs with Active staate",
-			config: []bootstrap.Config{saved[41]},
+			desc: "list configs with Active staate",
+			config: bootstrap.ConfigsPage{
+				Total:   1,
+				Offset:  35,
+				Limit:   20,
+				Configs: []bootstrap.Config{saved[41]},
+			},
 			filter: bootstrap.Filter{FullMatch: map[string]string{"state": bootstrap.Active.String()}},
 			key:    validToken,
 			offset: 35,
@@ -320,8 +340,13 @@ func TestList(t *testing.T) {
 			err:    nil,
 		},
 		{
-			desc:   "list unknown configs",
-			config: []bootstrap.Config{unknownConfig},
+			desc: "list unknown configs",
+			config: bootstrap.ConfigsPage{
+				Total:   1,
+				Offset:  0,
+				Limit:   20,
+				Configs: []bootstrap.Config{unknownConfig},
+			},
 			filter: bootstrap.Filter{Unknown: true},
 			key:    validToken,
 			offset: 0,
@@ -332,7 +357,8 @@ func TestList(t *testing.T) {
 
 	for _, tc := range cases {
 		result, err := svc.List(tc.key, tc.filter, tc.offset, tc.limit)
-		assert.ElementsMatch(t, tc.config, result, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.config, result))
+		assert.ElementsMatch(t, tc.config.Configs, result.Configs, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.config.Configs, result.Configs))
+		assert.Equal(t, tc.config.Total, result.Total, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.config.Total, result.Total))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -84,6 +84,9 @@ func TestAdd(t *testing.T) {
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
 
+	neID := config
+	neID.MFThing = "non-existent"
+
 	wrongChannels := config
 	ch := channel
 	ch.ID = "invalid"
@@ -100,6 +103,12 @@ func TestAdd(t *testing.T) {
 			config: config,
 			key:    validToken,
 			err:    nil,
+		},
+		{
+			desc:   "add a config with an invalid ID",
+			config: neID,
+			key:    validToken,
+			err:    bootstrap.ErrNotFound,
 		},
 		{
 			desc:   "add a config with wrong credentials",

--- a/bootstrap/swagger.yml
+++ b/bootstrap/swagger.yml
@@ -8,7 +8,7 @@ consumes:
 produces:
   - "application/json"
 paths:
-  /configs:
+  /things/configs:
     post:
       summary: Adds new config
       description: |
@@ -65,7 +65,7 @@ paths:
           description: Missing or invalid access token provided.
         500:
           $ref: "#/responses/ServiceError"
-  /bootstrap/{externalId}:
+  /things/bootstrap/{externalId}:
     get:
       summary: Retrieves configuration
       description: |
@@ -87,7 +87,7 @@ paths:
             added to the service later.
         500:
           $ref: "#/responses/ServiceError"
-  /configs/{configId}:
+  /things/configs/{configId}:
     get:
       summary: Retrieves config info
       tags:
@@ -155,7 +155,7 @@ paths:
           description: Missing or invalid access token provided.
         500:
           $ref: "#/responses/ServiceError"
-  /state/{configId}:
+  /things/state/{configId}:
     put:
       summary: Updates Config state.
       description: |
@@ -186,7 +186,7 @@ paths:
           description: Missing or invalid access token provided.
         500:
           $ref: "#/responses/ServiceError"
-  /unknown:
+  /things/unknown/configs:
     get:
       summary: Get a list of unsucessfully bootstrapped Things
       description: |
@@ -279,6 +279,17 @@ definitions:
   ConfigList:
     type: object
     properties:
+      total:
+        type: integer
+        description: Total number of results.
+        minimum: 0
+      offset:
+        type: integer
+        description: Number of items to skip during retrieval.
+        minimum: 0
+      limit:
+        type: integer
+        description: Size of the subset to retrieve.
       configs:
         type: array
         minItems: 0

--- a/bootstrap/swagger.yml
+++ b/bootstrap/swagger.yml
@@ -287,9 +287,12 @@ definitions:
         type: integer
         description: Number of items to skip during retrieval.
         minimum: 0
+        default: 0
       limit:
         type: integer
         description: Size of the subset to retrieve.
+        maximum: 100
+        default: 10
       configs:
         type: array
         minItems: 0


### PR DESCRIPTION
### What does this do?
This PR adds Page response for listing Configs.

### Which issue(s) does this PR fix/relate to?
This PR resolves #540.

### List any changes that modify/break current functionality
Bootstrap service API is changed. An endpoint for fetching a list of Configs returns a page entity response with metadata as well as a list of Configs.

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
Yes.