### PR TITLE
MF-552 - Use event sourcing to keep Bootstrap service in sync with Things service

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -45,9 +45,9 @@ The service is configured using the environment variables presented in the follo
 | MF_BOOTSTRAP_DB_SSL_ROOT_CERT | Path to the PEM encoded root certificate file                           |                       |
 | MF_BOOTSTRAP_CLIENT_TLS       | Flag that indicates if TLS should be turned on                          | false                 |
 | MF_BOOTSTRAP_CA_CERTS         | Path to trusted CAs in PEM format                                       |                       |
-| MF_BOOTSTRAP_PORT             | Bootstrap service HTTP port                                             | 8181                  |
-| MF_BOOTSTRAP_SERVER_CERT      | Path to server certificate in pem format                                | 8181                  |
-| MF_BOOTSTRAP_SERVER_KEY       | Path to server key in pem format                                        | 8181                  |
+| MF_BOOTSTRAP_PORT             | Bootstrap service HTTP port                                             | 8180                  |
+| MF_BOOTSTRAP_SERVER_CERT      | Path to server certificate in pem format                                |                       |
+| MF_BOOTSTRAP_SERVER_KEY       | Path to server key in pem format                                        |                       |
 | MF_SDK_BASE_URL               | Base url for Mainflux SDK                                               | http://localhost      |
 | MF_SDK_THINGS_PREFIX          | SDK prefix for Things service                                           |                       |
 | MF_USERS_URL                  | Users service URL                                                       | localhost:8181        |

--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -94,17 +94,10 @@ func updateEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		channels := []bootstrap.Channel{}
-		for _, c := range req.Channels {
-			channels = append(channels, bootstrap.Channel{ID: c})
-		}
-
 		config := bootstrap.Config{
-			MFThing:    req.id,
-			MFChannels: channels,
-			Name:       req.Name,
-			Content:    req.Content,
-			State:      req.State,
+			MFThing: req.id,
+			Name:    req.Name,
+			Content: req.Content,
 		}
 
 		if err := svc.Update(req.key, config); err != nil {
@@ -113,6 +106,27 @@ func updateEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 
 		res := configRes{
 			id:      config.MFThing,
+			created: false,
+		}
+
+		return res, nil
+	}
+}
+
+func updateConnEndpoint(svc bootstrap.Service) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req := request.(updateConnReq)
+
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.UpdateConnections(req.key, req.id, req.Channels); err != nil {
+			return nil, err
+		}
+
+		res := configRes{
+			id:      req.id,
 			created: false,
 		}
 

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -360,8 +360,7 @@ func TestView(t *testing.T) {
 
 		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", tc.desc, tc.status, res.StatusCode))
 		var view config
-		err = json.NewDecoder(res.Body).Decode(&view)
-		if err != io.EOF {
+		if err := json.NewDecoder(res.Body).Decode(&view); err != io.EOF {
 			assert.Nil(t, err, fmt.Sprintf("Decoding expeceted to succeed %s: %s", tc.desc, err))
 		}
 

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -93,15 +93,19 @@ func newConfig(channels []bootstrap.Channel) bootstrap.Config {
 
 func (tr testRequest) make() (*http.Response, error) {
 	req, err := http.NewRequest(tr.method, tr.url, tr.body)
+
 	if err != nil {
 		return nil, err
 	}
+
 	if tr.token != "" {
 		req.Header.Set("Authorization", tr.token)
 	}
+
 	if tr.contentType != "" {
 		req.Header.Set("Content-Type", tr.contentType)
 	}
+
 	return tr.client.Do(req)
 }
 
@@ -186,7 +190,7 @@ func TestAdd(t *testing.T) {
 			auth:        validToken,
 			contentType: contentType,
 			status:      http.StatusCreated,
-			location:    "/configs/1",
+			location:    "/things/configs/1",
 		},
 		{
 			desc:        "add a config with wring content type",

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -133,7 +133,7 @@ func (lm *loggingMiddleware) ChangeState(key, id string, state bootstrap.State) 
 	return lm.svc.ChangeState(key, id, state)
 }
 
-func (lm *loggingMiddleware) UpdateChannel(channel bootstrap.Channel) (err error) {
+func (lm *loggingMiddleware) UpdateChannelHandler(channel bootstrap.Channel) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method updateChannel for channel %s took %s to complete", channel.ID, time.Since(begin))
 		if err != nil {
@@ -143,10 +143,10 @@ func (lm *loggingMiddleware) UpdateChannel(channel bootstrap.Channel) (err error
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.UpdateChannel(channel)
+	return lm.svc.UpdateChannelHandler(channel)
 }
 
-func (lm *loggingMiddleware) RemoveConfig(id string) (err error) {
+func (lm *loggingMiddleware) RemoveConfigHandler(id string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method removeConfig for config %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -156,10 +156,10 @@ func (lm *loggingMiddleware) RemoveConfig(id string) (err error) {
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.RemoveConfig(id)
+	return lm.svc.RemoveConfigHandler(id)
 }
 
-func (lm *loggingMiddleware) RemoveChannel(id string) (err error) {
+func (lm *loggingMiddleware) RemoveChannelHandler(id string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method removeChannel for channel %s took %s to complete", id, time.Since(begin))
 		if err != nil {
@@ -169,5 +169,18 @@ func (lm *loggingMiddleware) RemoveChannel(id string) (err error) {
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.RemoveChannel(id)
+	return lm.svc.RemoveChannelHandler(id)
+}
+
+func (lm *loggingMiddleware) DisconnectThingHandler(channelID, thingID string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method disconnectThingHandler for channel %s and thing %s took %s to complete", channelID, thingID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.DisconnectThingHandler(channelID, thingID)
 }

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -145,3 +145,16 @@ func (lm *loggingMiddleware) RemoveConfig(id string) (err error) {
 
 	return lm.svc.RemoveConfig(id)
 }
+
+func (lm *loggingMiddleware) RemoveChannel(id string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method removeChannel for channel %s took %s to complete", id, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RemoveChannel(id)
+}

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -132,3 +132,16 @@ func (lm *loggingMiddleware) UpdateChannel(channel bootstrap.Channel) (err error
 
 	return lm.svc.UpdateChannel(channel)
 }
+
+func (lm *loggingMiddleware) RemoveConfig(id string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method removeConfig for config %s took %s to complete", id, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RemoveConfig(id)
+}

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -68,6 +68,19 @@ func (lm *loggingMiddleware) Update(key string, thing bootstrap.Config) (err err
 	return lm.svc.Update(key, thing)
 }
 
+func (lm *loggingMiddleware) UpdateConnections(key, id string, connections []string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method update_connections for key %s and thing %s took %s to complete", key, id, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.UpdateConnections(key, id, connections)
+}
+
 func (lm *loggingMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (res bootstrap.ConfigsPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method list for key %s and offset %d and limit %d took %s to complete", key, offset, limit, time.Since(begin))

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -119,3 +119,16 @@ func (lm *loggingMiddleware) ChangeState(key, id string, state bootstrap.State) 
 
 	return lm.svc.ChangeState(key, id, state)
 }
+
+func (lm *loggingMiddleware) UpdateChannel(channel bootstrap.Channel) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method updateChannel for channel %s took %s to complete", channel.ID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.UpdateChannel(channel)
+}

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -122,7 +122,7 @@ func (lm *loggingMiddleware) Bootstrap(externalKey, externalID string) (cfg boot
 
 func (lm *loggingMiddleware) ChangeState(key, id string, state bootstrap.State) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method changeState for key %s and thing %s took %s to complete", key, id, time.Since(begin))
+		message := fmt.Sprintf("Method change_state for key %s and thing %s took %s to complete", key, id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -135,7 +135,7 @@ func (lm *loggingMiddleware) ChangeState(key, id string, state bootstrap.State) 
 
 func (lm *loggingMiddleware) UpdateChannelHandler(channel bootstrap.Channel) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method updateChannel for channel %s took %s to complete", channel.ID, time.Since(begin))
+		message := fmt.Sprintf("Method update_channel_handler for channel %s took %s to complete", channel.ID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -148,7 +148,7 @@ func (lm *loggingMiddleware) UpdateChannelHandler(channel bootstrap.Channel) (er
 
 func (lm *loggingMiddleware) RemoveConfigHandler(id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method removeConfig for config %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method remove_config_handler for config %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -161,7 +161,7 @@ func (lm *loggingMiddleware) RemoveConfigHandler(id string) (err error) {
 
 func (lm *loggingMiddleware) RemoveChannelHandler(id string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method removeChannel for channel %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method remove_channel_handler for channel %s took %s to complete", id, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -174,7 +174,7 @@ func (lm *loggingMiddleware) RemoveChannelHandler(id string) (err error) {
 
 func (lm *loggingMiddleware) DisconnectThingHandler(channelID, thingID string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method disconnectThingHandler for channel %s and thing %s took %s to complete", channelID, thingID, time.Since(begin))
+		message := fmt.Sprintf("Method disconnect_thing_handler for channel %s and thing %s took %s to complete", channelID, thingID, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -99,8 +99,8 @@ func (mm *metricsMiddleware) ChangeState(id, key string, state bootstrap.State) 
 
 func (mm *metricsMiddleware) UpdateChannel(channel bootstrap.Channel) (err error) {
 	defer func(begin time.Time) {
-		mm.counter.With("method", "change_state").Add(1)
-		mm.latency.With("method", "change_state").Observe(time.Since(begin).Seconds())
+		mm.counter.With("method", "update_channel").Add(1)
+		mm.latency.With("method", "update_channel").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	return mm.svc.UpdateChannel(channel)
@@ -108,9 +108,18 @@ func (mm *metricsMiddleware) UpdateChannel(channel bootstrap.Channel) (err error
 
 func (mm *metricsMiddleware) RemoveConfig(id string) (err error) {
 	defer func(begin time.Time) {
-		mm.counter.With("method", "change_state").Add(1)
-		mm.latency.With("method", "change_state").Observe(time.Since(begin).Seconds())
+		mm.counter.With("method", "remove_config").Add(1)
+		mm.latency.With("method", "remove_config").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	return mm.svc.RemoveConfig(id)
+}
+
+func (mm *metricsMiddleware) RemoveChannel(id string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "remove_channel").Add(1)
+		mm.latency.With("method", "remove_channel").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.RemoveChannel(id)
 }

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -105,3 +105,12 @@ func (mm *metricsMiddleware) UpdateChannel(channel bootstrap.Channel) (err error
 
 	return mm.svc.UpdateChannel(channel)
 }
+
+func (mm *metricsMiddleware) RemoveConfig(id string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "change_state").Add(1)
+		mm.latency.With("method", "change_state").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.RemoveConfig(id)
+}

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -106,29 +106,38 @@ func (mm *metricsMiddleware) ChangeState(id, key string, state bootstrap.State) 
 	return mm.svc.ChangeState(id, key, state)
 }
 
-func (mm *metricsMiddleware) UpdateChannel(channel bootstrap.Channel) (err error) {
+func (mm *metricsMiddleware) UpdateChannelHandler(channel bootstrap.Channel) (err error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "update_channel").Add(1)
 		mm.latency.With("method", "update_channel").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.UpdateChannel(channel)
+	return mm.svc.UpdateChannelHandler(channel)
 }
 
-func (mm *metricsMiddleware) RemoveConfig(id string) (err error) {
+func (mm *metricsMiddleware) RemoveConfigHandler(id string) (err error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "remove_config").Add(1)
 		mm.latency.With("method", "remove_config").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.RemoveConfig(id)
+	return mm.svc.RemoveConfigHandler(id)
 }
 
-func (mm *metricsMiddleware) RemoveChannel(id string) (err error) {
+func (mm *metricsMiddleware) RemoveChannelHandler(id string) (err error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "remove_channel").Add(1)
 		mm.latency.With("method", "remove_channel").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.RemoveChannel(id)
+	return mm.svc.RemoveChannelHandler(id)
+}
+
+func (mm *metricsMiddleware) DisconnectThingHandler(channelID, thingID string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "disconnect_thing_handler").Add(1)
+		mm.latency.With("method", "disconnect_thing_handler").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.DisconnectThingHandler(channelID, thingID)
 }

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -96,3 +96,12 @@ func (mm *metricsMiddleware) ChangeState(id, key string, state bootstrap.State) 
 
 	return mm.svc.ChangeState(id, key, state)
 }
+
+func (mm *metricsMiddleware) UpdateChannel(channel bootstrap.Channel) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "change_state").Add(1)
+		mm.latency.With("method", "change_state").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.UpdateChannel(channel)
+}

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -54,11 +54,20 @@ func (mm *metricsMiddleware) View(id, key string) (saved bootstrap.Config, err e
 
 func (mm *metricsMiddleware) Update(key string, thing bootstrap.Config) (err error) {
 	defer func(begin time.Time) {
-		mm.counter.With("method", "view").Add(1)
-		mm.latency.With("method", "view").Observe(time.Since(begin).Seconds())
+		mm.counter.With("method", "update").Add(1)
+		mm.latency.With("method", "update").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	return mm.svc.Update(key, thing)
+}
+
+func (mm *metricsMiddleware) UpdateConnections(key, id string, connections []string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "update_connections").Add(1)
+		mm.latency.With("method", "update_connections").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.UpdateConnections(key, id, connections)
 }
 
 func (mm *metricsMiddleware) List(key string, filter bootstrap.Filter, offset, limit uint64) (saved bootstrap.ConfigsPage, err error) {

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -53,12 +53,10 @@ func (req entityReq) validate() error {
 }
 
 type updateReq struct {
-	key      string
-	id       string
-	Channels []string        `json:"channels"`
-	Name     string          `json:"name"`
-	Content  string          `json:"content"`
-	State    bootstrap.State `json:"state"`
+	key     string
+	id      string
+	Name    string `json:"name"`
+	Content string `json:"content"`
 }
 
 func (req updateReq) validate() error {
@@ -70,9 +68,21 @@ func (req updateReq) validate() error {
 		return bootstrap.ErrMalformedEntity
 	}
 
-	// Can't explicitly update state to NewThing or Created.
-	if req.State != bootstrap.Inactive &&
-		req.State != bootstrap.Active {
+	return nil
+}
+
+type updateConnReq struct {
+	key      string
+	id       string
+	Channels []string `json:"channels"`
+}
+
+func (req updateConnReq) validate() error {
+	if req.key == "" {
+		return bootstrap.ErrUnauthorizedAccess
+	}
+
+	if req.id == "" {
 		return bootstrap.ErrMalformedEntity
 	}
 

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -84,40 +84,61 @@ func TestEntityReqValidation(t *testing.T) {
 
 func TestUpdateReqValidation(t *testing.T) {
 	cases := []struct {
-		desc  string
-		key   string
-		id    string
-		state bootstrap.State
-		err   error
+		desc string
+		key  string
+		id   string
+		err  error
 	}{
 		{
-			desc:  "empty key",
-			key:   "",
-			id:    "id",
-			state: bootstrap.State(1),
-			err:   bootstrap.ErrUnauthorizedAccess,
+			desc: "empty key",
+			key:  "",
+			id:   "id",
+			err:  bootstrap.ErrUnauthorizedAccess,
 		},
 		{
-			desc:  "empty id",
-			key:   "key",
-			id:    "",
-			state: bootstrap.State(0),
-			err:   bootstrap.ErrMalformedEntity,
-		},
-		{
-			desc:  "invalid state",
-			key:   "key",
-			id:    "id",
-			state: bootstrap.State(14),
-			err:   bootstrap.ErrMalformedEntity,
+			desc: "empty id",
+			key:  "key",
+			id:   "",
+			err:  bootstrap.ErrMalformedEntity,
 		},
 	}
 
 	for _, tc := range cases {
 		req := updateReq{
-			key:   tc.key,
-			id:    tc.id,
-			State: tc.state,
+			key: tc.key,
+			id:  tc.id,
+		}
+
+		err := req.validate()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestUpdateConnReqValidation(t *testing.T) {
+	cases := []struct {
+		desc string
+		key  string
+		id   string
+		err  error
+	}{
+		{
+			desc: "empty key",
+			key:  "",
+			id:   "id",
+			err:  bootstrap.ErrUnauthorizedAccess,
+		},
+		{
+			desc: "empty id",
+			key:  "key",
+			id:   "",
+			err:  bootstrap.ErrMalformedEntity,
+		},
+	}
+
+	for _, tc := range cases {
+		req := updateReq{
+			key: tc.key,
+			id:  tc.id,
 		}
 
 		err := req.validate()

--- a/bootstrap/api/responses.go
+++ b/bootstrap/api/responses.go
@@ -53,7 +53,7 @@ func (res configRes) Code() int {
 func (res configRes) Headers() map[string]string {
 	if res.created {
 		return map[string]string{
-			"Location": fmt.Sprintf("/configs/%s", res.id),
+			"Location": fmt.Sprintf("/things/configs/%s", res.id),
 		}
 	}
 

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -62,6 +62,12 @@ func MakeHandler(svc bootstrap.Service, reader bootstrap.ConfigReader) http.Hand
 		encodeResponse,
 		opts...))
 
+	r.Put("/things/configs/connections/:id", kithttp.NewServer(
+		updateConnEndpoint(svc),
+		decodeUpdateConnRequest,
+		encodeResponse,
+		opts...))
+
 	r.Get("/things/configs", kithttp.NewServer(
 		listEndpoint(svc),
 		decodeListRequest,
@@ -117,6 +123,20 @@ func decodeUpdateRequest(_ context.Context, r *http.Request) (interface{}, error
 	}
 
 	req := updateReq{key: r.Header.Get("Authorization")}
+	req.id = bone.GetValue(r, "id")
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func decodeUpdateConnRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	if r.Header.Get("Content-Type") != contentType {
+		return nil, errUnsupportedContentType
+	}
+
+	req := updateConnReq{key: r.Header.Get("Authorization")}
 	req.id = bone.GetValue(r, "id")
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, err

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -73,7 +73,11 @@ type ConfigRepository interface {
 
 	// Update performs and update to an existing Config. A non-nil error is returned
 	// to indicate operation failure.
-	Update(Config, []string) error
+	Update(Config) error
+
+	// UpdateConnections updates a list of Channels the Config is connected to
+	// adding new Channels if needed.
+	UpdateConnections(string, string, []Channel, []string) error
 
 	// Remove removes the Config having the provided identifier, that is owned
 	// by the specified user.
@@ -88,8 +92,14 @@ type ConfigRepository interface {
 	// RetrieveUnknown returns a subset of unsuccessfully bootstrapped Things.
 	RetrieveUnknown(uint64, uint64) ConfigsPage
 
-	//Exist retrieves IDs of those channels from the given list that exist in DB.
-	Exist(string, []string) ([]string, error)
+	//ListExisting retrieves IDs of those channels from the given list that exist in DB.
+	ListExisting(string, []string) ([]string, error)
+
+	// Methods RemoveThing, UpdateChannel, and RemoveChannel are related to
+	// event sourcing. That's why these methods surpass ownership check.
+
+	// RemoveThing removes Config for Thing with an ID extracted from an event.
+	RemoveThing(string) error
 
 	// UpdateChannel updates channel extracting data from received event.
 	UpdateChannel(Channel) error

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -7,13 +7,6 @@
 
 package bootstrap
 
-const (
-	// Inactive Thing is created, but not able to exchange messages using Mainflux.
-	Inactive State = iota
-	// Active Thing is created, configured, and whitelisted.
-	Active
-)
-
 // Config represents Configuration entity. It wraps information about external entity
 // as well as info about corresponding Mainflux entities.
 // MFThing represents corresponding Mainflux Thing ID.
@@ -92,18 +85,22 @@ type ConfigRepository interface {
 	// RetrieveUnknown returns a subset of unsuccessfully bootstrapped Things.
 	RetrieveUnknown(uint64, uint64) ConfigsPage
 
-	//ListExisting retrieves IDs of those channels from the given list that exist in DB.
+	// ListExisting retrieves IDs of those channels from the given list that exist in DB.
 	ListExisting(string, []string) ([]string, error)
 
 	// Methods RemoveThing, UpdateChannel, and RemoveChannel are related to
 	// event sourcing. That's why these methods surpass ownership check.
 
-	// RemoveThing removes Config for Thing with an ID extracted from an event.
+	// RemoveThing removes Config of the Thing with the given ID.
 	RemoveThing(string) error
 
-	// UpdateChannel updates channel extracting data from received event.
+	// UpdateChannel updates channel with the given ID.
 	UpdateChannel(Channel) error
 
-	// RemoveChannel removes channel extracting id from received event.
-	RemoveChannel(id string) error
+	// RemoveChannel removes channel with the given ID.
+	RemoveChannel(string) error
+
+	// DisconnectHandler changes state of the Config when the corresponding Thing is
+	// disconnected from the Channel.
+	DisconnectThing(string, string) error
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -85,8 +85,8 @@ type ConfigRepository interface {
 	// RetrieveUnknown returns a subset of unsuccessfully bootstrapped Things.
 	RetrieveUnknown(uint64, uint64) ConfigsPage
 
-	// ListExisting retrieves IDs of those channels from the given list that exist in DB.
-	ListExisting(string, []string) ([]string, error)
+	// ListExisting retrieves those channels from the given list that exist in DB.
+	ListExisting(string, []string) ([]Channel, error)
 
 	// Methods RemoveThing, UpdateChannel, and RemoveChannel are related to
 	// event sourcing. That's why these methods surpass ownership check.

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -93,4 +93,7 @@ type ConfigRepository interface {
 
 	// UpdateChannel updates channel extracting data from received event.
 	UpdateChannel(Channel) error
+
+	// RemoveChannel removes channel extracting id from received event.
+	RemoveChannel(id string) error
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -58,7 +58,7 @@ type ConfigsPage struct {
 type ConfigRepository interface {
 	// Save persists the Config. Successful operation is indicated by non-nil
 	// error response.
-	Save(Config) (string, error)
+	Save(Config, []string) (string, error)
 
 	// RetrieveByID retrieves the Config having the provided identifier, that is owned
 	// by the specified user.
@@ -73,7 +73,7 @@ type ConfigRepository interface {
 
 	// Update performs and update to an existing Config. A non-nil error is returned
 	// to indicate operation failure.
-	Update(Config) error
+	Update(Config, []string) error
 
 	// Remove removes the Config having the provided identifier, that is owned
 	// by the specified user.
@@ -88,7 +88,6 @@ type ConfigRepository interface {
 	// RetrieveUnknown returns a subset of unsuccessfully bootstrapped Things.
 	RetrieveUnknown(uint64, uint64) ConfigsPage
 
-	// RemoveUnknown removes unsuccessfully bootstrapped Thing. This is done once the
-	// corresponding Config is added to the list of existing configs (Save method).
-	RemoveUnknown(string, string) error
+	//Exist retrieves IDs of those channels from the given list that exist in DB.
+	Exist(string, []string) ([]string, error)
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -90,4 +90,7 @@ type ConfigRepository interface {
 
 	//Exist retrieves IDs of those channels from the given list that exist in DB.
 	Exist(string, []string) ([]string, error)
+
+	// UpdateChannel updates channel extracting data from received event.
+	UpdateChannel(Channel) error
 }

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -500,6 +500,15 @@ func (cr configRepository) UpdateChannel(channel bootstrap.Channel) error {
 	return nil
 }
 
+func (cr configRepository) RemoveChannel(id string) error {
+	q := `DELETE FROM channels WHERE mainflux_channel = $1`
+	if _, err := cr.db.Exec(q, id); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (cr configRepository) rollback(content string, tx *sql.Tx, err error) {
 	cr.log.Error(fmt.Sprintf("%s %s", content, err))
 	if err := tx.Rollback(); err != nil {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -120,7 +120,7 @@ func (cr configRepository) RetrieveByID(key, id string) (bootstrap.Config, error
 
 	for rows.Next() {
 		c := bootstrap.Channel{}
-		if err = rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read connected thing due to %s", err))
 			return bootstrap.Config{}, err
 		}
@@ -208,7 +208,7 @@ func (cr configRepository) RetrieveByExternalID(externalKey, externalID string) 
 
 	for rows.Next() {
 		c := bootstrap.Channel{}
-		if err = rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read connected thing due to %s", err))
 			return bootstrap.Config{}, err
 		}
@@ -251,13 +251,13 @@ func (cr configRepository) UpdateConnections(key, id string, channels []bootstra
 		return err
 	}
 
-	if err = insertChannels(key, channels, tx); err != nil {
+	if err := insertChannels(key, channels, tx); err != nil {
 		cr.rollback("Failed to insert Channels during the update", tx, err)
 
 		return err
 	}
 
-	if err = updateConnections(key, id, connections, tx); err != nil {
+	if err := updateConnections(key, id, connections, tx); err != nil {
 		if e, ok := err.(*pq.Error); ok {
 			if e.Code.Name() == fkViolation && e.Constraint == connConstraintErr {
 				return bootstrap.ErrNotFound
@@ -319,7 +319,7 @@ func (cr configRepository) ListExisting(key string, ids []string) ([]bootstrap.C
 	var channels []bootstrap.Channel
 	for rows.Next() {
 		var ch bootstrap.Channel
-		if err = rows.Scan(&ch.ID, &ch.Name, &ch.Metadata); err != nil {
+		if err := rows.Scan(&ch.ID, &ch.Name, &ch.Metadata); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved channels due to %s", err))
 			return []bootstrap.Channel{}, nil
 		}
@@ -355,7 +355,7 @@ func (cr configRepository) RetrieveUnknown(offset, limit uint64) bootstrap.Confi
 	items := []bootstrap.Config{}
 	for rows.Next() {
 		c := bootstrap.Config{}
-		if err = rows.Scan(&c.ExternalID, &c.ExternalKey); err != nil {
+		if err := rows.Scan(&c.ExternalID, &c.ExternalKey); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
 			return bootstrap.ConfigsPage{}
 		}
@@ -437,6 +437,7 @@ func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter) (str
 
 func (cr configRepository) rollback(content string, tx *sql.Tx, err error) {
 	cr.log.Error(fmt.Sprintf("%s %s", content, err))
+
 	if err := tx.Rollback(); err != nil {
 		cr.log.Error(fmt.Sprintf("Failed to rollback due to %s", err))
 	}

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -9,7 +9,6 @@ package postgres
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -19,10 +18,11 @@ import (
 )
 
 const (
-	duplicateErr     = "unique_violation"
-	uuidErr          = "invalid input syntax for type uuid"
-	configFieldsNum  = 8
-	channelFieldsNum = 3
+	duplicateErr    = "unique_violation"
+	uuidErr         = "invalid input syntax for type uuid"
+	configFieldsNum = 8
+	chanFieldsNum   = 3
+	connFieldsNum   = 2
 )
 
 var _ bootstrap.ConfigRepository = (*configRepository)(nil)
@@ -44,46 +44,62 @@ func NewConfigRepository(db *sql.DB, log logger.Logger) bootstrap.ConfigReposito
 	return &configRepository{db: db, log: log}
 }
 
-func nullString(s string) sql.NullString {
-	if s == "" {
-		return sql.NullString{}
-	}
+func (cr configRepository) Save(cfg bootstrap.Config, connections []string) (string, error) {
+	q := `INSERT INTO configs (mainflux_thing, owner, name, mainflux_key, external_id, external_key, content, state)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 
-	return sql.NullString{
-		String: s,
-		Valid:  true,
-	}
-}
-
-func (cr configRepository) Save(cfg bootstrap.Config) (string, error) {
-	q := `INSERT INTO configs (mainflux_thing, owner, name, mainflux_key, external_id, external_key, content, state, mainflux_channels)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-
-	channels := toDBChannels(cfg.MFChannels)
-	jsn, err := json.Marshal(channels)
-	if err != nil {
-		return "", bootstrap.ErrMalformedEntity
-	}
 	content := nullString(cfg.Content)
 	name := nullString(cfg.Name)
+	tx, err := cr.db.Begin()
 
-	if _, err := cr.db.Exec(q, cfg.MFThing, cfg.Owner, name, cfg.MFKey, cfg.ExternalID, cfg.ExternalKey, content, cfg.State, jsn); err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == duplicateErr {
-			return "", bootstrap.ErrConflict
-		}
+	if err != nil {
 		return "", err
+	}
+
+	if _, err := tx.Exec(q, cfg.MFThing, cfg.Owner, name, cfg.MFKey, cfg.ExternalID, cfg.ExternalKey, content, cfg.State); err != nil {
+		e := err
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == duplicateErr {
+			e = bootstrap.ErrConflict
+		}
+
+		cr.rollback("Failed to insert a Config", tx, err)
+
+		return "", e
+	}
+
+	if err := insertChannels(cfg, tx); err != nil {
+		cr.rollback("Failed to insert Channels", tx, err)
+
+		return "", err
+	}
+
+	if err := insertConnections(cfg, connections, tx); err != nil {
+		cr.rollback("Failed to insert connections", tx, err)
+
+		return "", err
+	}
+
+	q = "DELETE FROM unknown_configs WHERE external_id = $1 AND external_key = $2"
+
+	if _, err := tx.Exec(q, cfg.ExternalID, cfg.ExternalKey); err != nil {
+		cr.rollback("Failed to remove from unknown", tx, err)
+
+		return "", err
+	}
+
+	if err := tx.Commit(); err != nil {
+		cr.rollback("Failed to commit Config save", tx, err)
 	}
 
 	return cfg.MFThing, nil
 }
 
 func (cr configRepository) RetrieveByID(key, id string) (bootstrap.Config, error) {
-	q := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state, mainflux_channels FROM configs WHERE mainflux_thing = $1 AND owner = $2`
+	q := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state FROM configs WHERE mainflux_thing = $1 AND owner = $2`
 	cfg := bootstrap.Config{MFThing: id, Owner: key, MFChannels: []bootstrap.Channel{}}
 	var name, content sql.NullString
-	var chs []byte
 	if err := cr.db.QueryRow(q, id, key).
-		Scan(&cfg.MFThing, &cfg.MFKey, &cfg.ExternalID, &cfg.ExternalKey, &name, &content, &cfg.State, &chs); err != nil {
+		Scan(&cfg.MFThing, &cfg.MFKey, &cfg.ExternalID, &cfg.ExternalKey, &name, &content, &cfg.State); err != nil {
 		empty := bootstrap.Config{}
 		if err == sql.ErrNoRows {
 			return empty, bootstrap.ErrNotFound
@@ -91,8 +107,26 @@ func (cr configRepository) RetrieveByID(key, id string) (bootstrap.Config, error
 		return empty, err
 	}
 
-	if err := json.Unmarshal(chs, &cfg.MFChannels); err != nil {
+	q = `SELECT mainflux_channel, name, metadata FROM channels ch
+	INNER JOIN connections conn
+	ON ch.mainflux_channel = conn.channel_id AND ch.owner = conn.config_owner
+	WHERE conn.config_id = $1 AND conn.config_owner = $2`
+
+	rows, err := cr.db.Query(q, cfg.MFThing, cfg.Owner)
+	if err != nil {
+		cr.log.Error(fmt.Sprintf("Failed to retrieve connected due to %s", err))
 		return bootstrap.Config{}, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		c := bootstrap.Channel{}
+		if err = rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
+			cr.log.Error(fmt.Sprintf("Failed to read connected thing due to %s", err))
+			return bootstrap.Config{}, err
+		}
+
+		cfg.MFChannels = append(cfg.MFChannels, c)
 	}
 
 	cfg.Content = content.String
@@ -105,8 +139,8 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 	search, params := cr.retrieveAll(key, filter)
 	n := len(params)
 
-	q := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state, mainflux_channels
-	 			 FROM configs %s ORDER BY mainflux_thing LIMIT $%d OFFSET $%d`
+	q := `SELECT mainflux_thing, mainflux_key, external_id, external_key, name, content, state
+	FROM configs %s ORDER BY mainflux_thing LIMIT $%d OFFSET $%d`
 	q = fmt.Sprintf(q, search, n+1, n+2)
 
 	rows, err := cr.db.Query(q, append(params, limit, offset)...)
@@ -120,14 +154,8 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 	configs := []bootstrap.Config{}
 
 	for rows.Next() {
-		var chs []byte
 		c := bootstrap.Config{Owner: key}
-		if err := rows.Scan(&c.MFThing, &c.MFKey, &c.ExternalID, &c.ExternalKey, &name, &content, &c.State, &chs); err != nil {
-			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
-			return bootstrap.ConfigsPage{}
-		}
-
-		if err := json.Unmarshal(chs, &c.MFChannels); err != nil {
+		if err := rows.Scan(&c.MFThing, &c.MFKey, &c.ExternalID, &c.ExternalKey, &name, &content, &c.State); err != nil {
 			cr.log.Error(fmt.Sprintf("Failed to read retrieved config due to %s", err))
 			return bootstrap.ConfigsPage{}
 		}
@@ -154,18 +182,11 @@ func (cr configRepository) RetrieveAll(key string, filter bootstrap.Filter, offs
 }
 
 func (cr configRepository) RetrieveByExternalID(externalKey, externalID string) (bootstrap.Config, error) {
-	q := `SELECT mainflux_thing, owner, mainflux_key, name, content, state, mainflux_channels
-		  FROM configs WHERE external_key = $1 AND external_id = $2`
-
+	q := `SELECT mainflux_thing, mainflux_key, owner, name, content, state FROM configs WHERE external_key = $1 AND external_id = $2`
+	cfg := bootstrap.Config{ExternalID: externalID, ExternalKey: externalKey, MFChannels: []bootstrap.Channel{}}
 	var name, content sql.NullString
-	cfg := bootstrap.Config{
-		ExternalID:  externalID,
-		ExternalKey: externalKey,
-	}
-
-	var chs []byte
 	if err := cr.db.QueryRow(q, externalKey, externalID).
-		Scan(&cfg.MFThing, &cfg.Owner, &cfg.MFKey, &name, &content, &cfg.State, &chs); err != nil {
+		Scan(&cfg.MFThing, &cfg.MFKey, &cfg.Owner, &name, &content, &cfg.State); err != nil {
 		empty := bootstrap.Config{}
 		if err == sql.ErrNoRows {
 			return empty, bootstrap.ErrNotFound
@@ -173,41 +194,70 @@ func (cr configRepository) RetrieveByExternalID(externalKey, externalID string) 
 		return empty, err
 	}
 
-	if err := json.Unmarshal(chs, &cfg.MFChannels); err != nil {
+	q = `SELECT mainflux_channel, name, metadata FROM channels ch
+	INNER JOIN connections conn
+	ON ch.mainflux_channel = conn.channel_id AND ch.owner = conn.config_owner
+	WHERE conn.config_id = $1 AND conn.config_owner = $2`
+
+	rows, err := cr.db.Query(q, cfg.MFThing, cfg.Owner)
+	if err != nil {
+		cr.log.Error(fmt.Sprintf("Failed to retrieve connected due to %s", err))
 		return bootstrap.Config{}, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		c := bootstrap.Channel{}
+		if err = rows.Scan(&c.ID, &c.Name, &c.Metadata); err != nil {
+			cr.log.Error(fmt.Sprintf("Failed to read connected thing due to %s", err))
+			return bootstrap.Config{}, err
+		}
+
+		cfg.MFChannels = append(cfg.MFChannels, c)
 	}
 
 	cfg.Content = content.String
+	cfg.Name = name.String
 
 	return cfg, nil
 }
 
-func (cr configRepository) Update(cfg bootstrap.Config) error {
-	q := `UPDATE configs SET name = $1, content = $2, state = $3, mainflux_channels = $4 WHERE mainflux_thing = $5 AND owner = $6`
+func (cr configRepository) Update(cfg bootstrap.Config, connections []string) error {
+	q := `UPDATE configs SET name = $1, content = $2, state = $3 WHERE mainflux_thing = $4 AND owner = $5`
 
-	channels := toDBChannels(cfg.MFChannels)
-
-	jsn, err := json.Marshal(channels)
-	if err != nil {
-		cr.log.Error(fmt.Sprintf("Failed to serialize channels list due to %s", err))
-		return bootstrap.ErrMalformedEntity
-	}
-
-	name := nullString(cfg.Name)
 	content := nullString(cfg.Content)
+	name := nullString(cfg.Name)
+	tx, err := cr.db.Begin()
 
-	res, err := cr.db.Exec(q, name, content, cfg.State, jsn, cfg.MFThing, cfg.Owner)
 	if err != nil {
 		return err
 	}
 
-	cnt, err := res.RowsAffected()
-	if err != nil {
+	if _, err := tx.Exec(q, name, content, cfg.State, cfg.MFThing, cfg.Owner); err != nil {
+		e := err
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == duplicateErr {
+			e = bootstrap.ErrConflict
+		}
+
+		cr.rollback("Failed to update a Config", tx, err)
+
+		return e
+	}
+
+	if err = insertChannels(cfg, tx); err != nil {
+		cr.rollback("Failed to insert Channels during the update", tx, err)
+
 		return err
 	}
 
-	if cnt == 0 {
-		return bootstrap.ErrNotFound
+	if err = updateConnections(cfg, connections, tx); err != nil {
+		cr.rollback("Failed to update connections during the update", tx, err)
+
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		cr.rollback("Failed to commit Config update", tx, err)
 	}
 
 	return nil
@@ -238,6 +288,28 @@ func (cr configRepository) ChangeState(key, id string, state bootstrap.State) er
 	}
 
 	return nil
+}
+
+func (cr configRepository) Exist(key string, ids []string) ([]string, error) {
+	q := "SELECT mainflux_channel FROM channels WHERE owner = $1 AND mainflux_channel IN ($2)"
+
+	rows, err := cr.db.Query(q, key, pq.Array(ids))
+	if err != nil {
+		return []string{}, err
+	}
+
+	var connections []string
+	for rows.Next() {
+		var ch string
+		if err = rows.Scan(&ch); err != nil {
+			cr.log.Error(fmt.Sprintf("Failed to read retrieved channels due to %s", err))
+			return []string{}, nil
+		}
+
+		connections = append(connections, ch)
+	}
+
+	return connections, nil
 }
 
 func (cr configRepository) SaveUnknown(key, id string) error {
@@ -289,13 +361,6 @@ func (cr configRepository) RetrieveUnknown(offset, limit uint64) bootstrap.Confi
 	}
 }
 
-func (cr configRepository) RemoveUnknown(key, id string) error {
-	q := `DELETE FROM unknown_configs WHERE external_id = $1 AND external_key = $2`
-	_, err := cr.db.Exec(q, id, key)
-
-	return err
-}
-
 func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter) (string, []interface{}) {
 	template := `WHERE owner = $1 %s`
 	params := []interface{}{key}
@@ -319,17 +384,121 @@ func (cr configRepository) retrieveAll(key string, filter bootstrap.Filter) (str
 	return fmt.Sprintf(template, f), params
 }
 
-func toDBChannels(channels []bootstrap.Channel) []dbChannel {
-	ret := []dbChannel{}
-	for _, ch := range channels {
-		c := dbChannel{
-			ID:       ch.ID,
-			Name:     ch.Name,
-			Metadata: ch.Metadata,
-		}
-
-		ret = append(ret, c)
+func insertChannels(cfg bootstrap.Config, tx *sql.Tx) error {
+	if len(cfg.MFChannels) == 0 {
+		return nil
 	}
 
-	return ret
+	q := `INSERT INTO channels (mainflux_channel, owner, name, metadata) VALUES `
+	v := []interface{}{cfg.Owner}
+	var vals []string
+	// Since the first value is owner, start with the second one.
+	count := 2
+	for _, ch := range cfg.MFChannels {
+		vals = append(vals, fmt.Sprintf("($%d, $1, $%d, $%d)", count, count+1, count+2))
+		v = append(v, ch.ID, ch.Name, ch.Metadata)
+		count += chanFieldsNum
+	}
+
+	q = fmt.Sprintf("%s%s%s", q, strings.Join(vals, ","), "ON CONFLICT (mainflux_channel) DO NOTHING")
+	_, err := tx.Exec(q, v...)
+
+	return err
+}
+
+func insertConnections(cfg bootstrap.Config, connections []string, tx *sql.Tx) error {
+	if len(connections) == 0 {
+		return nil
+	}
+
+	q := `INSERT INTO connections (config_id, channel_id, config_owner, channel_owner) VALUES`
+	v := []interface{}{cfg.MFThing, cfg.Owner}
+	var vals []string
+
+	// Since the first value is Config ID and the second and third
+	// are Config owner, start with  the second one.
+	count := 3
+	for _, id := range connections {
+		vals = append(vals, fmt.Sprintf("($1, $%d, $2, $2)", count))
+		v = append(v, id)
+		count++
+	}
+
+	q = fmt.Sprintf("%s%s", q, strings.Join(vals, ","))
+	_, err := tx.Exec(q, v...)
+
+	return err
+}
+
+// Updating connections is removing old and adding new ones.
+func updateConnections(cfg bootstrap.Config, connections []string, tx *sql.Tx) error {
+	if len(connections) == 0 {
+		return nil
+	}
+
+	q := `DELETE FROM connections
+	WHERE config_id = $1 AND config_owner = $2 AND channel_owner = $2
+	AND channel_id NOT IN ($3)`
+
+	v := []interface{}{cfg.MFThing, cfg.Owner}
+	v = append(v, pq.Array(connections))
+
+	res, err := tx.Exec(q, v...)
+
+	if err != nil {
+		return err
+	}
+
+	cnt, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	q = `INSERT INTO connections (config_id, external_id, channel_id, config_owner, channel_owner) VALUES`
+	v = []interface{}{cfg.MFThing, cfg.ExternalID, cfg.Owner}
+	var vals []string
+
+	// Since the first value is Config ID and the second is Config
+	// owner, start with  the second one.
+	count := 4
+	for _, id := range connections {
+		vals = append(vals, fmt.Sprintf("($1, $2, $%d, $3, $3)", count))
+		v = append(v, id)
+		count++
+	}
+
+	// Add connections for current list of channels. Ignore if already exists.
+	q = fmt.Sprintf("%s%s%s", q, strings.Join(vals, ","), "ON CONFLICT (config_id, config_owner, channel_id, channel_owner) DO NOTHING")
+	if _, err := tx.Exec(q, v...); err != nil {
+		return err
+	}
+
+	if cnt == 0 {
+		return nil
+	}
+
+	q = `DELETE FROM channels ch WHERE ch.mainflux_channel NOT IN (
+    SELECT channel_id FROM connections)`
+
+	_, err = tx.Exec(q)
+
+	return err
+}
+
+func (cr configRepository) rollback(content string, tx *sql.Tx, err error) {
+	cr.log.Error(fmt.Sprintf("%s %s", content, err))
+	if err := tx.Rollback(); err != nil {
+		cr.log.Error(fmt.Sprintf("Failed to rollback due to %s", err))
+	}
+}
+
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+
+	return sql.NullString{
+		String: s,
+		Valid:  true,
+	}
 }

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -264,8 +264,14 @@ func (cr configRepository) Update(cfg bootstrap.Config, connections []string) er
 }
 
 func (cr configRepository) Remove(key, id string) error {
-	q := `DELETE FROM configs WHERE mainflux_thing = $1 AND owner = $2`
-	cr.db.Exec(q, id, key)
+	params := []interface{}{id}
+	q := `DELETE FROM configs WHERE mainflux_thing = $1`
+	if key != "" {
+		q = fmt.Sprintf("%s%s", q, " AND owner = $2")
+		params = append(params, key)
+	}
+
+	cr.db.Exec(q, params...)
 
 	return nil
 }

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -285,7 +285,7 @@ func (cr configRepository) ChangeState(key, id string, state bootstrap.State) er
 }
 
 func (cr configRepository) ListExisting(key string, ids []string) ([]string, error) {
-	q := "SELECT mainflux_channel FROM channels WHERE owner = $1 AND mainflux_channel IN ($2)"
+	q := "SELECT mainflux_channel FROM channels WHERE owner = $1 AND mainflux_channel = ANY ($2)"
 
 	rows, err := cr.db.Query(q, key, pq.Array(ids))
 	if err != nil {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -485,6 +485,15 @@ func updateConnections(cfg bootstrap.Config, connections []string, tx *sql.Tx) e
 	return err
 }
 
+func (cr configRepository) UpdateChannel(channel bootstrap.Channel) error {
+	q := `UPDATE channels SET name = $1, metadata = $2 WHERE mainflux_channel = $3`
+	if _, err := cr.db.Exec(q, channel.Name, channel.Metadata, channel.ID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (cr configRepository) rollback(content string, tx *sql.Tx, err error) {
 	cr.log.Error(fmt.Sprintf("%s %s", content, err))
 	if err := tx.Rollback(); err != nil {

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -21,46 +21,88 @@ import (
 
 const numConfigs = 10
 
-var config = bootstrap.Config{
-	MFThing:     "mf-thing",
-	MFKey:       "mf-key",
-	ExternalID:  "external-id",
-	ExternalKey: "external-key",
-	Owner:       "user@email.com",
-	MFChannels: []bootstrap.Channel{
-		bootstrap.Channel{ID: "1", Name: "name 1", Metadata: "{\"meta\":1}"},
-		bootstrap.Channel{ID: "2", Name: "name 2", Metadata: "{\"meta\":2}"},
-	},
-	Content: "content",
-	State:   bootstrap.Inactive,
-}
+var (
+	config = bootstrap.Config{
+		MFThing:     "mf-thing",
+		MFKey:       "mf-key",
+		ExternalID:  "external-id",
+		ExternalKey: "external-key",
+		Owner:       "user@email.com",
+		MFChannels: []bootstrap.Channel{
+			bootstrap.Channel{ID: "1", Name: "name 1", Metadata: "{\"meta\":1}"},
+			bootstrap.Channel{ID: "2", Name: "name 2", Metadata: "{\"meta\":2}"},
+		},
+		Content: "content",
+		State:   bootstrap.Inactive,
+	}
+
+	channels = []string{"1", "2"}
+)
 
 func TestSave(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
+	diff := "different"
+
+	duplicateThing := config
+	duplicateThing.ExternalID = diff
+	duplicateThing.MFKey = diff
+	duplicateThing.MFChannels = []bootstrap.Channel{}
+
+	duplicateExternal := config
+	duplicateExternal.MFThing = diff
+	duplicateExternal.MFKey = diff
+	duplicateExternal.MFChannels = []bootstrap.Channel{}
+
+	duplicateChannels := config
+	duplicateChannels.ExternalID = diff
+	duplicateChannels.MFKey = diff
+	duplicateChannels.MFThing = diff
+
 	cases := []struct {
-		desc   string
-		config bootstrap.Config
-		err    error
+		desc        string
+		config      bootstrap.Config
+		connections []string
+		err         error
 	}{
 		{
-			desc:   "save a config",
-			config: config,
-			err:    nil,
+			desc:        "save a config",
+			config:      config,
+			connections: channels,
+			err:         nil,
 		},
 		{
-			desc:   "save config with same external ID",
-			config: config,
-			err:    bootstrap.ErrConflict,
+			desc:        "save config with same Thing ID",
+			config:      duplicateThing,
+			connections: nil,
+			err:         bootstrap.ErrConflict,
+		},
+		{
+			desc:        "save config with same external ID",
+			config:      duplicateExternal,
+			connections: nil,
+			err:         bootstrap.ErrConflict,
+		},
+		{
+			desc:        "save config with same Channels",
+			config:      duplicateChannels,
+			connections: channels,
+			err:         bootstrap.ErrConflict,
 		},
 	}
 	for _, tc := range cases {
-		_, err := repo.Save(tc.config)
+		_, err := repo.Save(tc.config, tc.connections)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 
 func TestRetrieveByID(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
 	c := config
 	// Use UUID to prevent conflicts.
 	id := uuid.NewV4().String()
@@ -68,7 +110,7 @@ func TestRetrieveByID(t *testing.T) {
 	c.MFThing = id
 	c.ExternalID = id
 	c.ExternalKey = id
-	id, err := repo.Save(c)
+	id, err = repo.Save(c, channels)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	cases := []struct {
 		desc  string
@@ -106,8 +148,11 @@ func TestRetrieveByID(t *testing.T) {
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
+
 func TestRetrieveAll(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
 
 	for i := 0; i < numConfigs; i++ {
 		c := config
@@ -117,12 +162,19 @@ func TestRetrieveAll(t *testing.T) {
 		c.Name = fmt.Sprintf("name %d", i)
 		c.MFThing = id
 		c.MFKey = id
+
 		if i%2 == 0 {
 			c.State = bootstrap.Active
 		}
-		_, err := repo.Save(c)
+
+		if i > 0 {
+			c.MFChannels = nil
+		}
+
+		_, err := repo.Save(c, channels)
 		require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	}
+
 	cases := []struct {
 		desc   string
 		owner  string
@@ -178,6 +230,9 @@ func TestRetrieveAll(t *testing.T) {
 
 func TestRetrieveByExternalID(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
 	c := config
 	// Use UUID to prevent conflicts.
 	id := uuid.NewV4().String()
@@ -185,7 +240,7 @@ func TestRetrieveByExternalID(t *testing.T) {
 	c.MFThing = id
 	c.ExternalID = id
 	c.ExternalKey = id
-	_, err := repo.Save(c)
+	_, err = repo.Save(c, channels)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 
 	cases := []struct {
@@ -221,6 +276,9 @@ func TestRetrieveByExternalID(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
 	c := config
 	// Use UUID to prevent conflicts.
 	id := uuid.NewV4().String()
@@ -228,16 +286,11 @@ func TestUpdate(t *testing.T) {
 	c.MFThing = id
 	c.ExternalID = id
 	c.ExternalKey = id
-	saved, err := repo.Save(c)
+	_, err = repo.Save(c, channels)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 
-	id = uuid.NewV4().String()
-	c.MFThing = saved
-	c.ExternalID = id
-	c.ExternalKey = id
-	c.MFChannels = append(config.MFChannels, bootstrap.Channel{ID: "3", Name: "name 3", Metadata: `{"meta": 3}`})
-	c.State = bootstrap.Active
 	c.Content = "new content"
+	c.Name = "new name"
 
 	wrongOwner := c
 	wrongOwner.Owner = "3"
@@ -265,8 +318,11 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
-func TestRemove(t *testing.T) {
+func TestUpdateConnections(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
 	c := config
 	// Use UUID to prevent conflicts.
 	id := uuid.NewV4().String()
@@ -274,7 +330,70 @@ func TestRemove(t *testing.T) {
 	c.MFThing = id
 	c.ExternalID = id
 	c.ExternalKey = id
-	id, err := repo.Save(c)
+	_, err = repo.Save(c, channels)
+	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
+	// Use UUID to prevent conflicts.
+	id = uuid.NewV4().String()
+	c.MFKey = id
+	c.MFThing = id
+	c.ExternalID = id
+	c.ExternalKey = id
+	c.MFChannels = []bootstrap.Channel{}
+	_, err = repo.Save(c, []string{channels[0]})
+	require.Nil(t, err, fmt.Sprintf("Saving a config expected to succeed: %s.\n", err))
+
+	cases := []struct {
+		desc        string
+		key         string
+		id          string
+		channels    []bootstrap.Channel
+		connections []string
+		err         error
+	}{
+		{
+			desc:        "update connections of non-existing config",
+			key:         config.Owner,
+			id:          "unknown",
+			channels:    nil,
+			connections: []string{channels[1]},
+			err:         bootstrap.ErrNotFound,
+		},
+		{
+			desc:        "update connections",
+			key:         config.Owner,
+			id:          c.MFThing,
+			channels:    nil,
+			connections: []string{channels[1]},
+			err:         nil,
+		},
+		{
+			desc:        "update connections no channels",
+			key:         config.Owner,
+			id:          c.MFThing,
+			channels:    nil,
+			connections: nil,
+			err:         nil,
+		},
+	}
+	for _, tc := range cases {
+		err := repo.UpdateConnections(tc.key, tc.id, tc.channels, tc.connections)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestRemove(t *testing.T) {
+	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
+	c := config
+	// Use UUID to prevent conflicts.
+	id := uuid.NewV4().String()
+	c.MFKey = id
+	c.MFThing = id
+	c.ExternalID = id
+	c.ExternalKey = id
+	id, err = repo.Save(c, channels)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 
 	// Removal works the same for both existing and non-existing
@@ -290,6 +409,9 @@ func TestRemove(t *testing.T) {
 
 func TestChangeState(t *testing.T) {
 	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
 	c := config
 	// Use UUID to prevent conflicts.
 	id := uuid.NewV4().String()
@@ -297,7 +419,7 @@ func TestChangeState(t *testing.T) {
 	c.MFThing = id
 	c.ExternalID = id
 	c.ExternalKey = id
-	saved, err := repo.Save(c)
+	saved, err := repo.Save(c, channels)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 
 	cases := []struct {
@@ -337,6 +459,53 @@ func TestChangeState(t *testing.T) {
 	for _, tc := range cases {
 		err := repo.ChangeState(tc.owner, tc.id, tc.state)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func testListExisting(t *testing.T) {
+	repo := postgres.NewConfigRepository(db, testLog)
+	err := deleteChannels(repo)
+	require.Nil(t, err, "Channels cleanup expected to succeed.")
+
+	c := config
+	// Use UUID to prevent conflicts.
+	id := uuid.NewV4().String()
+	c.MFKey = id
+	c.MFThing = id
+	c.ExternalID = id
+	c.ExternalKey = id
+	_, err = repo.Save(c, channels)
+	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
+
+	cases := []struct {
+		desc        string
+		key         string
+		connections []string
+		existing    []string
+	}{
+		{
+			desc:        "list all existing channels",
+			key:         c.Owner,
+			connections: channels,
+			existing:    channels,
+		},
+		{
+			desc:        "list a subset of existing channels",
+			key:         c.Owner,
+			connections: []string{channels[0], "5"},
+			existing:    []string{channels[0]},
+		},
+		{
+			desc:        "list a subset of existing channels",
+			key:         c.Owner,
+			connections: []string{"5", "6"},
+			existing:    []string{},
+		},
+	}
+	for _, tc := range cases {
+		existing, err := repo.ListExisting(tc.key, tc.connections)
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error: %s", tc.desc, err))
+		assert.ElementsMatch(t, tc.existing, existing, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.existing, existing))
 	}
 }
 
@@ -402,16 +571,12 @@ func TestRetrieveUnknown(t *testing.T) {
 	}
 }
 
-func TestRemoveUnknown(t *testing.T) {
-	repo := postgres.NewConfigRepository(db, testLog)
-
-	id := uuid.NewV4().String()
-	repo.SaveUnknown(id, id)
-
-	// Removal works the same for both existing and non-existing
-	// (removed) config
-	for i := 0; i < 2; i++ {
-		err := repo.RemoveUnknown(id, id)
-		require.Nil(t, err, fmt.Sprintf("%d: failed to remove config due to: %s", i, err))
+func deleteChannels(repo bootstrap.ConfigRepository) error {
+	for _, ch := range channels {
+		if err := repo.RemoveChannel(ch); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }

--- a/bootstrap/postgres/init.go
+++ b/bootstrap/postgres/init.go
@@ -53,25 +53,42 @@ func migrateDB(db *sql.DB) error {
 				Id: "configs_1",
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS configs (
-						mainflux_thing    TEXT UNIQUE NOT NULL,
-						owner             VARCHAR(254),
-						name 			  TEXT,
-						mainflux_key      CHAR(36) UNIQUE NOT NULL,
-						mainflux_channels jsonb,
-						external_id       TEXT UNIQUE NOT NULL,
-						external_key 	  TEXT NOT NULL,
-						content  		  TEXT,
-						state             BIGINT NOT NULL,
-						PRIMARY KEY (mainflux_thing, external_id)
+						mainflux_thing TEXT UNIQUE NOT NULL,
+						owner          VARCHAR(254),
+						name           TEXT,
+						mainflux_key   CHAR(36) UNIQUE NOT NULL,
+						external_id    TEXT UNIQUE NOT NULL,
+						external_key   TEXT NOT NULL,
+						content  	   TEXT,
+						state          BIGINT NOT NULL,
+						PRIMARY KEY (mainflux_thing, owner)
 					)`,
 					`CREATE TABLE IF NOT EXISTS unknown_configs (
-						external_id       TEXT UNIQUE NOT NULL,
-						external_key 	  TEXT NOT NULL,
+						external_id  TEXT UNIQUE NOT NULL,
+						external_key TEXT NOT NULL,
 						PRIMARY KEY (external_id, external_key)
+					)`,
+					`CREATE TABLE IF NOT EXISTS channels (
+						mainflux_channel TEXT UNIQUE NOT NULL,
+						owner    		 VARCHAR(254),
+						name     		 TEXT,
+						metadata 		 JSON,
+						PRIMARY KEY (mainflux_channel, owner)
+					)`,
+					`CREATE TABLE IF NOT EXISTS connections (
+						config_id     TEXT,
+						config_owner  VARCHAR(256),
+						channel_id    TEXT,
+						channel_owner VARCHAR(256),
+						FOREIGN KEY (channel_id, channel_owner) REFERENCES channels (mainflux_channel, owner) ON DELETE CASCADE ON UPDATE CASCADE,
+						FOREIGN KEY (config_id, config_owner) REFERENCES configs (mainflux_thing, owner) ON DELETE CASCADE ON UPDATE CASCADE,
+						PRIMARY KEY (channel_id, channel_owner, config_id, config_owner)
 					)`,
 				},
 				Down: []string{
+					"DROP TABLE connections",
 					"DROP TABLE configs",
+					"DROP TABLE channels",
 					"DROP TABLE unknown_configs",
 				},
 			},

--- a/bootstrap/postgres/init.go
+++ b/bootstrap/postgres/init.go
@@ -76,10 +76,10 @@ func migrateDB(db *sql.DB) error {
 						PRIMARY KEY (mainflux_channel, owner)
 					)`,
 					`CREATE TABLE IF NOT EXISTS connections (
-						config_id     TEXT,
-						config_owner  VARCHAR(256),
 						channel_id    TEXT,
 						channel_owner VARCHAR(256),
+						config_id     TEXT,
+						config_owner  VARCHAR(256),
 						FOREIGN KEY (channel_id, channel_owner) REFERENCES channels (mainflux_channel, owner) ON DELETE CASCADE ON UPDATE CASCADE,
 						FOREIGN KEY (config_id, config_owner) REFERENCES configs (mainflux_thing, owner) ON DELETE CASCADE ON UPDATE CASCADE,
 						PRIMARY KEY (channel_id, channel_owner, config_id, config_owner)

--- a/bootstrap/postgres/init.go
+++ b/bootstrap/postgres/init.go
@@ -96,5 +96,6 @@ func migrateDB(db *sql.DB) error {
 	}
 
 	_, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
+
 	return err
 }

--- a/bootstrap/redis/events.go
+++ b/bootstrap/redis/events.go
@@ -9,3 +9,9 @@ type updateChannelEvent struct {
 	name     string
 	metadata string
 }
+
+// Connection event is either connect or disconnect event.
+type disconnectEvent struct {
+	thingID   string
+	channelID string
+}

--- a/bootstrap/redis/events.go
+++ b/bootstrap/redis/events.go
@@ -1,0 +1,11 @@
+package redis
+
+type removeEvent struct {
+	id string
+}
+
+type updateChannelEvent struct {
+	id       string
+	name     string
+	metadata string
+}

--- a/bootstrap/redis/streams.go
+++ b/bootstrap/redis/streams.go
@@ -101,9 +101,7 @@ func decodeRemoveChannel(event map[string]interface{}) removeEvent {
 }
 
 func (es eventStore) handleRemoveThing(rte removeEvent) error {
-	println("remove thing")
-	return nil
-	// return es.svc.RemoveThing(rte.id)
+	return es.svc.RemoveConfig(rte.id)
 }
 
 func (es eventStore) handleUpdateChannel(uce updateChannelEvent) error {

--- a/bootstrap/redis/streams.go
+++ b/bootstrap/redis/streams.go
@@ -107,9 +107,12 @@ func (es eventStore) handleRemoveThing(rte removeEvent) error {
 }
 
 func (es eventStore) handleUpdateChannel(uce updateChannelEvent) error {
-	println("update chann")
-	return nil
-	// return es.svc.UpdateChannel(uce.id, cm.AppID)
+	channel := bootstrap.Channel{
+		ID:       uce.id,
+		Name:     uce.name,
+		Metadata: uce.metadata,
+	}
+	return es.svc.UpdateChannel(channel)
 }
 
 func (es eventStore) handleRemoveChannel(rce removeEvent) error {

--- a/bootstrap/redis/streams.go
+++ b/bootstrap/redis/streams.go
@@ -114,9 +114,7 @@ func (es eventStore) handleUpdateChannel(uce updateChannelEvent) error {
 }
 
 func (es eventStore) handleRemoveChannel(rce removeEvent) error {
-	println("remove chann")
-	return nil
-	// return es.svc.RemoveChannel(rce.id)
+	return es.svc.RemoveChannel(rce.id)
 }
 
 func read(event map[string]interface{}, key, def string) string {

--- a/bootstrap/redis/streams.go
+++ b/bootstrap/redis/streams.go
@@ -1,0 +1,128 @@
+package redis
+
+import (
+	"fmt"
+
+	"github.com/go-redis/redis"
+	"github.com/mainflux/mainflux/bootstrap"
+	"github.com/mainflux/mainflux/logger"
+)
+
+const (
+	stream = "mainflux.things"
+	group  = "mainflux.bootstrap"
+
+	thingPrefix = "thing."
+	thingRemove = thingPrefix + "remove"
+
+	channelPrefix = "channel."
+	channelUpdate = channelPrefix + "update"
+	channelRemove = channelPrefix + "remove"
+)
+
+// EventStore represents event source for things and channels provisioning.
+type EventStore interface {
+	// Subscribes to given subject and receives events.
+	Subscribe(string)
+}
+
+type eventStore struct {
+	svc      bootstrap.Service
+	client   *redis.Client
+	consumer string
+	logger   logger.Logger
+}
+
+// NewEventStore returns new event store instance.
+func NewEventStore(svc bootstrap.Service, client *redis.Client, consumer string, log logger.Logger) EventStore {
+	return eventStore{
+		svc:      svc,
+		client:   client,
+		consumer: consumer,
+		logger:   log,
+	}
+}
+
+func (es eventStore) Subscribe(subject string) {
+	es.client.XGroupCreateMkStream(stream, group, "$").Err()
+	for {
+		streams, err := es.client.XReadGroup(&redis.XReadGroupArgs{
+			Group:    group,
+			Consumer: es.consumer,
+			Streams:  []string{stream, ">"},
+			Count:    100,
+		}).Result()
+		if err != nil || len(streams) == 0 {
+			continue
+		}
+
+		for _, msg := range streams[0].Messages {
+			event := msg.Values
+
+			var err error
+			switch event["operation"] {
+			case thingRemove:
+				rte := decodeRemoveThing(event)
+				err = es.handleRemoveThing(rte)
+			case channelUpdate:
+				uce := decodeUpdateChannel(event)
+				err = es.handleUpdateChannel(uce)
+			case channelRemove:
+				rce := decodeRemoveChannel(event)
+				err = es.handleRemoveChannel(rce)
+			}
+			if err != nil {
+				es.logger.Warn(fmt.Sprintf("Failed to handle event sourcing: %s", err.Error()))
+				break
+			}
+			es.client.XAck(stream, group, msg.ID)
+		}
+	}
+}
+
+func decodeRemoveThing(event map[string]interface{}) removeEvent {
+	return removeEvent{
+		id: read(event, "id", ""),
+	}
+}
+
+func decodeUpdateChannel(event map[string]interface{}) updateChannelEvent {
+	return updateChannelEvent{
+		id:       read(event, "id", ""),
+		name:     read(event, "name", ""),
+		metadata: read(event, "metadata", ""),
+	}
+}
+
+func decodeRemoveChannel(event map[string]interface{}) removeEvent {
+	return removeEvent{
+		id: read(event, "id", ""),
+	}
+}
+
+func (es eventStore) handleRemoveThing(rte removeEvent) error {
+	println("remove thing")
+	return nil
+	// return es.svc.RemoveThing(rte.id)
+}
+
+func (es eventStore) handleUpdateChannel(uce updateChannelEvent) error {
+	println("update chann")
+	return nil
+	// return es.svc.UpdateChannel(uce.id, cm.AppID)
+}
+
+func (es eventStore) handleRemoveChannel(rce removeEvent) error {
+	println("remove chann")
+	return nil
+	// return es.svc.RemoveChannel(rce.id)
+}
+
+func read(event map[string]interface{}, key, def string) string {
+	val, ok := event[key].(string)
+	if !ok {
+		return def
+	}
+
+	return val
+}

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -70,6 +70,9 @@ type Service interface {
 
 	// UpdateChannel updates Channel with data received from an event.
 	UpdateChannel(Channel) error
+
+	// RemoveConfig removes Configuration with id received from an event.
+	RemoveConfig(string) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -233,18 +236,6 @@ func (bs bootstrapService) Remove(key, id string) error {
 		return err
 	}
 
-	thing, err := bs.configs.RetrieveByID(owner, id)
-	if err != nil {
-		if err == ErrNotFound {
-			return nil
-		}
-		return err
-	}
-
-	if err := bs.sdk.DeleteThing(thing.MFThing, key); err != nil {
-		return ErrThings
-	}
-
 	return bs.configs.Remove(owner, id)
 }
 
@@ -304,6 +295,10 @@ func (bs bootstrapService) ChangeState(key, id string, state State) error {
 
 func (bs bootstrapService) UpdateChannel(channel Channel) error {
 	return bs.configs.UpdateChannel(channel)
+}
+
+func (bs bootstrapService) RemoveConfig(id string) error {
+	return bs.configs.Remove("", id)
 }
 
 // Method thing retrieves Mainflux Thing creating one if an empty ID is passed.

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -74,14 +74,17 @@ type Service interface {
 	// Methods RemoveConfig, UpdateChannel, and RemoveChannel are used as
 	// handlers for events. That's why these methods surpass ownership check.
 
-	// RemoveConfig removes Configuration with id received from an event.
-	RemoveConfig(string) error
+	// RemoveConfigHandler removes Configuration with id received from an event.
+	RemoveConfigHandler(string) error
 
-	// UpdateChannel updates Channel with data received from an event.
-	UpdateChannel(Channel) error
+	// UpdateChannelHandler updates Channel with data received from an event.
+	UpdateChannelHandler(Channel) error
 
-	// RemoveChannel removes Channel with id received from an event.
-	RemoveChannel(string) error
+	// RemoveChannelHandler removes Channel with id received from an event.
+	RemoveChannelHandler(string) error
+
+	// DisconnectHandler changes state of the Config when connect/disconnect event occurs.
+	DisconnectThingHandler(string, string) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -308,16 +311,20 @@ func (bs bootstrapService) ChangeState(key, id string, state State) error {
 	return bs.configs.ChangeState(owner, id, state)
 }
 
-func (bs bootstrapService) UpdateChannel(channel Channel) error {
+func (bs bootstrapService) UpdateChannelHandler(channel Channel) error {
 	return bs.configs.UpdateChannel(channel)
 }
 
-func (bs bootstrapService) RemoveConfig(id string) error {
-	return bs.configs.Remove("", id)
+func (bs bootstrapService) RemoveConfigHandler(id string) error {
+	return bs.configs.RemoveThing(id)
 }
 
-func (bs bootstrapService) RemoveChannel(id string) error {
+func (bs bootstrapService) RemoveChannelHandler(id string) error {
 	return bs.configs.RemoveChannel(id)
+}
+
+func (bs bootstrapService) DisconnectThingHandler(channelID, thingID string) error {
+	return bs.configs.DisconnectThing(channelID, thingID)
 }
 
 func (bs bootstrapService) identify(token string) (string, error) {

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -46,13 +46,13 @@ var _ Service = (*bootstrapService)(nil)
 // Service specifies an API that must be fulfilled by the domain service
 // implementation, and all of its decorators (e.g. logging & metrics).
 type Service interface {
-	// Add adds new Thing to the user identified by the provided key.
+	// Add adds new Thing Config to the user identified by the provided key.
 	Add(string, Config) (Config, error)
 
-	// View returns Thing with given ID belonging to the user identified by the given key.
+	// View returns Thing Config with given ID belonging to the user identified by the given key.
 	View(string, string) (Config, error)
 
-	// Update updates editable fields of the provided Thing.
+	// Update updates editable fields of the provided Config.
 	Update(string, Config) error
 
 	// List returns subset of Configs with given search params that belong to the
@@ -132,6 +132,7 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 
 	if err != nil {
 		if id == "" {
+			// Fail silently.
 			bs.sdk.DeleteThing(cfg.MFThing, key)
 		}
 		return Config{}, err
@@ -154,8 +155,10 @@ func (bs bootstrapService) View(key, id string) (Config, error) {
 	}
 
 	for i, ch := range cfg.MFChannels {
-		if err := json.Unmarshal(ch.Metadata.([]byte), &cfg.MFChannels[i].Metadata); err != nil {
-			return Config{}, err
+		if meta, ok := ch.Metadata.([]byte); ok {
+			if err := json.Unmarshal(meta, &cfg.MFChannels[i].Metadata); err != nil {
+				return Config{}, err
+			}
 		}
 	}
 

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -73,6 +73,9 @@ type Service interface {
 
 	// RemoveConfig removes Configuration with id received from an event.
 	RemoveConfig(string) error
+
+	// RemoveChannel removes Channel with id received from an event.
+	RemoveChannel(string) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -299,6 +302,10 @@ func (bs bootstrapService) UpdateChannel(channel Channel) error {
 
 func (bs bootstrapService) RemoveConfig(id string) error {
 	return bs.configs.Remove("", id)
+}
+
+func (bs bootstrapService) RemoveChannel(id string) error {
+	return bs.configs.RemoveChannel(id)
 }
 
 // Method thing retrieves Mainflux Thing creating one if an empty ID is passed.

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -122,7 +122,7 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 	}
 
 	// Check if channels exist. This is the way to prevent invalid configuration to be saved.
-	existing, err := bs.configs.ListExisting(key, toConnect)
+	existing, err := bs.configs.ListExisting(owner, toConnect)
 	if err != nil {
 		return Config{}, err
 	}

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -67,6 +67,9 @@ type Service interface {
 
 	// ChangeState changes state of the Thing with given ID and owner.
 	ChangeState(string, string, State) error
+
+	// UpdateChannel updates Channel with data received from an event.
+	UpdateChannel(Channel) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -103,8 +106,6 @@ func (bs bootstrapService) Add(key string, cfg Config) (Config, error) {
 		toConnect = append(toConnect, ch.ID)
 	}
 	// Check if channels exist. This is the way to prevent invalid configuration to be saved.
-	// However, channels deletion will eventually cause this; since Bootstrap service is not
-	// using events from the Things service at the moment. See #552.
 	connected, err := bs.configs.Exist(key, toConnect)
 	if err != nil {
 		return Config{}, err
@@ -299,6 +300,10 @@ func (bs bootstrapService) ChangeState(key, id string, state State) error {
 	}
 
 	return bs.configs.ChangeState(owner, id, state)
+}
+
+func (bs bootstrapService) UpdateChannel(channel Channel) error {
+	return bs.configs.UpdateChannel(channel)
 }
 
 // Method thing retrieves Mainflux Thing creating one if an empty ID is passed.

--- a/bootstrap/state.go
+++ b/bootstrap/state.go
@@ -9,6 +9,13 @@ package bootstrap
 
 import "strconv"
 
+const (
+	// Inactive Thing is created, but not able to exchange messages using Mainflux.
+	Inactive State = iota
+	// Active Thing is created, configured, and whitelisted.
+	Active
+)
+
 // State represents corresponding Mainflux Thing state. The possible Config States
 // as well as description of what that State represents are given in the table:
 // | State    | What it means 		                                                           |

--- a/bootstrap/swagger.yml
+++ b/bootstrap/swagger.yml
@@ -30,7 +30,7 @@ paths:
           headers:
             Location:
               type: string
-              description: Created config's relative URL (i.e. /configs/{configId}).
+              description: Created config's relative URL (i.e. /things/configs/{configId}).
         400:
           description: Failed due to malformed JSON.
         403:

--- a/bootstrap/swagger.yml
+++ b/bootstrap/swagger.yml
@@ -56,7 +56,8 @@ paths:
         - $ref: "#/parameters/Name"
       responses:
         200:
-          description: Data retrieved.
+          description: | 
+            Data retrieved. Configs from this list don't contain channels.
           schema:
             $ref: "#/definitions/ConfigList"
         400:
@@ -89,7 +90,7 @@ paths:
           $ref: "#/responses/ServiceError"
   /things/configs/{configId}:
     get:
-      summary: Retrieves config info
+      summary: Retrieves config info (with channels)
       tags:
         - configs
       parameters:
@@ -153,6 +154,38 @@ paths:
           description: Failed due to malformed config's ID.
         403:
           description: Missing or invalid access token provided.
+        500:
+          $ref: "#/responses/ServiceError"
+  /things/configs/connections/{configId}:
+    put:
+      summary: Updates channels the thing is connected to
+      description: |
+        Update connections performs update of the channel list corresponding 
+        Thing is connected to.
+      tags:
+        - configs
+      parameters:
+        - $ref: "#/parameters/Authorization"
+        - $ref: "#/parameters/ConfigId"
+        - name: channels
+          description: Array if IDs the thing is be connected to.
+          in: body
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+      responses:
+        200:
+          description: Config updated.
+        400:
+          description: Failed due to malformed JSON.
+        403:
+          description: Missing or invalid access token provided.
+        404:
+          description: Config does not exist.
+        415:
+          description: Missing or invalid content type.
         500:
           $ref: "#/responses/ServiceError"
   /things/state/{configId}:
@@ -395,9 +428,8 @@ definitions:
           type: string
       content:
         type: string
-      state:
-        $ref: '#/definitions/State'
+      name:
+        type: string
     required:
-      - channels
       - content
-      - state
+      - name


### PR DESCRIPTION
### What does this do?
This PR adds the use of event sourcing from Things service to keep corresponding Bootstrap service entities in sync.

### Which issue(s) does this PR fix/relate to?
This PR resolves #552.

### List any changes that modify/break current functionality
There are 2 major API changes:
    - List of Configs does not return Channels
    - Update Config is split to Config fields update and Config connections update

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
Yes, docs are up to date.