### PR TITLE
MF-583 - Correct cmd/mongodb-reader HTTPServer log Info

### DIFF
--- a/cmd/mongodb-reader/main.go
+++ b/cmd/mongodb-reader/main.go
@@ -167,5 +167,5 @@ func newService(db *mongo.Database, logger logger.Logger) readers.MessageReposit
 func startHTTPServer(repo readers.MessageRepository, tc mainflux.ThingsServiceClient, port string, logger logger.Logger, errs chan error) {
 	p := fmt.Sprintf(":%s", port)
 	logger.Info(fmt.Sprintf("Mongo reader service started, exposed port %s", port))
-	errs <- http.ListenAndServe(p, api.MakeHandler(repo, tc, "cassandra-reader"))
+	errs <- http.ListenAndServe(p, api.MakeHandler(repo, tc, "mongodb-reader"))
 }


### PR DESCRIPTION
### What does this do?

correct `cmd/moanog-reader` HTTPServer log info typo error 

### Which issue(s) does this PR fix/relate to?

This PR resolves #583 

### List any changes that modify/break current functionality

There are no such changes

### Have you included tests for your changes?

N/A

### Did you document any new/modified functionality?

There are no such changes

### Notes

just fix typo error
