### PR TITLE
MF-832 Invalid Content-Type in MQTT Version Endpoint, MF-822 Return 404 for non `/version` paths on MQTT adapter

### DIFF
--- a/mqtt/aedes/mqtt.js
+++ b/mqtt/aedes/mqtt.js
@@ -112,11 +112,13 @@ esclient.on('error', function(err) {
 function startWs() {
     var server = http.createServer();
     server.on('request', (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
         if (req.url === '/version') {
             res.statusCode = 200;
-            res.setHeader('Content-Type', 'text/plain; charset=utf-8');
             res.end(`{"service":"mqtt-adapter","version":"${version}"}`);
         }
+        res.statusCode = 404;
+        res.end('{"service":"mqtt-adpater", "message": "not found"}')
     }); 
     websocket.createServer({server: server}, aedes.handle);
     server.listen(config.ws_port);


### PR DESCRIPTION

### What does this do?
It fixes content-type and not-found issues in MQTT version endpoint. if you use invalid route instead of getting empty response you get 404 error with a not-found message.

### Which issue(s) does this PR fix/relate to?
Resolve #832 
Resolve #822 

### List any changes that modify/break current functionality
It doesn't break or change current functionality.

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
