### PR TITLE
MF-656 - Change bootstrap service port to 8200

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -71,7 +71,7 @@ version: "2"
       - bootstrap-db
     restart: on-failure
     ports:
-      - 8900:8900
+      - 8200:8200
     environment:
       MF_BOOTSTRAP_LOG_LEVEL: [Bootstrap log level]
       MF_BOOTSTRAP_DB_HOST: [Database host address]
@@ -85,7 +85,7 @@ version: "2"
       MF_BOOTSTRAP_DB_SSL_ROOT_CERT: [Path to the PEM encoded root certificate file]
       MF_BOOTSTRAP_CLIENT_TLS: [Boolean value to enable/disable client TLS]
       MF_BOOTSTRAP_CA_CERTS: [Path to trusted CAs in PEM format]
-      MF_BOOTSTRAP_PORT: 8900
+      MF_BOOTSTRAP_PORT: 8200
       MF_BOOTSTRAP_SERVER_CERT: [String path to server cert in pem format]
       MF_BOOTSTRAP_SERVER_KEY: [String path to server key in pem format]
       MF_SDK_BASE_URL: [Base SDK URL for the Mainflux services]

--- a/docker/addons/bootstrap/docker-compose.yml
+++ b/docker/addons/bootstrap/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - bootstrap-db
     restart: on-failure
     ports:
-      - 8900:8900
+      - 8200:8200
     environment:
       MF_BOOTSTRAP_LOG_LEVEL: debug
       MF_BOOTSTRAP_DB_HOST: bootstrap-db
@@ -32,7 +32,7 @@ services:
       MF_BOOTSTRAP_DB_PASS: mainflux
       MF_BOOTSTRAP_DB: bootstrap
       MF_BOOTSTRAP_DB_SSL_MODE: disable
-      MF_BOOTSTRAP_PORT: 8900
+      MF_BOOTSTRAP_PORT: 8200
       MF_SDK_BASE_URL: http://mainflux-things:8182
       MF_USERS_URL: mainflux-users:8181
     networks:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -21,7 +21,7 @@ Also, the configuration contains an external ID and external key, which will be 
 In order to enable the thing to start bootstrapping process, the user needs to upload a valid configuration for that specific thing. This can be done using the following HTTP request:
 
 ```
-curl -s -S -i -X POST -H "Authorization: <user_token>" -H "Content-Type: application/json" http://localhost:8900/things/configs -d '{
+curl -s -S -i -X POST -H "Authorization: <user_token>" -H "Content-Type: application/json" http://localhost:8200/things/configs -d '{
         "external_id":"09:6:0:sb:sa",
         "thing_id": "1b9b8fae-9035-4969-a240-7fe5bdc0ed28",
         "external_key":"key",
@@ -45,7 +45,7 @@ There are two more fields: `external_id` and `external_key`. External ID represe
 Currently, the bootstrapping procedure is executed over the HTTP protocol. Bootstrapping is nothing else but fetching and applying the configuration that corresponds to the given Mainflux thing. In order to fetch the configuration, _the thing_ needs to send a bootstrapping request:
 
 ```
-curl -s -S -i -H "Authorization: <external_key>" http://localhost:8900/things/bootstrap/<external_id>
+curl -s -S -i -H "Authorization: <external_key>" http://localhost:8200/things/bootstrap/<external_id>
 ```
 
 The response body should look something like:
@@ -82,7 +82,7 @@ The response consists of an ID and key of the Mainflux thing, the list of channe
 Uploading configuration does not automatically connect thing to the given list of channels. In order to connect the thing to the channels, user needs to send the following HTTP request:
 
 ```
-curl -s -S -i -X PUT -H "Authorization: <user_token>" -H "Content-Type: application/json" http://localhost:8900/things/state/<thing_id> -d '{"state": 1}'
+curl -s -S -i -X PUT -H "Authorization: <user_token>" -H "Content-Type: application/json" http://localhost:8200/things/state/<thing_id> -d '{"state": 1}'
 ```
 
 In order to disconnect, the same request should be sent with the value of `state` set to 0.

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -175,6 +175,8 @@ func TestUpdateThing(t *testing.T) {
 }
 
 func TestViewThing(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create thing without sending event.
 	sth, err := svc.AddThing(token, things.Thing{Type: "app", Name: "a"})
@@ -188,6 +190,8 @@ func TestViewThing(t *testing.T) {
 }
 
 func TestListThings(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create thing without sending event.
 	_, err := svc.AddThing(token, things.Thing{Type: "app", Name: "a"})
@@ -201,6 +205,8 @@ func TestListThings(t *testing.T) {
 }
 
 func TestListThingsByChannel(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create thing without sending event.
 	sth, err := svc.AddThing(token, things.Thing{Type: "app", Name: "a"})
@@ -396,6 +402,8 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestViewChannel(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create channel without sending event.
 	sch, err := svc.CreateChannel(token, things.Channel{Name: "a"})
@@ -409,6 +417,8 @@ func TestViewChannel(t *testing.T) {
 }
 
 func TestListChannels(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create thing without sending event.
 	_, err := svc.CreateChannel(token, things.Channel{Name: "a"})
@@ -422,6 +432,8 @@ func TestListChannels(t *testing.T) {
 }
 
 func TestListChannelsByThing(t *testing.T) {
+	redisClient.FlushAll().Err()
+
 	svc := newService(map[string]string{token: email})
 	// Create thing without sending event.
 	sth, err := svc.AddThing(token, things.Thing{Type: "app", Name: "a"})


### PR DESCRIPTION
### What does this do?
Changes bootstrap service port to 8200.

### Which issue(s) does this PR fix/relate to?
Resolves #656.

### List any changes that modify/break current functionality
Bootstrap service port is moved from port `8900` to `8200`.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
Existing documentation is updated.
