### PR TITLE
MF-673 - Fix offset calculation after deleting thing or channel

### DIFF
--- a/ui/src/Helpers.elm
+++ b/ui/src/Helpers.elm
@@ -85,7 +85,7 @@ offsetToPage offset limit =
 validateOffset : Int -> Int -> Int -> Int
 validateOffset offset total limit =
     if offset >= (total - 1) then
-        (total - 1) - limit
+        Basics.max ((total - 1) - limit) 0
 
     else
         offset


### PR DESCRIPTION

Signed-off-by: Ivan Milošević <iva@blokovi.com>


### What does this do?
Fix offset calculation after deleting thing/channel, not to go to negative offset after deleting last thing/channel

### Which issue(s) does this PR fix/relate to?
Resolves #673 


