### PR TITLE
MF-846 - Install python in docker build for aedes mqtt image

### DIFF
--- a/mqtt/aedes/Dockerfile
+++ b/mqtt/aedes/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) Mainflux
+# SPDX-License-Identifier: Apache-2.0
+
 FROM node:10.15.1-alpine as builder
 
 ## Install build toolchain, install node deps and compile native add-ons

--- a/mqtt/aedes/Dockerfile
+++ b/mqtt/aedes/Dockerfile
@@ -1,8 +1,14 @@
+FROM node:10.15.1-alpine as builder
+
+## Install build toolchain, install node deps and compile native add-ons
+RUN apk add --no-cache python make g++
+COPY mqtt/aedes/package.json .
+RUN npm rebuild && npm install --only=production
+
 FROM node:10.15.1-alpine
-
+## Copy built node modules and binaries without including the toolchain
+COPY --from=builder node_modules .
 COPY *.proto mqtt/* ./
-
-RUN npm rebuild && npm install
 
 EXPOSE 1883 8880
 


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>

### What does this do?
Include python in multi-stage docker build for aedes mqtt image

### Which issue(s) does this PR fix/relate to?
Resolves #846 

