### PR TITLE
MF-655 Proper usage of docker volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,23 +30,25 @@ clean:
 	rm -rf ${BUILD_DIR}
 	rm -rf mqtt/node_modules
 
-cleandocker: cleanghost
+cleandocker:
 	# Stop all containers (if running)
 	docker-compose -f docker/docker-compose.yml stop
 	# Remove mainflux containers
 	docker ps -f name=mainflux -aq | xargs -r docker rm
+
+	# Remove exited containers
+	docker ps -f name=mainflux -f status=dead -f status=exited -aq | xargs -r docker rm -v
+
+	# Remove unused images
+	docker images "mainflux\/*" -f dangling=true -q | xargs -r docker rmi
+
 	# Remove old mainflux images
 	docker images -q mainflux\/* | xargs -r docker rmi
 
-# Clean ghost docker images
-cleanghost:
-	# Remove exited containers
-	docker ps -f status=dead -f status=exited -aq | xargs -r docker rm -v
-	# Remove unused images
-	docker images -f dangling=true -q | xargs -r docker rmi
+ifndef spv
 	# Remove unused volumes
-	docker volume ls -f dangling=true -q | xargs -r docker volume rm
-
+	docker volume ls -f name=mainflux -f dangling=true -q | xargs -r docker volume rm
+endif
 install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 

--- a/docker/addons/bootstrap/docker-compose.yml
+++ b/docker/addons/bootstrap/docker-compose.yml
@@ -4,6 +4,9 @@ networks:
   docker_mainflux-base-net:
     external: true
 
+volumes:
+  mainflux-bootstrap-db-volume:
+
 services:
   bootstrap-db:
     image: postgres:10.2-alpine
@@ -15,6 +18,8 @@ services:
       POSTGRES_DB: bootstrap
     networks:
       - docker_mainflux-base-net
+    volumes:
+      - mainflux-bootstrap-db-volume:/var/lib/postgresql/data
 
   bootstrap:
     image: mainflux/bootstrap:latest

--- a/docker/addons/cassandra-writer/docker-compose.yml
+++ b/docker/addons/cassandra-writer/docker-compose.yml
@@ -12,6 +12,9 @@ networks:
   docker_mainflux-base-net:
     external: true
 
+volumes:
+  mainflux-cassandra-volume:
+
 services:
   cassandra:
     image: cassandra:3.11.3
@@ -21,6 +24,8 @@ services:
       - docker_mainflux-base-net
     ports:
       - 9042:9042
+    volumes:
+      - mainflux-cassandra-volume:/var/lib/cassandra
 
   cassandra-writer:
     image: mainflux/cassandra-writer:latest

--- a/docker/addons/influxdb-writer/docker-compose.yml
+++ b/docker/addons/influxdb-writer/docker-compose.yml
@@ -11,6 +11,10 @@ networks:
   docker_mainflux-base-net:
     external: true
 
+volumes:
+  mainflux-influxdb-volume:
+  mainflux-grafana-volume:
+
 services:
 
   influxdb:
@@ -25,6 +29,8 @@ services:
       - docker_mainflux-base-net
     ports:
       - 8086:8086
+    volumes:
+      - mainflux-influxdb-volume:/var/lib/influxdb
 
   influxdb-writer:
     image: mainflux/influxdb-writer:latest
@@ -58,3 +64,5 @@ services:
       - 3001:3000
     networks:
       - docker_mainflux-base-net
+    volumes:
+      - mainflux-grafana-volume:/var/lib/grafana

--- a/docker/addons/mongodb-writer/docker-compose.yml
+++ b/docker/addons/mongodb-writer/docker-compose.yml
@@ -13,6 +13,10 @@ networks:
   docker_mainflux-base-net:
     external: true
 
+volumes:
+  mainflux-mongodb-db-volume:
+  mainflux-mongodb-configdb-volume:
+
 services:
   mongodb:
     image: mongo:3.6-jessie
@@ -24,6 +28,9 @@ services:
       - 27017:27017
     networks:
       - docker_mainflux-base-net
+    volumes:
+      - mainflux-mongodb-db-volume:/data/db
+      - mainflux-mongodb-configdb-volume:/data/configdb
 
   mongodb-writer:
     image: mainflux/mongodb-writer:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,13 @@ networks:
   mainflux-base-net:
     driver: bridge
 
+volumes:
+  mainflux-users-db-volume:
+  mainflux-things-db-volume:
+  mainflux-mqtt-redis-volume:
+  mainflux-things-redis-volume:
+  mainflux-es-redis-volume:
+
 services:
   nginx:
     image: nginx:1.14.2
@@ -48,6 +55,8 @@ services:
       POSTGRES_DB: users
     networks:
       - mainflux-base-net
+    volumes:
+      - mainflux-users-db-volume:/var/lib/postgresql/data
 
   users:
     image: mainflux/users:latest
@@ -82,6 +91,8 @@ services:
       POSTGRES_DB: things
     networks:
       - mainflux-base-net
+    volumes:
+      - mainflux-things-db-volume:/var/lib/postgresql/data
 
   things-redis:
     image: redis:5.0-alpine
@@ -89,6 +100,8 @@ services:
     restart: on-failure
     networks:
       - mainflux-base-net
+    volumes:
+      - mainflux-things-redis-volume:/data
 
   things:
     image: mainflux/things:latest
@@ -184,6 +197,8 @@ services:
     restart: on-failure
     networks:
       - mainflux-base-net
+    volumes:
+      - mainflux-es-redis-volume:/data
 
   mqtt-redis:
     image: redis:5.0-alpine
@@ -191,6 +206,8 @@ services:
     restart: on-failure
     networks:
       - mainflux-base-net
+    volumes:
+      - mainflux-mqtt-redis-volume:/data
 
   mqtt-adapter:
     image: mainflux/mqtt:latest


### PR DESCRIPTION
### What does this do?

* adds names for the persistent volumes that we already use them
* adds filters for the `cleanghost` to filter out only the containers which we have created
* adds a switch which when is present the persistent volumes will not be deleted. The default behavior or volume deletion is not changed.

## Which issue(s) does this PR fix/relate to?
Resolves #655 

### List any changes that modify/break current functionality
none

### Have you included tests for your changes?
no

### Did you document any new/modified functionality?
added description about the changes in the dev guide

### Notes
See the issue for more details