### PR TITLE
MF-821 - Switch secure of WS connection according to secure of http connection of UI

### DIFF
--- a/ui/src/Websocket.js
+++ b/ui/src/Websocket.js
@@ -6,7 +6,11 @@ MF.log = function(msg) {
 }
 
 MF.url = function(data) {
-    return 'wss://' + window.location.hostname + '/ws/channels/' + data.channelid + '/messages?authorization=' + data.thingkey
+    var wsProtocol = 'ws';
+    if (window.location.protocol == 'https:') {
+        wsProtocol = 'wss'
+    }
+    return wsProtocol + '://' + window.location.hostname + '/ws/channels/' + data.channelid + '/messages?authorization=' + data.thingkey
 }
 
 app.ports.connectWebsocket.subscribe(function(data) {


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>

### What does this do?
Switch secure of WebSocket connection according to secure of http connection of UI
When UI is on `https://`, protocol of WebSocket connection will be `wss://`, and when ui is on `http://` WS connection will be `ws://`

This prevent mixed content error (UI on https trying to connect to insecure WS endpoint). 
Also, this prevent common error in development when UI trying to connect on `wss://` endpoint on domain that doesn't have valid certificate but there is no warning in browser to accept this unsecure connection (because UI is on `http://`)

### Which issue(s) does this PR fix/relate to?
This PR with previously merged #826 resolve #821 


