### PR TITLE
MF-574 - Add missing environment variables to Cassandra writer

### DIFF
--- a/cmd/cassandra-writer/main.go
+++ b/cmd/cassandra-writer/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -38,6 +39,9 @@ const (
 	defPort        = "8180"
 	defCluster     = "127.0.0.1"
 	defKeyspace    = "mainflux"
+	defDBUsername  = ""
+	defDBPassword  = ""
+	defDBPort      = "9042"
 	defChanCfgPath = "/config/channels.toml"
 
 	envNatsURL     = "MF_NATS_URL"
@@ -45,6 +49,9 @@ const (
 	envPort        = "MF_CASSANDRA_WRITER_PORT"
 	envCluster     = "MF_CASSANDRA_WRITER_DB_CLUSTER"
 	envKeyspace    = "MF_CASSANDRA_WRITER_DB_KEYSPACE"
+	envDBUsername  = "MF_CASSANDRA_WRITER_DB_USERNAME"
+	envDBPassword  = "MF_CASSANDRA_WRITER_DB_PASSWORD"
+	envDBPort      = "MF_CASSANDRA_WRITER_DB_PORT"
 	envChanCfgPath = "MF_CASSANDRA_WRITER_CHANNELS_CONFIG"
 )
 
@@ -52,8 +59,7 @@ type config struct {
 	natsURL  string
 	logLevel string
 	port     string
-	cluster  string
-	keyspace string
+	dbCfg    cassandra.DBConfig
 	channels []string
 }
 
@@ -68,7 +74,7 @@ func main() {
 	nc := connectToNATS(cfg.natsURL, logger)
 	defer nc.Close()
 
-	session := connectToCassandra(cfg.cluster, cfg.keyspace, logger)
+	session := connectToCassandra(cfg.dbCfg, logger)
 	defer session.Close()
 
 	repo := newService(session, logger)
@@ -91,13 +97,25 @@ func main() {
 }
 
 func loadConfig() config {
+	dbPort, err := strconv.Atoi(mainflux.Env(envDBPort, defDBPort))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dbCfg := cassandra.DBConfig{
+		Hosts:    strings.Split(mainflux.Env(envCluster, defCluster), sep),
+		Keyspace: mainflux.Env(envKeyspace, defKeyspace),
+		Username: mainflux.Env(envDBUsername, defDBUsername),
+		Password: mainflux.Env(envDBPassword, defDBPassword),
+		Port:     dbPort,
+	}
+
 	chanCfgPath := mainflux.Env(envChanCfgPath, defChanCfgPath)
 	return config{
 		natsURL:  mainflux.Env(envNatsURL, defNatsURL),
 		logLevel: mainflux.Env(envLogLevel, defLogLevel),
 		port:     mainflux.Env(envPort, defPort),
-		cluster:  mainflux.Env(envCluster, defCluster),
-		keyspace: mainflux.Env(envKeyspace, defKeyspace),
+		dbCfg:    dbCfg,
 		channels: loadChansConfig(chanCfgPath),
 	}
 }
@@ -136,8 +154,8 @@ func connectToNATS(url string, logger logger.Logger) *nats.Conn {
 	return nc
 }
 
-func connectToCassandra(cluster, keyspace string, logger logger.Logger) *gocql.Session {
-	session, err := cassandra.Connect(strings.Split(cluster, sep), keyspace)
+func connectToCassandra(dbCfg cassandra.DBConfig, logger logger.Logger) *gocql.Session {
+	session, err := cassandra.Connect(dbCfg)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to connect to Cassandra cluster: %s", err))
 		os.Exit(1)

--- a/readers/cassandra/README.md
+++ b/readers/cassandra/README.md
@@ -13,6 +13,9 @@ default values.
 | MF_CASSANDRA_READER_PORT        | Service HTTP port                              | 8180           |
 | MF_CASSANDRA_READER_DB_CLUSTER  | Cassandra cluster comma separated addresses    | 127.0.0.1      |
 | MF_CASSANDRA_READER_DB_KEYSPACE | Cassandra keyspace name                        | mainflux       |
+| MF_CASSANDRA_READER_DB_USERNAME | Cassandra DB username                          |                |
+| MF_CASSANDRA_READER_DB_PASSWORD | Cassandra DB password                          |                |
+| MF_CASSANDRA_READER_DB_PORT     | Cassandra DB port                              | 9042           |
 | MF_THINGS_URL                   | Things service URL                             | localhost:8181 |
 | MF_CASSANDRA_READER_CLIENT_TLS  | Flag that indicates if TLS should be turned on | false          |
 | MF_CASSANDRA_READER_CA_CERTS    | Path to trusted CAs in PEM format              |                |
@@ -32,6 +35,9 @@ default values.
       MF_CASSANDRA_READER_PORT: [Service HTTP port]
       MF_CASSANDRA_READER_DB_CLUSTER: [Cassandra cluster comma separated addresses]
       MF_CASSANDRA_READER_DB_KEYSPACE: [Cassandra keyspace name]
+      MF_CASSANDRA_READER_DB_USERNAME: [Cassandra DB username]
+      MF_CASSANDRA_READER_DB_PASSWORD: [Cassandra DB password]
+      MF_CASSANDRA_READER_DB_PORT: [Cassandra DB port]
       MF_CASSANDRA_READER_CLIENT_TLS: [Flag that indicates if TLS should be turned on]
       MF_CASSANDRA_READER_CA_CERTS: [Path to trusted CAs in PEM format]
     ports:
@@ -54,7 +60,7 @@ make cassandra-reader
 make install
 
 # Set the environment variables and run the service
-MF_THINGS_URL=[Things service URL] MF_CASSANDRA_READER_PORT=[Service HTTP port] MF_CASSANDRA_READER_DB_CLUSTER=[Cassandra cluster comma separated addresses] MF_CASSANDRA_READER_DB_KEYSPACE=[Cassandra keyspace name] MF_CASSANDRA_READER_CLIENT_TLS=[Flag that indicates if TLS should be turned on] MF_CASSANDRA_READER_CA_CERTS=[Path to trusted CAs in PEM format] $GOBIN/mainflux-cassandra-reader
+MF_THINGS_URL=[Things service URL] MF_CASSANDRA_READER_PORT=[Service HTTP port] MF_CASSANDRA_READER_DB_CLUSTER=[Cassandra cluster comma separated addresses] MF_CASSANDRA_READER_DB_KEYSPACE=[Cassandra keyspace name] MF_CASSANDRA_READER_DB_USERNAME=[Cassandra DB username] MF_CASSANDRA_READER_DB_PASSWORD=[Cassandra DB password] MF_CASSANDRA_READER_DB_PORT=[Cassandra DB port] MF_CASSANDRA_READER_CLIENT_TLS=[Flag that indicates if TLS should be turned on] MF_CASSANDRA_READER_CA_CERTS=[Path to trusted CAs in PEM format] $GOBIN/mainflux-cassandra-reader
 
 ```
 

--- a/readers/cassandra/init.go
+++ b/readers/cassandra/init.go
@@ -11,11 +11,25 @@ import (
 	"github.com/gocql/gocql"
 )
 
+// DBConfig contains Cassandra DB specific parameters.
+type DBConfig struct {
+	Hosts    []string
+	Keyspace string
+	Username string
+	Password string
+	Port     int
+}
+
 // Connect establishes connection to the Cassandra cluster.
-func Connect(hosts []string, keyspace string) (*gocql.Session, error) {
-	cluster := gocql.NewCluster(hosts...)
-	cluster.Keyspace = keyspace
+func Connect(cfg DBConfig) (*gocql.Session, error) {
+	cluster := gocql.NewCluster(cfg.Hosts...)
+	cluster.Keyspace = cfg.Keyspace
 	cluster.Consistency = gocql.Quorum
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: cfg.Username,
+		Password: cfg.Password,
+	}
+	cluster.Port = cfg.Port
 
 	return cluster.CreateSession()
 }

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -38,7 +38,10 @@ var (
 )
 
 func TestReadAll(t *testing.T) {
-	session, err := creaders.Connect([]string{addr}, keyspace)
+	session, err := creaders.Connect(creaders.DBConfig{
+		Hosts:    []string{addr},
+		Keyspace: keyspace,
+	})
 	require.Nil(t, err, fmt.Sprintf("failed to connect to Cassandra: %s", err))
 	defer session.Close()
 	writer := cwriters.New(session)

--- a/readers/cassandra/setup_test.go
+++ b/readers/cassandra/setup_test.go
@@ -39,7 +39,10 @@ func TestMain(m *testing.M) {
 			return err
 		}
 
-		session, err := cassandra.Connect([]string{addr}, keyspace)
+		session, err := cassandra.Connect(cassandra.DBConfig{
+			Hosts:    []string{addr},
+			Keyspace: keyspace,
+		})
 		if err != nil {
 			return err
 		}

--- a/writers/cassandra/README.md
+++ b/writers/cassandra/README.md
@@ -15,6 +15,9 @@ default values.
 | MF_CASSANDRA_WRITER_PORT            | Service HTTP port                                          | 8180                  |
 | MF_CASSANDRA_WRITER_DB_CLUSTER      | Cassandra cluster comma separated addresses                | 127.0.0.1             |
 | MF_CASSANDRA_WRITER_DB_KEYSPACE     | Cassandra keyspace name                                    | mainflux              |
+| MF_CASSANDRA_READER_DB_USERNAME     | Cassandra DB username                                      |                       |
+| MF_CASSANDRA_READER_DB_PASSWORD     | Cassandra DB password                                      |                       |
+| MF_CASSANDRA_READER_DB_PORT         | Cassandra DB port                                          | 9042                  |
 | MF_CASSANDRA_WRITER_CHANNELS_CONFIG | Configuration file path with channels list                 | /config/channels.yaml |
 ## Deployment
 
@@ -32,6 +35,9 @@ default values.
       MF_CASSANDRA_WRITER_PORT: [Service HTTP port]
       MF_CASSANDRA_WRITER_DB_CLUSTER: [Cassandra cluster comma separated addresses]
       MF_CASSANDRA_WRITER_DB_KEYSPACE: [Cassandra keyspace name]
+      MF_CASSANDRA_READER_DB_USERNAME: [Cassandra DB username]
+      MF_CASSANDRA_READER_DB_PASSWORD: [Cassandra DB password]
+      MF_CASSANDRA_READER_DB_PORT: [Cassandra DB port]
       MF_CASSANDRA_WRITER_CHANNELS_CONFIG: [Configuration file path with channels list]
     ports:
       - [host machine port]:[configured HTTP port]
@@ -55,7 +61,7 @@ make cassandra-writer
 make install
 
 # Set the environment variables and run the service
-MF_NATS_URL=[NATS instance URL] MF_CASSANDRA_WRITER_LOG_LEVEL=[Cassandra writer log level] MF_CASSANDRA_WRITER_PORT=[Service HTTP port] MF_CASSANDRA_WRITER_DB_CLUSTER=[Cassandra cluster comma separated addresses] MF_CASSANDRA_WRITER_DB_KEYSPACE=[Cassandra keyspace name] MF_CASSANDRA_WRITER_CHANNELS_CONFIG=[Configuration file path with channels list] $GOBIN/mainflux-cassandra-writer
+MF_NATS_URL=[NATS instance URL] MF_CASSANDRA_WRITER_LOG_LEVEL=[Cassandra writer log level] MF_CASSANDRA_WRITER_PORT=[Service HTTP port] MF_CASSANDRA_WRITER_DB_CLUSTER=[Cassandra cluster comma separated addresses] MF_CASSANDRA_WRITER_DB_KEYSPACE=[Cassandra keyspace name] MF_CASSANDRA_READER_DB_USERNAME=[Cassandra DB username] MF_CASSANDRA_READER_DB_PASSWORD=[Cassandra DB password] MF_CASSANDRA_READER_DB_PORT=[Cassandra DB port] MF_CASSANDRA_WRITER_CHANNELS_CONFIG=[Configuration file path with channels list] $GOBIN/mainflux-cassandra-writer
 
 ```
 

--- a/writers/cassandra/init.go
+++ b/writers/cassandra/init.go
@@ -26,13 +26,27 @@ const table = `CREATE TABLE IF NOT EXISTS messages (
     	update_time double,
     	link text,
         PRIMARY KEY (channel, time, id)
-    ) WITH CLUSTERING ORDER BY (time DESC)`
+	) WITH CLUSTERING ORDER BY (time DESC)`
+
+// DBConfig contains Cassandra DB specific parameters.
+type DBConfig struct {
+	Hosts    []string
+	Keyspace string
+	Username string
+	Password string
+	Port     int
+}
 
 // Connect establishes connection to the Cassandra cluster.
-func Connect(hosts []string, keyspace string) (*gocql.Session, error) {
-	cluster := gocql.NewCluster(hosts...)
-	cluster.Keyspace = keyspace
+func Connect(cfg DBConfig) (*gocql.Session, error) {
+	cluster := gocql.NewCluster(cfg.Hosts...)
+	cluster.Keyspace = cfg.Keyspace
 	cluster.Consistency = gocql.Quorum
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: cfg.Username,
+		Password: cfg.Password,
+	}
+	cluster.Port = cfg.Port
 
 	session, err := cluster.CreateSession()
 	if err != nil {

--- a/writers/cassandra/messages_test.go
+++ b/writers/cassandra/messages_test.go
@@ -32,7 +32,10 @@ var (
 )
 
 func TestSave(t *testing.T) {
-	session, err := cassandra.Connect([]string{addr}, keyspace)
+	session, err := cassandra.Connect(cassandra.DBConfig{
+		Hosts:    []string{addr},
+		Keyspace: keyspace,
+	})
 	require.Nil(t, err, fmt.Sprintf("failed to connect to Cassandra: %s", err))
 
 	repo := cassandra.New(session)

--- a/writers/cassandra/setup_test.go
+++ b/writers/cassandra/setup_test.go
@@ -39,7 +39,10 @@ func TestMain(m *testing.M) {
 			return err
 		}
 
-		session, err := cassandra.Connect([]string{addr}, keyspace)
+		session, err := cassandra.Connect(cassandra.DBConfig{
+			Hosts:    []string{addr},
+			Keyspace: keyspace,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this do?
Adds env vars for DB username, password, and port.

### Which issue(s) does this PR fix/relate to?
Resolves #574.

### List any changes that modify/break current functionality
There are no such changes.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
I've updated existing README files.
