### PR TITLE
NOISSUE - Add content type as part of MQTT subscription topic

### DIFF
--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -223,7 +223,7 @@ func receive(svc coap.Service, msg *gocoap.Message) *gocoap.Message {
 
 	ct, err := contentType(msg)
 	if err != nil {
-		ct = mainflux.SenMLJSON
+		ct = ""
 	}
 
 	publisher, err := authorize(msg, res, chanID)

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -70,12 +70,8 @@ mosquitto_sub -u <thing_id> -P <thing_key> -t channels/<channel_id>/messages -h 
 In order to pass content type as part of topic, one should append it to the end
 of an existing topic. Content type value should always be prefixed with `/ct/`.
 If you want to use standard topic such as `channels/<channel_id>/messages`
-with SenML content type, you should use following topic `channels/<channel_id>/messages/ct/application_senml-json`.
-If there is no `/ct/` prefix in the subtopic, then content type will have the 
-default value which is `application/senml+json`. Content type will be removed from
-the topic under the hood. You should pass content type only when you're publishing
-a message. Characters like `_` and `-` in the content type will be replaced with `/`
-and `+` respectively.
+with SenML content type, you should use following topic `channels/<channel_id>/messages/ct/application_senml-json`. Characters like `_` and `-` in the content type will be
+replaced with `/` and `+` respectively.
 
 If you are using TLS to secure MQTT connection, add `--cafile docker/ssl/certs/ca.crt`
 to every command.

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -111,10 +111,6 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	}
 
 	ct := r.Header.Get("Content-Type")
-	if ct == "" {
-		ct = mainflux.SenMLJSON
-	}
-
 	msg := mainflux.RawMessage{
 		Protocol:    protocol,
 		ContentType: ct,

--- a/ws/api/transport.go
+++ b/ws/api/transport.go
@@ -190,7 +190,7 @@ func contentType(r *http.Request) string {
 	if ct == "" {
 		ctvals := bone.GetQuery(r, "content-type")
 		if len(ctvals) == 0 {
-			return mainflux.SenMLJSON
+			return ""
 		}
 		ct = ctvals[0]
 	}


### PR DESCRIPTION
### What does this do?
Adds content type as part of MQTT subscription topic.

### Which issue(s) does this PR fix/relate to?
There is no issue for this PR.

### List any changes that modify/break current functionality
The default value for content type is not SenML JSON, but an empty string.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
I've updated existing docs.
