### PR TITLE
MF-571 Add things and channels lists to Connection module

### DIFF
--- a/ui/elm.json
+++ b/ui/elm.json
@@ -12,6 +12,7 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.2",
             "elm/url": "1.0.0",
+            "elm-community/list-extra": "8.1.0",
             "rundis/elm-bootstrap": "5.0.0"
         },
         "indirect": {

--- a/ui/src/Channel.elm
+++ b/ui/src/Channel.elm
@@ -73,7 +73,7 @@ update msg model token =
             updateChannelList { model | limit = limit } token
 
         ProvisionChannel ->
-            ( model
+            ( { model | name = "" }
             , provision
                 (B.crossOrigin url.base url.path [])
                 token
@@ -126,8 +126,8 @@ view : Model -> Html Msg
 view model =
     Grid.container []
         [ Grid.row []
-            [ Grid.col [] [ Input.text [ Input.placeholder "offset", Input.id "offset", Input.onInput SubmitOffset ] ]
-            , Grid.col [] [ Input.text [ Input.placeholder "limit", Input.id "limit", Input.onInput SubmitLimit ] ]
+            [ Helpers.genFormField "offset" model.offset SubmitOffset
+            , Helpers.genFormField "limit" model.limit SubmitLimit
             ]
         , Grid.row []
             [ Grid.col []
@@ -139,7 +139,7 @@ view model =
                     , Table.tbody []
                         (List.append
                             [ Table.tr []
-                                [ Table.td [] [ Input.text [ Input.id "name", Input.onInput SubmitName ] ]
+                                [ Table.td [] [ Input.text [ Input.attrs [ id "name", value model.name ], Input.onInput SubmitName ] ]
                                 , Table.td [] []
                                 , Table.td [] [ Button.button [ Button.primary, Button.attrs [ Spacing.ml1 ], Button.onClick ProvisionChannel ] [ text "+" ] ]
                                 ]

--- a/ui/src/Channel.elm
+++ b/ui/src/Channel.elm
@@ -1,4 +1,4 @@
-module Channel exposing (Model, Msg(..), initial, update, view)
+module Channel exposing (Channel, Model, Msg(..), initial, update, view)
 
 import Bootstrap.Button as Button
 import Bootstrap.Form as Form
@@ -154,20 +154,10 @@ view model =
 
 genTableRows : List Channel -> List (Table.Row Msg)
 genTableRows channels =
-    let
-        parseName : Maybe String -> String
-        parseName channelName =
-            case channelName of
-                Just name ->
-                    name
-
-                Nothing ->
-                    ""
-    in
     List.map
         (\channel ->
             Table.tr []
-                [ Table.td [] [ text (parseName channel.name) ]
+                [ Table.td [] [ text (Helpers.parseName channel.name) ]
                 , Table.td [] [ text channel.id ]
                 , Table.td [] [ Button.button [ Button.primary, Button.attrs [ Spacing.ml1 ], Button.onClick (RemoveChannel channel.id) ] [ text "-" ] ]
                 ]

--- a/ui/src/Helpers.elm
+++ b/ui/src/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (buildQueryParamList, response)
+module Helpers exposing (buildQueryParamList, parseName, response)
 
 import Bootstrap.Grid as Grid
 import Html exposing (hr, p, text)
@@ -37,3 +37,13 @@ buildQueryParamList offset limit query =
                         B.string (Tuple.first tpl) query.limit
         )
         [ ( "offset", offset ), ( "limit", limit ) ]
+
+
+parseName : Maybe String -> String
+parseName thingName =
+    case thingName of
+        Just name ->
+            name
+
+        Nothing ->
+            ""

--- a/ui/src/Helpers.elm
+++ b/ui/src/Helpers.elm
@@ -1,7 +1,12 @@
-module Helpers exposing (buildQueryParamList, parseName, response)
+module Helpers exposing (buildQueryParamList, genFormField, parseName, response)
 
+import Bootstrap.Form as Form
+import Bootstrap.Form.Input as Input
 import Bootstrap.Grid as Grid
+import Bootstrap.Grid.Col as Col
+import Bootstrap.Grid.Row as Row
 import Html exposing (hr, p, text)
+import Html.Attributes exposing (..)
 import Url.Builder as B
 
 
@@ -47,3 +52,13 @@ parseName thingName =
 
         Nothing ->
             ""
+
+
+genFormField : String -> String -> (String -> msg) -> Grid.Column msg
+genFormField txt val msg =
+    Grid.col []
+        [ Form.formInline []
+            [ Form.label [] [ text (txt ++ ": ") ]
+            , Input.text [ Input.attrs [ placeholder txt, id txt, value val ], Input.onInput msg ]
+            ]
+        ]

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -247,12 +247,12 @@ view model =
 
             menu =
                 if loggedIn then
-                    [ ButtonGroup.linkButton [ Button.primary, Button.onClick Account, buttonAttrs ] [ text "Account" ]
-                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Things, buttonAttrs ] [ text "Things" ]
-                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Channels, buttonAttrs ] [ text "Channels" ]
-                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Connection, buttonAttrs ] [ text "Connection" ]
-                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Messages, buttonAttrs ] [ text "Messages" ]
-                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Version, buttonAttrs ] [ text "Version" ]
+                    [ ButtonGroup.linkButton [ Button.primary, Button.onClick Account, buttonAttrs ] [ text "account" ]
+                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Things, buttonAttrs ] [ text "things" ]
+                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Channels, buttonAttrs ] [ text "channels" ]
+                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Connection, buttonAttrs ] [ text "connection" ]
+                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Messages, buttonAttrs ] [ text "messages" ]
+                    , ButtonGroup.linkButton [ Button.primary, Button.onClick Version, buttonAttrs ] [ text "version" ]
                     ]
 
                 else
@@ -289,7 +289,7 @@ view model =
           Grid.container []
             [ CDN.stylesheet -- creates an inline style node with the Bootstrap CSS
             , Grid.row []
-                [ Grid.col [] [ h1 [] [ text "Gateflux" ] ] ]
+                [ Grid.col [] [ h1 [] [ text model.view ] ] ]
             , Grid.row []
                 [ Grid.col []
                     [ -- In this column we put the button group defined below

--- a/ui/src/Thing.elm
+++ b/ui/src/Thing.elm
@@ -1,4 +1,4 @@
-module Thing exposing (Model, Msg(..), initial, update, view)
+module Thing exposing (Model, Msg(..), Thing, initial, update, view)
 
 import Bootstrap.Button as Button
 import Bootstrap.Form as Form
@@ -163,20 +163,10 @@ view model =
 
 genTableRows : List Thing -> List (Table.Row Msg)
 genTableRows things =
-    let
-        parseName : Maybe String -> String
-        parseName thingName =
-            case thingName of
-                Just name ->
-                    name
-
-                Nothing ->
-                    ""
-    in
     List.map
         (\thing ->
             Table.tr []
-                [ Table.td [] [ text (parseName thing.name) ]
+                [ Table.td [] [ text (Helpers.parseName thing.name) ]
                 , Table.td [] [ text thing.id ]
                 , Table.td [] [ text thing.type_ ]
                 , Table.td [] [ text thing.key ]

--- a/ui/src/Thing.elm
+++ b/ui/src/Thing.elm
@@ -78,7 +78,7 @@ update msg model token =
             updateThingList { model | limit = limit } token
 
         ProvisionThing ->
-            ( model
+            ( { model | name = "", type_ = "" }
             , provision
                 (B.crossOrigin url.base url.path [])
                 token
@@ -129,11 +129,9 @@ view : Model -> Html Msg
 view model =
     Grid.container []
         [ Grid.row []
-            [ Grid.col [] [ Input.text [ Input.placeholder "offset", Input.id "offset", Input.onInput SubmitOffset ] ]
-            , Grid.col [] [ Input.text [ Input.placeholder "limit", Input.id "limit", Input.onInput SubmitLimit ] ]
+            [ Helpers.genFormField "offset" model.offset SubmitOffset
+            , Helpers.genFormField "limit" model.limit SubmitLimit
             ]
-
-        -- , Helpers.response model.response
         , Grid.row []
             [ Grid.col []
                 [ Table.simpleTable
@@ -146,9 +144,9 @@ view model =
                     , Table.tbody []
                         (List.append
                             [ Table.tr []
-                                [ Table.td [] [ Input.text [ Input.id "name", Input.onInput SubmitName ] ]
+                                [ Table.td [] [ Input.text [ Input.attrs [ id "name", value model.name ], Input.onInput SubmitName ] ]
                                 , Table.td [] []
-                                , Table.td [] [ Input.text [ Input.id "type", Input.onInput SubmitType ] ]
+                                , Table.td [] [ Input.text [ Input.attrs [ id "type", value model.type_ ], Input.onInput SubmitType ] ]
                                 , Table.td [] []
                                 , Table.td [] [ Button.button [ Button.primary, Button.attrs [ Spacing.ml1 ], Button.onClick ProvisionThing ] [ text "+" ] ]
                                 ]


### PR DESCRIPTION
Signed-off-by: Darko Draskovic <darko.draskovic@gmail.com>

### What does this do?

Add things and channels checkbox lists to Connection module. The lists refresh automatically depending on offset and limit params.

### Have you included tests for your changes?

No.

### Did you document any new/modified functionality?

No.