### PR TITLE
MF-688 - InfluxDB writer invalid time parsing

### DIFF
--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -9,6 +9,7 @@ package influxdb
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -112,7 +113,9 @@ func (repo *influxRepo) savePoint(point *influxdata.Point) error {
 
 func (repo *influxRepo) Save(msg mainflux.Message) error {
 	tgs, flds := repo.tagsOf(&msg), repo.fieldsOf(&msg)
-	t := time.Unix(int64(msg.Time), 0)
+
+	sec, dec := math.Modf(msg.Time)
+	t := time.Unix(int64(sec), int64(dec*(1e9)))
 
 	pt, err := influxdata.NewPoint(pointName, tgs, flds, t)
 	if err != nil {


### PR DESCRIPTION
### What does this do?
This pull request fixes invalid time parse in InfluxDB writer.

### Which issue(s) does this PR fix/relate to?
This pull request fixes #688.

### List any changes that modify/break current functionality
There are no such changes.

### Have you included tests for your changes?
No, this is a simple fix.

### Did you document any new/modified functionality?
No, since this is just a fix of the already documented feature.