### PR TITLE
NOISSUE - Remove debugging message from response of handle error function

### DIFF
--- a/ui/src/Error.elm
+++ b/ui/src/Error.elm
@@ -25,4 +25,4 @@ handle error =
             "Bad status: " ++ String.fromInt code
 
         Http.BadBody err ->
-            err
+            "Invalid response body"

--- a/ui/src/Error.elm
+++ b/ui/src/Error.elm
@@ -6,6 +6,7 @@
 
 module Error exposing (handle)
 
+import Debug
 import Http
 
 
@@ -25,4 +26,8 @@ handle error =
             "Bad status: " ++ String.fromInt code
 
         Http.BadBody err ->
+            let
+                _ =
+                    Debug.log "Bad body error: " err
+            in
             "Invalid response body"


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>


### What does this do?

Remove debugging message that explains what went wrong with JSON decoder from response of handle error function. Mainflux version on dashboard display that response,  so it's swiched to nice error message instead of huge debug.

### Which issue(s) does this PR fix/relate to?
No issue

