### PR TITLE
Fix .dockerignore file by removing index.html

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,2 +1,2 @@
 elm-stuff
-index.html
+

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,2 +1,2 @@
 elm-stuff
-
+main.js

--- a/ui/docker/Dockerfile
+++ b/ui/docker/Dockerfile
@@ -18,5 +18,6 @@ RUN elm make --optimize src/Main.elm --output=main.js
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
 FROM nginx:1.14.2-alpine
 COPY --from=builder /app/index.html /usr/share/nginx/html
+COPY --from=builder /app/main.js /usr/share/nginx/html
 COPY --from=builder /app/css/mainflux.css /usr/share/nginx/html/css/
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf

--- a/ui/src/JsonMF.elm
+++ b/ui/src/JsonMF.elm
@@ -75,7 +75,7 @@ jsonValueEncoder json =
 
 jsonValueToString : JsonValue -> String
 jsonValueToString jsonValue =
-    jsonValue |> jsonValueEncoder |> E.encode 4
+    jsonValue |> jsonValueEncoder |> E.encode 1
 
 
 


### PR DESCRIPTION
UI docker container build is faling because `index.html` wasn't copied to the container. 

Signed-off-by: Darko Draskovic <darko.draskovic@gmail.com>