### PR TITLE
NOISSUE - Fix logging in publish event callback

### DIFF
--- a/mqtt/mqtt.js
+++ b/mqtt/mqtt.js
@@ -227,7 +227,7 @@ aedes.on('connectionError', function (client, err) {
 function publishConnEvent(id, type) {
     var onPublish = function(err) {
         if (err) {
-            console.error(err);
+            logger.warn('event publish failed: %s', err);
         }
     };
     esclient.xadd(config.event_stream, '*',


### PR DESCRIPTION
### What does this do?
Replaces `console.error` from MQTT publish event callback with proper logging.

### Which issue(s) does this PR fix/relate to?
There is no issue for this.
