### PR TITLE
MF-787 - Add tags to user, thing, and channel spans

### DIFF
--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -306,7 +306,6 @@ func connectToUsers(cfg config, logger logger.Logger) *grpc.ClientConn {
 }
 
 func newService(users mainflux.UsersServiceClient, dbTracer opentracing.Tracer, cacheTracer opentracing.Tracer, db *sqlx.DB, cacheClient *redis.Client, esClient *redis.Client, logger logger.Logger) things.Service {
-
 	dbMiddleware := postgres.NewDatabaseMiddleware(db)
 
 	thingsRepo := postgres.NewThingRepository(dbMiddleware)

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -306,12 +306,12 @@ func connectToUsers(cfg config, logger logger.Logger) *grpc.ClientConn {
 }
 
 func newService(users mainflux.UsersServiceClient, dbTracer opentracing.Tracer, cacheTracer opentracing.Tracer, db *sqlx.DB, cacheClient *redis.Client, esClient *redis.Client, logger logger.Logger) things.Service {
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	database := postgres.NewDatabase(db)
 
-	thingsRepo := postgres.NewThingRepository(dbMiddleware)
+	thingsRepo := postgres.NewThingRepository(database)
 	thingsRepo = tracing.ThingRepositoryMiddleware(dbTracer, thingsRepo)
 
-	channelsRepo := postgres.NewChannelRepository(dbMiddleware)
+	channelsRepo := postgres.NewChannelRepository(database)
 	channelsRepo = tracing.ChannelRepositoryMiddleware(dbTracer, channelsRepo)
 
 	chanCache := rediscache.NewChannelCache(cacheClient)

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -306,7 +306,9 @@ func connectToUsers(cfg config, logger logger.Logger) *grpc.ClientConn {
 }
 
 func newService(users mainflux.UsersServiceClient, dbTracer opentracing.Tracer, cacheTracer opentracing.Tracer, db *sqlx.DB, cacheClient *redis.Client, esClient *redis.Client, logger logger.Logger) things.Service {
-	thingsRepo := postgres.NewThingRepository(db)
+
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingsRepo := postgres.NewThingRepository(dbMiddleware)
 	thingsRepo = tracing.ThingRepositoryMiddleware(dbTracer, thingsRepo)
 
 	channelsRepo := postgres.NewChannelRepository(db)

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -308,10 +308,11 @@ func connectToUsers(cfg config, logger logger.Logger) *grpc.ClientConn {
 func newService(users mainflux.UsersServiceClient, dbTracer opentracing.Tracer, cacheTracer opentracing.Tracer, db *sqlx.DB, cacheClient *redis.Client, esClient *redis.Client, logger logger.Logger) things.Service {
 
 	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+
 	thingsRepo := postgres.NewThingRepository(dbMiddleware)
 	thingsRepo = tracing.ThingRepositoryMiddleware(dbTracer, thingsRepo)
 
-	channelsRepo := postgres.NewChannelRepository(db)
+	channelsRepo := postgres.NewChannelRepository(dbMiddleware)
 	channelsRepo = tracing.ChannelRepositoryMiddleware(dbTracer, channelsRepo)
 
 	chanCache := rediscache.NewChannelCache(cacheClient)

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -178,7 +178,8 @@ func connectToDB(dbConfig postgres.Config, logger logger.Logger) *sqlx.DB {
 }
 
 func newService(db *sqlx.DB, tracer opentracing.Tracer, secret string, logger logger.Logger) users.Service {
-	repo := tracing.UserRepositoryMiddleware(postgres.New(db), tracer)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	repo := tracing.UserRepositoryMiddleware(postgres.New(dbMiddleware), tracer)
 	hasher := bcrypt.New()
 	idp := jwt.New(secret)
 

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -178,8 +178,8 @@ func connectToDB(dbConfig postgres.Config, logger logger.Logger) *sqlx.DB {
 }
 
 func newService(db *sqlx.DB, tracer opentracing.Tracer, secret string, logger logger.Logger) users.Service {
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
-	repo := tracing.UserRepositoryMiddleware(postgres.New(dbMiddleware), tracer)
+	database := postgres.NewDatabase(db)
+	repo := tracing.UserRepositoryMiddleware(postgres.New(database), tracer)
 	hasher := bcrypt.New()
 	idp := jwt.New(secret)
 

--- a/mqtt/aedes/package-lock.json
+++ b/mqtt/aedes/package-lock.json
@@ -13,8 +13,8 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
       "integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
       "requires": {
-        "lodash.camelcase": "^4.3.0",
-        "protobufjs": "^6.8.6"
+        "lodash.camelcase": "4.3.0",
+        "protobufjs": "6.8.8"
       }
     },
     "@protobufjs/aspromise": {
@@ -42,8 +42,8 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/inquire": "1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -76,8 +76,8 @@
       "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
       "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
       "requires": {
-        "@types/long": "*",
-        "@types/node": "*"
+        "@types/long": "4.0.0",
+        "@types/node": "10.14.18"
       }
     },
     "@types/long": {
@@ -102,7 +102,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -118,22 +118,22 @@
       "resolved": "https://registry.npmjs.org/aedes/-/aedes-0.39.0.tgz",
       "integrity": "sha512-AV7pN4Ogt4tNNgNNabKjsC7Cw7bMMNjQH1hua4zQV0TFf/QEBPVu1YDZMH3Lrrt2XziydQzmBrBc5aAQvAq5FQ==",
       "requires": {
-        "aedes-packet": "^1.0.0",
-        "aedes-persistence": "^6.0.0",
-        "bulk-write-stream": "^2.0.0",
-        "end-of-stream": "^1.4.1",
-        "fastfall": "^1.5.1",
-        "fastparallel": "^2.3.0",
-        "fastseries": "^1.7.2",
-        "from2": "^2.3.0",
-        "mqemitter": "^3.0.0",
-        "mqtt-packet": "^6.1.2",
-        "pump": "^3.0.0",
-        "retimer": "^2.0.0",
-        "reusify": "^1.0.4",
-        "shortid": "^2.2.14",
-        "through2": "^3.0.1",
-        "uuid": "^3.3.2"
+        "aedes-packet": "1.0.0",
+        "aedes-persistence": "6.0.0",
+        "bulk-write-stream": "2.0.0",
+        "end-of-stream": "1.4.1",
+        "fastfall": "1.5.1",
+        "fastparallel": "2.3.0",
+        "fastseries": "1.7.2",
+        "from2": "2.3.0",
+        "mqemitter": "3.0.0",
+        "mqtt-packet": "6.2.1",
+        "pump": "3.0.0",
+        "retimer": "2.0.0",
+        "reusify": "1.0.4",
+        "shortid": "2.2.15",
+        "through2": "3.0.1",
+        "uuid": "3.3.3"
       }
     },
     "aedes-cached-persistence": {
@@ -141,11 +141,11 @@
       "resolved": "https://registry.npmjs.org/aedes-cached-persistence/-/aedes-cached-persistence-6.0.0.tgz",
       "integrity": "sha512-cAorxr+vf3a48FqCZ0NE4jj93Lris39TguuLOGa8KoPOUt5MYcD90vW+bqYWtTITn3A51R2FrRn68QVuEl0shQ==",
       "requires": {
-        "aedes-packet": "^1.0.0",
-        "aedes-persistence": "^5.1.1",
-        "fastparallel": "^2.3.0",
-        "multistream": "^2.1.0",
-        "qlobber": "^1.8.0"
+        "aedes-packet": "1.0.0",
+        "aedes-persistence": "5.1.1",
+        "fastparallel": "2.3.0",
+        "multistream": "2.1.1",
+        "qlobber": "1.8.0"
       },
       "dependencies": {
         "aedes-persistence": {
@@ -153,10 +153,10 @@
           "resolved": "https://registry.npmjs.org/aedes-persistence/-/aedes-persistence-5.1.1.tgz",
           "integrity": "sha512-LqEW+SKKpcVlHmsSVyWRESITq2ty1josLersto0g2LX2u15UCD0AC6okfktH27xipEXLV6EpJjw1bP0m4FC73g==",
           "requires": {
-            "aedes-packet": "^1.0.0",
-            "from2": "^2.1.0",
-            "qlobber": "^1.8.0",
-            "safe-buffer": "^5.0.1"
+            "aedes-packet": "1.0.0",
+            "from2": "2.3.0",
+            "qlobber": "1.8.0",
+            "safe-buffer": "5.1.2"
           }
         },
         "qlobber": {
@@ -171,8 +171,8 @@
       "resolved": "https://registry.npmjs.org/aedes-logging/-/aedes-logging-2.0.1.tgz",
       "integrity": "sha512-eQdBRaZqUPcwmYAMLev22lF456ToTDw24oOPryGJaPm+fYfvKx5Wobvy2UWMdfzm1Qj6BkFS3iztCEQOO6O7Ig==",
       "requires": {
-        "pino": "^4.0.0",
-        "safe-buffer": "^5.0.1"
+        "pino": "4.17.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "aedes-packet": {
@@ -185,9 +185,9 @@
       "resolved": "https://registry.npmjs.org/aedes-persistence/-/aedes-persistence-6.0.0.tgz",
       "integrity": "sha512-LVk80Mg6bCfQgbcyo16ipuFo5KdORVxtzFAMmaisE3Hkydwt5H9I02gmF5IPADF5zPk0RfYxumQ4IIV1+jEp7Q==",
       "requires": {
-        "aedes-packet": "^1.0.0",
-        "from2": "^2.1.0",
-        "qlobber": "^3.0.2"
+        "aedes-packet": "1.0.0",
+        "from2": "2.3.0",
+        "qlobber": "3.1.0"
       }
     },
     "aedes-persistence-redis": {
@@ -195,15 +195,15 @@
       "resolved": "https://registry.npmjs.org/aedes-persistence-redis/-/aedes-persistence-redis-6.0.0.tgz",
       "integrity": "sha512-uK5yEuGEhrVbOse+UEomfCK2hxbXuCCfpO9bvsZJK/8bFam8T9YC6FLH5LdGB3bnsUWUtr7Og7ObMmAKW2u7dw==",
       "requires": {
-        "aedes-cached-persistence": "^6.0.0",
-        "from2": "^2.3.0",
-        "hashlru": "^2.2.1",
-        "ioredis": "^3.2.2",
-        "msgpack-lite": "^0.1.20",
-        "pump": "^3.0.0",
-        "qlobber": "^1.8.0",
-        "through2": "^2.0.0",
-        "throughv": "^1.0.3"
+        "aedes-cached-persistence": "6.0.0",
+        "from2": "2.3.0",
+        "hashlru": "2.3.0",
+        "ioredis": "3.2.2",
+        "msgpack-lite": "0.1.26",
+        "pump": "3.0.0",
+        "qlobber": "1.8.0",
+        "through2": "2.0.5",
+        "throughv": "1.0.4"
       },
       "dependencies": {
         "qlobber": {
@@ -216,8 +216,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.2"
           }
         }
       }
@@ -227,10 +227,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-keywords": {
@@ -255,7 +255,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "argparse": {
@@ -264,7 +264,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-includes": {
@@ -273,8 +273,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2"
       }
     },
     "ascli": {
@@ -282,8 +282,8 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "requires": {
-        "colour": "~0.7.1",
-        "optjs": "~3.2.2"
+        "colour": "0.7.1",
+        "optjs": "3.2.2"
       }
     },
     "asn1": {
@@ -291,7 +291,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -336,9 +336,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.3",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -353,11 +353,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -378,7 +378,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "tweetnacl": {
@@ -399,8 +399,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "bluebird": {
@@ -413,7 +413,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -434,8 +434,8 @@
       "resolved": "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-2.0.0.tgz",
       "integrity": "sha512-wFAa8+yXEvYO0W/zxh3q5X3cqxk0SyjbTH77pF82nEm0XY2ABu4zwx7/BA5bDgTjXgeCm0QEgnQCQ/c9d87BdA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
+        "inherits": "2.0.4",
+        "readable-stream": "3.4.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -443,9 +443,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.4",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -455,10 +455,10 @@
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
       "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
       "requires": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
+        "dtrace-provider": "0.8.8",
+        "moment": "2.24.0",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.2.0"
       }
     },
     "bytebuffer": {
@@ -466,7 +466,7 @@
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
-        "long": "~3"
+        "long": "3.2.0"
       },
       "dependencies": {
         "long": {
@@ -482,7 +482,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -507,9 +507,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chalk": {
@@ -517,9 +517,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -540,7 +540,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -554,9 +554,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "cluster-key-slot": {
@@ -598,7 +598,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -624,10 +624,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "contains-path": {
@@ -653,9 +653,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.5",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "dashdash": {
@@ -663,7 +663,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -708,7 +708,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       }
     },
     "delayed-stream": {
@@ -733,7 +733,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.3"
       }
     },
     "double-ended-queue": {
@@ -747,7 +747,7 @@
       "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
       "optional": true,
       "requires": {
-        "nan": "^2.14.0"
+        "nan": "2.14.0"
       }
     },
     "duplexify": {
@@ -755,10 +755,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -766,8 +766,8 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "end-of-stream": {
@@ -775,7 +775,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "error-ex": {
@@ -784,7 +784,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -793,16 +793,16 @@
       "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.0",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4",
+        "object-inspect": "1.6.0",
+        "object-keys": "1.1.1",
+        "string.prototype.trimleft": "2.1.0",
+        "string.prototype.trimright": "2.1.0"
       }
     },
     "es-to-primitive": {
@@ -811,9 +811,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -827,44 +827,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.2",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.2.6",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.3",
+        "eslint-visitor-keys": "1.1.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.3",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.4",
+        "globals": "11.12.0",
+        "ignore": "3.3.10",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.13.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.15",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.3",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.7.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
         "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -873,10 +873,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
@@ -891,7 +891,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "fast-deep-equal": {
@@ -906,12 +906,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "json-schema-traverse": {
@@ -932,7 +932,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -943,7 +943,7 @@
       "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1"
+        "eslint-restricted-globals": "0.1.1"
       }
     },
     "eslint-import-resolver-node": {
@@ -952,8 +952,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.12.0"
       }
     },
     "eslint-module-utils": {
@@ -962,8 +962,8 @@
       "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "2.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -972,17 +972,17 @@
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.9",
+        "array-includes": "3.0.3",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
-        "has": "^1.0.3",
-        "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.4.1",
+        "has": "1.0.3",
+        "minimatch": "3.0.4",
+        "object.values": "1.1.0",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.12.0"
       },
       "dependencies": {
         "doctrine": {
@@ -991,8 +991,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.3",
+            "isarray": "1.0.0"
           }
         }
       }
@@ -1009,8 +1009,8 @@
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.3.0"
       }
     },
     "eslint-visitor-keys": {
@@ -1025,8 +1025,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.7.3",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -1041,7 +1041,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.3.0"
       }
     },
     "esrecurse": {
@@ -1050,7 +1050,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.3.0"
       }
     },
     "estraverse": {
@@ -1081,9 +1081,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extsprintf": {
@@ -1122,7 +1122,7 @@
       "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
       "integrity": "sha1-P+4DMxpJ0dObPN96XpzWb0dee5Q=",
       "requires": {
-        "reusify": "^1.0.0"
+        "reusify": "1.0.4"
       }
     },
     "fastparallel": {
@@ -1130,8 +1130,8 @@
       "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.3.0.tgz",
       "integrity": "sha1-HnCb+2oDmT84V+POfwExHOdgJhM=",
       "requires": {
-        "reusify": "^1.0.0",
-        "xtend": "^4.0.1"
+        "reusify": "1.0.4",
+        "xtend": "4.0.2"
       }
     },
     "fastseries": {
@@ -1139,8 +1139,8 @@
       "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
       "integrity": "sha1-0izhO5Qz3/M4jZHb1ri9qbIaD0s=",
       "requires": {
-        "reusify": "^1.0.0",
-        "xtend": "^4.0.0"
+        "reusify": "1.0.4",
+        "xtend": "4.0.2"
       }
     },
     "figures": {
@@ -1149,7 +1149,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1158,8 +1158,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "find-up": {
@@ -1168,7 +1168,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "flat-cache": {
@@ -1177,10 +1177,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.2.2",
+        "rimraf": "2.6.3",
+        "write": "0.2.1"
       },
       "dependencies": {
         "glob": {
@@ -1189,12 +1189,12 @@
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "rimraf": {
@@ -1203,7 +1203,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         }
       }
@@ -1228,9 +1228,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.8",
+        "mime-types": "2.1.24"
       }
     },
     "formidable": {
@@ -1244,8 +1244,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6"
       }
     },
     "fs.realpath": {
@@ -1271,7 +1271,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -1280,11 +1280,11 @@
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "optional": true,
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -1310,12 +1310,12 @@
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.23.3.tgz",
       "integrity": "sha512-7vdzxPw9s5UYch4aUn4hyM5tMaouaxUUkwkgJlwbR4AXMxiYZJOv19N2ps2eKiuUbJovo5fnGF9hg/X91gWYjw==",
       "requires": {
-        "@types/bytebuffer": "^5.0.40",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.clone": "^4.5.0",
-        "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
-        "protobufjs": "^5.0.3"
+        "@types/bytebuffer": "5.0.40",
+        "lodash.camelcase": "4.3.0",
+        "lodash.clone": "4.5.0",
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.13.0",
+        "protobufjs": "5.0.3"
       },
       "dependencies": {
         "abbrev": {
@@ -1334,8 +1334,8 @@
           "version": "1.1.5",
           "bundled": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -1346,7 +1346,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1374,7 +1374,7 @@
           "version": "3.2.6",
           "bundled": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "deep-extend": {
@@ -1393,7 +1393,7 @@
           "version": "1.2.6",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -1404,26 +1404,26 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
           "version": "7.1.4",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -1434,22 +1434,22 @@
           "version": "0.4.24",
           "bundled": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -1464,7 +1464,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -1475,7 +1475,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -1486,15 +1486,15 @@
           "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
@@ -1518,33 +1518,33 @@
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "3.2.6",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.13.0",
           "bundled": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.4.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.4",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.7.1",
+            "semver": "5.7.1",
+            "tar": "4.4.10"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -1555,18 +1555,18 @@
           "version": "1.4.4",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.6"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -1581,7 +1581,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -1596,8 +1596,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -1613,40 +1613,40 @@
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
           "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
           "requires": {
-            "ascli": "~1",
-            "bytebuffer": "~5",
-            "glob": "^7.0.5",
-            "yargs": "^3.10.0"
+            "ascli": "1.0.1",
+            "bytebuffer": "5.0.1",
+            "glob": "7.1.4",
+            "yargs": "3.32.0"
           }
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         },
         "safe-buffer": {
@@ -1677,23 +1677,23 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -1704,13 +1704,13 @@
           "version": "4.4.10",
           "bundled": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "1.1.2",
+            "fs-minipass": "1.2.6",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -1721,7 +1721,7 @@
           "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -1744,8 +1744,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.10.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -1754,7 +1754,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1763,7 +1763,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -1799,9 +1799,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "hyperid": {
@@ -1809,8 +1809,8 @@
       "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-1.4.1.tgz",
       "integrity": "sha512-rtuRoJyEPZZEGN25T1PC2/IYxdApJEYbBB+8e7vZMFnfhZV7HobkpUr7z1gZvcxqleg4OVg0YrMEtfmIoV85gQ==",
       "requires": {
-        "uuid": "^3.2.1",
-        "uuid-parse": "^1.0.0"
+        "uuid": "3.3.3",
+        "uuid-parse": "1.1.0"
       }
     },
     "iconv-lite": {
@@ -1819,7 +1819,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -1844,8 +1844,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1859,20 +1859,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.15",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1893,8 +1893,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1903,7 +1903,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1923,29 +1923,29 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
       "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
       "requires": {
-        "bluebird": "^3.3.4",
-        "cluster-key-slot": "^1.0.6",
-        "debug": "^2.6.9",
-        "denque": "^1.1.0",
+        "bluebird": "3.5.5",
+        "cluster-key-slot": "1.1.0",
+        "debug": "2.6.9",
+        "denque": "1.4.1",
         "flexbuffer": "0.0.6",
-        "lodash.assign": "^4.2.0",
-        "lodash.bind": "^4.2.1",
-        "lodash.clone": "^4.5.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.foreach": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.keys": "^4.2.0",
-        "lodash.noop": "^3.0.1",
-        "lodash.partial": "^4.2.1",
-        "lodash.pick": "^4.4.0",
-        "lodash.sample": "^4.2.1",
-        "lodash.shuffle": "^4.2.0",
-        "lodash.values": "^4.3.0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.4.0"
+        "lodash.assign": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.clone": "4.5.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.defaults": "4.2.0",
+        "lodash.difference": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.isempty": "4.4.0",
+        "lodash.keys": "4.2.0",
+        "lodash.noop": "3.0.1",
+        "lodash.partial": "4.2.1",
+        "lodash.pick": "4.4.0",
+        "lodash.sample": "4.2.1",
+        "lodash.shuffle": "4.2.0",
+        "lodash.values": "4.3.0",
+        "redis-commands": "1.5.0",
+        "redis-parser": "2.6.0"
       }
     },
     "irregular-plurals": {
@@ -1977,7 +1977,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-promise": {
@@ -1992,7 +1992,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-resolvable": {
@@ -2007,7 +2007,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -2043,8 +2043,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -2058,12 +2058,12 @@
       "integrity": "sha1-JCCCosA1rgP9gQROBXDMQgjPbmE=",
       "dev": true,
       "requires": {
-        "beeper": "^1.1.0",
-        "chalk": "^1.0.0",
-        "log-symbols": "^1.0.0",
-        "plur": "^2.1.0",
-        "string-length": "^1.0.0",
-        "text-table": "^0.2.0"
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "string-length": "1.0.1",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2078,11 +2078,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -2130,7 +2130,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
@@ -2139,8 +2139,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -2149,10 +2149,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.2.2",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -2161,8 +2161,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -2261,7 +2261,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2276,11 +2276,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -2301,8 +2301,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "methods": {
@@ -2341,7 +2341,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2391,12 +2391,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "supports-color": {
@@ -2405,7 +2405,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2421,8 +2421,8 @@
       "resolved": "https://registry.npmjs.org/mqemitter/-/mqemitter-3.0.0.tgz",
       "integrity": "sha512-1HduoiTFngBGFEKCGvfCpGfPM/3g58xtDW9fmuHpbnRieC01uAi3yJE/F1YsUrzH8p441l10kosYzi3HhJYnrQ==",
       "requires": {
-        "fastparallel": "^2.3.0",
-        "qlobber": "^3.1.0"
+        "fastparallel": "2.3.0",
+        "qlobber": "3.1.0"
       }
     },
     "mqemitter-redis": {
@@ -2430,12 +2430,12 @@
       "resolved": "https://registry.npmjs.org/mqemitter-redis/-/mqemitter-redis-3.0.0.tgz",
       "integrity": "sha512-Lk2kjJ8zCqnqH+0MDB2PdFLc88WOqrQ1peAJ+9YiJJqiqwzrEJU0QMJq1h9VRSZd6wqmovB8XyUPy+vD4cS/Zg==",
       "requires": {
-        "hyperid": "^1.4.1",
-        "inherits": "^2.0.1",
-        "ioredis": "^3.2.2",
-        "lru-cache": "^4.1.3",
-        "mqemitter": "^2.2.0",
-        "msgpack-lite": "^0.1.14"
+        "hyperid": "1.4.1",
+        "inherits": "2.0.4",
+        "ioredis": "3.2.2",
+        "lru-cache": "4.1.5",
+        "mqemitter": "2.2.0",
+        "msgpack-lite": "0.1.26"
       },
       "dependencies": {
         "mqemitter": {
@@ -2443,8 +2443,8 @@
           "resolved": "https://registry.npmjs.org/mqemitter/-/mqemitter-2.2.0.tgz",
           "integrity": "sha512-vyglbOjB8wWsL6qmu2ePFp3yOoK/aOSOQeIgvmrlPxfuqiZU/AcIkI0xGJun0sEOTCqa2LFyR6T+YX/2qFz+WA==",
           "requires": {
-            "fastparallel": "^2.0.0",
-            "qlobber": "^1.8.0"
+            "fastparallel": "2.3.0",
+            "qlobber": "1.8.0"
           }
         },
         "qlobber": {
@@ -2459,10 +2459,10 @@
       "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.2.1.tgz",
       "integrity": "sha512-ZxG5QVb7+gMix5n4DClym9dQoCZC6DoNEqgMkMi/GMXvIU4Wsdx+/6KBavw50HHFH9kN1lBSY7phxNlAS2+jnw==",
       "requires": {
-        "bl": "^1.2.2",
-        "inherits": "^2.0.3",
-        "process-nextick-args": "^2.0.0",
-        "safe-buffer": "^5.1.2"
+        "bl": "1.2.2",
+        "inherits": "2.0.4",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2"
       }
     },
     "ms": {
@@ -2475,10 +2475,10 @@
       "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
       "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
       "requires": {
-        "event-lite": "^0.1.1",
-        "ieee754": "^1.1.8",
-        "int64-buffer": "^0.1.9",
-        "isarray": "^1.0.0"
+        "event-lite": "0.1.2",
+        "ieee754": "1.1.13",
+        "int64-buffer": "0.1.10",
+        "isarray": "1.0.0"
       }
     },
     "multistream": {
@@ -2486,8 +2486,8 @@
       "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
       "integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.5"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6"
       }
     },
     "mute-stream": {
@@ -2502,9 +2502,9 @@
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
       }
     },
     "nan": {
@@ -2522,8 +2522,8 @@
       "resolved": "https://registry.npmjs.org/nats/-/nats-1.3.0.tgz",
       "integrity": "sha512-0Rbtl0WV5kXLcZlE5fbX06/YwVzvx9Ui5xaIsVH6rzRGu7FRUAHxueaZBPHIN3M82s3N4bbkSwghYipgcsIgbA==",
       "requires": {
-        "nuid": "^1.0.0",
-        "ts-nkeys": "^1.0.8"
+        "nuid": "1.1.0",
+        "ts-nkeys": "1.0.12"
       }
     },
     "natural-compare": {
@@ -2544,10 +2544,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.8.4",
+        "resolve": "1.12.0",
+        "semver": "5.7.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "nuid": {
@@ -2589,10 +2589,10 @@
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.14.2",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "once": {
@@ -2600,7 +2600,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -2609,7 +2609,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -2618,12 +2618,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "optjs": {
@@ -2636,7 +2636,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -2651,7 +2651,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -2660,7 +2660,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -2675,7 +2675,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "path-exists": {
@@ -2707,7 +2707,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "performance-now": {
@@ -2726,14 +2726,14 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-4.17.6.tgz",
       "integrity": "sha512-LFDwmhyWLBnmwO/2UFbWu1jEGVDzaPupaVdx0XcZ3tIAx1EDEBauzxXf2S0UcFK7oe+X9MApjH0hx9U1XMgfCA==",
       "requires": {
-        "chalk": "^2.4.1",
-        "fast-json-parse": "^1.0.3",
-        "fast-safe-stringify": "^1.2.3",
-        "flatstr": "^1.0.5",
-        "pino-std-serializers": "^2.0.0",
-        "pump": "^3.0.0",
-        "quick-format-unescaped": "^1.1.2",
-        "split2": "^2.2.0"
+        "chalk": "2.4.2",
+        "fast-json-parse": "1.0.3",
+        "fast-safe-stringify": "1.2.3",
+        "flatstr": "1.0.12",
+        "pino-std-serializers": "2.4.2",
+        "pump": "3.0.0",
+        "quick-format-unescaped": "1.1.2",
+        "split2": "2.2.0"
       }
     },
     "pino-std-serializers": {
@@ -2747,7 +2747,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "plur": {
@@ -2756,7 +2756,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -2787,19 +2787,19 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
+        "@protobufjs/aspromise": "1.1.2",
+        "@protobufjs/base64": "1.1.2",
+        "@protobufjs/codegen": "2.0.4",
+        "@protobufjs/eventemitter": "1.1.0",
+        "@protobufjs/fetch": "1.1.0",
+        "@protobufjs/float": "1.0.2",
+        "@protobufjs/inquire": "1.1.0",
+        "@protobufjs/path": "1.1.2",
+        "@protobufjs/pool": "1.1.0",
+        "@protobufjs/utf8": "1.1.0",
+        "@types/long": "4.0.0",
+        "@types/node": "10.14.18",
+        "long": "4.0.0"
       }
     },
     "pseudomap": {
@@ -2817,8 +2817,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -2841,7 +2841,7 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
       "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
       "requires": {
-        "fast-safe-stringify": "^1.0.8"
+        "fast-safe-stringify": "1.2.3"
       }
     },
     "read-pkg": {
@@ -2850,9 +2850,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.5.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -2861,8 +2861,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       }
     },
     "readable-stream": {
@@ -2870,13 +2870,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.4",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "redis": {
@@ -2884,9 +2884,9 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.5.0",
+        "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
@@ -2910,26 +2910,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.8",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.24",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.3"
       }
     },
     "require-uncached": {
@@ -2938,8 +2938,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -2948,7 +2948,7 @@
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-from": {
@@ -2963,8 +2963,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "retimer": {
@@ -2983,7 +2983,7 @@
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "optional": true,
       "requires": {
-        "glob": "^6.0.1"
+        "glob": "6.0.4"
       }
     },
     "run-async": {
@@ -2992,7 +2992,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -3007,7 +3007,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -3038,7 +3038,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -3052,7 +3052,7 @@
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
       "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
       "requires": {
-        "nanoid": "^2.1.0"
+        "nanoid": "2.1.1"
       }
     },
     "signal-exit": {
@@ -3067,7 +3067,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -3084,8 +3084,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-exceptions": {
@@ -3100,8 +3100,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-license-ids": {
@@ -3115,7 +3115,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.5"
       },
       "dependencies": {
         "through2": {
@@ -3123,8 +3123,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.2"
           }
         }
       }
@@ -3140,15 +3140,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "tweetnacl": {
@@ -3169,7 +3169,7 @@
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "3.0.1"
       }
     },
     "string-width": {
@@ -3177,9 +3177,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.prototype.trimleft": {
@@ -3188,8 +3188,8 @@
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -3198,8 +3198,8 @@
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -3207,7 +3207,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -3215,7 +3215,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -3236,16 +3236,16 @@
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "1.3.0",
+        "cookiejar": "2.1.2",
+        "debug": "3.2.6",
+        "extend": "3.0.2",
+        "form-data": "2.3.3",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.2",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -3254,7 +3254,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -3271,8 +3271,8 @@
       "integrity": "sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==",
       "dev": true,
       "requires": {
-        "methods": "^1.1.2",
-        "superagent": "^3.8.3"
+        "methods": "1.1.2",
+        "superagent": "3.8.3"
       }
     },
     "supports-color": {
@@ -3280,7 +3280,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "table": {
@@ -3289,12 +3289,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.2",
+        "lodash": "4.17.15",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -3303,10 +3303,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ansi-regex": {
@@ -3339,8 +3339,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -3349,7 +3349,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -3371,7 +3371,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "requires": {
-        "readable-stream": "2 || 3"
+        "readable-stream": "2.3.6"
       }
     },
     "throughv": {
@@ -3379,9 +3379,9 @@
       "resolved": "https://registry.npmjs.org/throughv/-/throughv-1.0.4.tgz",
       "integrity": "sha512-sbtnSX5BC0IEbDNl4K4IRtea0ujic9uRlZPFzkQ8R9Z/F1NXM4mMWk9VwbI9tIltvxD7vnFJY5L4jDyb6xVsAA==",
       "requires": {
-        "fastparallel": "^2.3.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
+        "fastparallel": "2.3.0",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6"
       }
     },
     "tmp": {
@@ -3390,7 +3390,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "toml": {
@@ -3403,8 +3403,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.4.0",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -3419,7 +3419,7 @@
       "resolved": "https://registry.npmjs.org/ts-nkeys/-/ts-nkeys-1.0.12.tgz",
       "integrity": "sha512-5TgA+wbfxTy/9pdSuAhvneuL65KKoI7phonzNQH2UhnorAQAWehUwHNLEuli596wu/Fxh0SAhMeKZVLNx4s7Ow==",
       "requires": {
-        "tweetnacl": "^1.0.1"
+        "tweetnacl": "1.0.1"
       }
     },
     "tunnel-agent": {
@@ -3427,7 +3427,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -3441,7 +3441,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-detect": {
@@ -3466,7 +3466,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "util-deprecate": {
@@ -3490,8 +3490,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "verror": {
@@ -3499,9 +3499,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "websocket-stream": {
@@ -3509,12 +3509,12 @@
       "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.0.tgz",
       "integrity": "sha512-EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==",
       "requires": {
-        "duplexify": "^3.5.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "safe-buffer": "^5.1.2",
-        "ws": "^3.2.0",
-        "xtend": "^4.0.0"
+        "duplexify": "3.7.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "ws": "3.3.3",
+        "xtend": "4.0.2"
       }
     },
     "which": {
@@ -3523,7 +3523,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "window-size": {
@@ -3542,8 +3542,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -3557,7 +3557,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "ws": {
@@ -3565,9 +3565,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "xtend": {
@@ -3590,13 +3590,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     }
   }

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -104,7 +104,7 @@ func (cr channelRepository) RetrieveByID(ctx context.Context, owner, id string) 
 	return toChannel(dbch), nil
 }
 
-func (cr channelRepository) RetrieveAll(_ context.Context, owner string, offset, limit uint64, name string, metadata things.Metadata) (things.ChannelsPage, error) {
+func (cr channelRepository) RetrieveAll(ctx context.Context, owner string, offset, limit uint64, name string, metadata things.Metadata) (things.ChannelsPage, error) {
 	nq, name := getNameQuery(name)
 	m, mq, err := getMetadataQuery(metadata)
 	if err != nil {

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -23,14 +23,14 @@ import (
 var _ things.ChannelRepository = (*channelRepository)(nil)
 
 type channelRepository struct {
-	dm Database
+	db Database
 }
 
 // NewChannelRepository instantiates a PostgreSQL implementation of channel
 // repository.
-func NewChannelRepository(dm Database) things.ChannelRepository {
+func NewChannelRepository(db Database) things.ChannelRepository {
 	return &channelRepository{
-		dm: dm,
+		db: db,
 	}
 }
 
@@ -40,7 +40,7 @@ func (cr channelRepository) Save(ctx context.Context, channel things.Channel) (s
 
 	dbch := toDBChannel(channel)
 
-	if _, err := cr.dm.NamedExecContext(ctx, q, dbch); err != nil {
+	if _, err := cr.db.NamedExecContext(ctx, q, dbch); err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
 			switch pqErr.Code.Name() {
@@ -60,7 +60,7 @@ func (cr channelRepository) Update(ctx context.Context, channel things.Channel) 
 
 	dbch := toDBChannel(channel)
 
-	res, err := cr.dm.NamedExecContext(ctx, q, dbch)
+	res, err := cr.db.NamedExecContext(ctx, q, dbch)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -92,7 +92,7 @@ func (cr channelRepository) RetrieveByID(ctx context.Context, owner, id string) 
 		ID:    id,
 		Owner: owner,
 	}
-	if err := cr.dm.QueryRowxContext(ctx, q, id, owner).StructScan(&dbch); err != nil {
+	if err := cr.db.QueryRowxContext(ctx, q, id, owner).StructScan(&dbch); err != nil {
 		empty := things.Channel{}
 		pqErr, ok := err.(*pq.Error)
 		if err == sql.ErrNoRows || ok && errInvalid == pqErr.Code.Name() {
@@ -121,7 +121,7 @@ func (cr channelRepository) RetrieveAll(_ context.Context, owner string, offset,
 		"name":     name,
 		"metadata": m,
 	}
-	rows, err := cr.dm.NamedQueryContext(ctx, q, params)
+	rows, err := cr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return things.ChannelsPage{}, err
 	}
@@ -148,11 +148,11 @@ func (cr channelRepository) RetrieveAll(_ context.Context, owner string, offset,
 	total := uint64(0)
 	switch name {
 	case "":
-		if err := cr.dm.GetContext(ctx, &total, q, owner); err != nil {
+		if err := cr.db.GetContext(ctx, &total, q, owner); err != nil {
 			return things.ChannelsPage{}, err
 		}
 	default:
-		if err := cr.dm.GetContext(ctx, &total, q, owner, name); err != nil {
+		if err := cr.db.GetContext(ctx, &total, q, owner, name); err != nil {
 			return things.ChannelsPage{}, err
 		}
 	}
@@ -191,7 +191,7 @@ func (cr channelRepository) RetrieveByThing(ctx context.Context, owner, thing st
 		"offset": offset,
 	}
 
-	rows, err := cr.dm.NamedQueryContext(ctx, q, params)
+	rows, err := cr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return things.ChannelsPage{}, err
 	}
@@ -215,7 +215,7 @@ func (cr channelRepository) RetrieveByThing(ctx context.Context, owner, thing st
 	     WHERE ch.owner = $1 AND co.thing_id = $2`
 
 	var total uint64
-	if err := cr.dm.GetContext(ctx, &total, q, owner, thing); err != nil {
+	if err := cr.db.GetContext(ctx, &total, q, owner, thing); err != nil {
 		return things.ChannelsPage{}, err
 	}
 
@@ -235,7 +235,7 @@ func (cr channelRepository) Remove(ctx context.Context, owner, id string) error 
 		Owner: owner,
 	}
 	q := `DELETE FROM channels WHERE id = :id AND owner = :owner`
-	cr.dm.NamedExecContext(ctx, q, dbch)
+	cr.db.NamedExecContext(ctx, q, dbch)
 	return nil
 }
 
@@ -249,7 +249,7 @@ func (cr channelRepository) Connect(ctx context.Context, owner, chanID, thingID 
 		Owner:   owner,
 	}
 
-	if _, err := cr.dm.NamedExecContext(ctx, q, conn); err != nil {
+	if _, err := cr.db.NamedExecContext(ctx, q, conn); err != nil {
 		pqErr, ok := err.(*pq.Error)
 
 		if ok && errFK == pqErr.Code.Name() {
@@ -278,7 +278,7 @@ func (cr channelRepository) Disconnect(ctx context.Context, owner, chanID, thing
 		Owner:   owner,
 	}
 
-	res, err := cr.dm.NamedExecContext(ctx, q, conn)
+	res, err := cr.db.NamedExecContext(ctx, q, conn)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (cr channelRepository) Disconnect(ctx context.Context, owner, chanID, thing
 func (cr channelRepository) HasThing(ctx context.Context, chanID, key string) (string, error) {
 	var thingID string
 	q := `SELECT id FROM things WHERE key = $1`
-	if err := cr.dm.QueryRowxContext(ctx, q, key).Scan(&thingID); err != nil {
+	if err := cr.db.QueryRowxContext(ctx, q, key).Scan(&thingID); err != nil {
 		return "", err
 
 	}
@@ -317,7 +317,7 @@ func (cr channelRepository) HasThingByID(ctx context.Context, chanID, thingID st
 func (cr channelRepository) hasThing(ctx context.Context, chanID, thingID string) error {
 	q := `SELECT EXISTS (SELECT 1 FROM connections WHERE channel_id = $1 AND thing_id = $2);`
 	exists := false
-	if err := cr.dm.QueryRowxContext(ctx, q, chanID, thingID).Scan(&exists); err != nil {
+	if err := cr.db.QueryRowxContext(ctx, q, chanID, thingID).Scan(&exists); err != nil {
 		return err
 	}
 
@@ -416,7 +416,7 @@ func getMetadataQuery(m things.Metadata) ([]byte, string, error) {
 }
 
 type dbConnection struct {
-	Channel string `dm:"channel"`
-	Thing   string `dm:"thing"`
-	Owner   string `dm:"owner"`
+	Channel string `db:"channel"`
+	Thing   string `db:"thing"`
+	Owner   string `db:"owner"`
 }

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestChannelSave(t *testing.T) {
 	email := "channel-save@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	channelRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	id, err := uuid.New().ID()
@@ -70,7 +70,7 @@ func TestChannelSave(t *testing.T) {
 
 func TestChannelUpdate(t *testing.T) {
 	email := "channel-update@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	cid, err := uuid.New().ID()
@@ -130,7 +130,7 @@ func TestChannelUpdate(t *testing.T) {
 
 func TestSingleChannelRetrieval(t *testing.T) {
 	email := "channel-single-retrieval@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
@@ -195,7 +195,7 @@ func TestSingleChannelRetrieval(t *testing.T) {
 
 func TestMultiChannelRetrieval(t *testing.T) {
 	email := "channel-multi-retrieval@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	channelName := "channel_name"
 	meta := things.Metadata{}
@@ -302,7 +302,7 @@ func TestMultiChannelRetrieval(t *testing.T) {
 func TestMultiChannelRetrievalByThing(t *testing.T) {
 	email := "channel-multi-retrieval-by-thing@example.com"
 	idp := uuid.New()
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
@@ -387,7 +387,7 @@ func TestMultiChannelRetrievalByThing(t *testing.T) {
 
 func TestChannelRemoval(t *testing.T) {
 	email := "channel-removal@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	chid, err := uuid.New().ID()
@@ -410,7 +410,7 @@ func TestChannelRemoval(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	email := "channel-connect@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
@@ -493,7 +493,7 @@ func TestConnect(t *testing.T) {
 
 func TestDisconnect(t *testing.T) {
 	email := "channel-disconnect@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
@@ -576,7 +576,7 @@ func TestDisconnect(t *testing.T) {
 
 func TestHasThing(t *testing.T) {
 	email := "channel-access-check@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
@@ -634,7 +634,7 @@ func TestHasThing(t *testing.T) {
 
 func TestHasThingByID(t *testing.T) {
 	email := "channel-access-check@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -22,7 +22,8 @@ import (
 
 func TestChannelSave(t *testing.T) {
 	email := "channel-save@example.com"
-	channelRepo := postgres.NewChannelRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	channelRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	id, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -69,7 +70,8 @@ func TestChannelSave(t *testing.T) {
 
 func TestChannelUpdate(t *testing.T) {
 	email := "channel-update@example.com"
-	chanRepo := postgres.NewChannelRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	cid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -128,8 +130,9 @@ func TestChannelUpdate(t *testing.T) {
 
 func TestSingleChannelRetrieval(t *testing.T) {
 	email := "channel-single-retrieval@example.com"
-	chanRepo := postgres.NewChannelRepository(db)
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -192,7 +195,8 @@ func TestSingleChannelRetrieval(t *testing.T) {
 
 func TestMultiChannelRetrieval(t *testing.T) {
 	email := "channel-multi-retrieval@example.com"
-	chanRepo := postgres.NewChannelRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	channelName := "channel_name"
 	meta := things.Metadata{}
 	wrongMeta := things.Metadata{}
@@ -298,8 +302,9 @@ func TestMultiChannelRetrieval(t *testing.T) {
 func TestMultiChannelRetrievalByThing(t *testing.T) {
 	email := "channel-multi-retrieval-by-thing@example.com"
 	idp := uuid.New()
-	chanRepo := postgres.NewChannelRepository(db)
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := idp.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -382,7 +387,8 @@ func TestMultiChannelRetrievalByThing(t *testing.T) {
 
 func TestChannelRemoval(t *testing.T) {
 	email := "channel-removal@example.com"
-	chanRepo := postgres.NewChannelRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	chid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -404,7 +410,8 @@ func TestChannelRemoval(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	email := "channel-connect@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -419,7 +426,7 @@ func TestConnect(t *testing.T) {
 	}
 	thingID, _ := thingRepo.Save(context.Background(), thing)
 
-	chanRepo := postgres.NewChannelRepository(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	chid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -486,7 +493,8 @@ func TestConnect(t *testing.T) {
 
 func TestDisconnect(t *testing.T) {
 	email := "channel-disconnect@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -501,7 +509,7 @@ func TestDisconnect(t *testing.T) {
 	}
 	thingID, _ := thingRepo.Save(context.Background(), thing)
 
-	chanRepo := postgres.NewChannelRepository(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	chid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	chanID, _ := chanRepo.Save(context.Background(), things.Channel{
@@ -568,7 +576,8 @@ func TestDisconnect(t *testing.T) {
 
 func TestHasThing(t *testing.T) {
 	email := "channel-access-check@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -582,7 +591,7 @@ func TestHasThing(t *testing.T) {
 	}
 	thingID, _ := thingRepo.Save(context.Background(), thing)
 
-	chanRepo := postgres.NewChannelRepository(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	chid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	chanID, _ := chanRepo.Save(context.Background(), things.Channel{
@@ -625,7 +634,8 @@ func TestHasThing(t *testing.T) {
 
 func TestHasThingByID(t *testing.T) {
 	email := "channel-access-check@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -651,7 +661,7 @@ func TestHasThingByID(t *testing.T) {
 	}
 	disconnectedThingID, _ := thingRepo.Save(context.Background(), disconnectedThing)
 
-	chanRepo := postgres.NewChannelRepository(db)
+	chanRepo := postgres.NewChannelRepository(dbMiddleware)
 	chid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	chanID, _ := chanRepo.Save(context.Background(), things.Channel{

--- a/things/postgres/database.go
+++ b/things/postgres/database.go
@@ -30,45 +30,31 @@ func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
 }
 
 func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.NamedExec(query, args)
 }
 
 func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.QueryRowx(query, args...)
 }
 
 func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.NamedQuery(query, args)
 }
 
 func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.Get(dest, query, args...)
+}
+
+func addSpanTags(ctx context.Context, query string) {
+	span := opentracing.SpanFromContext(ctx)
+	if span != nil {
+		span.SetTag("sql.statement", query)
+		span.SetTag("span.kind", "client")
+		span.SetTag("peer.service", "postgres")
+		span.SetTag("db.type", "sql")
+	}
 }

--- a/things/postgres/database.go
+++ b/things/postgres/database.go
@@ -8,45 +8,45 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-var _ DatabaseMiddleware = (*databaseMiddleware)(nil)
+var _ Database = (*database)(nil)
 
-type databaseMiddleware struct {
+type database struct {
 	db *sqlx.DB
 }
 
-// DatabaseMiddleware provides a database interface
-type DatabaseMiddleware interface {
-	NamedExec(context.Context, string, interface{}) (sql.Result, error)
-	QueryRowx(context.Context, string, ...interface{}) *sqlx.Row
-	NamedQuery(context.Context, string, interface{}) (*sqlx.Rows, error)
-	Get(context.Context, interface{}, string, ...interface{}) error
+// Database provides a database interface
+type Database interface {
+	NamedExecContext(context.Context, string, interface{}) (sql.Result, error)
+	QueryRowxContext(context.Context, string, ...interface{}) *sqlx.Row
+	NamedQueryContext(context.Context, string, interface{}) (*sqlx.Rows, error)
+	GetContext(context.Context, interface{}, string, ...interface{}) error
 }
 
-// NewDatabaseMiddleware creates a ThingDatabase instance
-func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
-	return &databaseMiddleware{
+// NewDatabase creates a ThingDatabase instance
+func NewDatabase(db *sqlx.DB) Database {
+	return &database{
 		db: db,
 	}
 }
 
-func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
+func (dm database) NamedExecContext(ctx context.Context, query string, args interface{}) (sql.Result, error) {
 	addSpanTags(ctx, query)
-	return dm.db.NamedExec(query, args)
+	return dm.db.NamedExecContext(ctx, query, args)
 }
 
-func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+func (dm database) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
 	addSpanTags(ctx, query)
-	return dm.db.QueryRowx(query, args...)
+	return dm.db.QueryRowxContext(ctx, query, args...)
 }
 
-func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
+func (dm database) NamedQueryContext(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
 	addSpanTags(ctx, query)
-	return dm.db.NamedQuery(query, args)
+	return dm.db.NamedQueryContext(ctx, query, args)
 }
 
-func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+func (dm database) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	addSpanTags(ctx, query)
-	return dm.db.Get(dest, query, args...)
+	return dm.db.GetContext(ctx, dest, query, args...)
 }
 
 func addSpanTags(ctx context.Context, query string) {

--- a/things/postgres/database.go
+++ b/things/postgres/database.go
@@ -1,0 +1,74 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/opentracing/opentracing-go"
+)
+
+var _ DatabaseMiddleware = (*databaseMiddleware)(nil)
+
+type databaseMiddleware struct {
+	db *sqlx.DB
+}
+
+// DatabaseMiddleware provides a database interface
+type DatabaseMiddleware interface {
+	NamedExec(context.Context, string, interface{}) (sql.Result, error)
+	QueryRowx(context.Context, string, ...interface{}) *sqlx.Row
+	NamedQuery(context.Context, string, interface{}) (*sqlx.Rows, error)
+	Get(context.Context, interface{}, string, ...interface{}) error
+}
+
+// NewDatabaseMiddleware creates a ThingDatabase instance
+func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
+	return &databaseMiddleware{
+		db: db,
+	}
+}
+
+func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.NamedExec(query, args)
+}
+
+func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.QueryRowx(query, args...)
+}
+
+func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.NamedQuery(query, args)
+}
+
+func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.Get(dest, query, args...)
+}

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -171,7 +171,7 @@ func (tr thingRepository) RetrieveByKey(ctx context.Context, key string) (string
 	return id, nil
 }
 
-func (tr thingRepository) RetrieveAll(_ context.Context, owner string, offset, limit uint64, name string, metadata things.Metadata) (things.ThingsPage, error) {
+func (tr thingRepository) RetrieveAll(ctx context.Context, owner string, offset, limit uint64, name string, metadata things.Metadata) (things.ThingsPage, error) {
 	nq, name := getNameQuery(name)
 	m, mq, err := getMetadataQuery(metadata)
 	if err != nil {

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -28,14 +28,14 @@ const (
 var _ things.ThingRepository = (*thingRepository)(nil)
 
 type thingRepository struct {
-	dm Database
+	db Database
 }
 
 // NewThingRepository instantiates a PostgreSQL implementation of thing
 // repository.
-func NewThingRepository(dm Database) things.ThingRepository {
+func NewThingRepository(db Database) things.ThingRepository {
 	return &thingRepository{
-		dm: dm,
+		db: db,
 	}
 }
 
@@ -48,7 +48,7 @@ func (tr thingRepository) Save(ctx context.Context, thing things.Thing) (string,
 		return "", err
 	}
 
-	_, err = tr.dm.NamedExecContext(ctx, q, dbth)
+	_, err = tr.db.NamedExecContext(ctx, q, dbth)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -74,7 +74,7 @@ func (tr thingRepository) Update(ctx context.Context, thing things.Thing) error 
 		return err
 	}
 
-	res, err := tr.dm.NamedExecContext(ctx, q, dbth)
+	res, err := tr.db.NamedExecContext(ctx, q, dbth)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -108,7 +108,7 @@ func (tr thingRepository) UpdateKey(ctx context.Context, owner, id, key string) 
 		Key:   key,
 	}
 
-	res, err := tr.dm.NamedExecContext(ctx, q, dbth)
+	res, err := tr.db.NamedExecContext(ctx, q, dbth)
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if ok {
@@ -143,7 +143,7 @@ func (tr thingRepository) RetrieveByID(ctx context.Context, owner, id string) (t
 		Owner: owner,
 	}
 
-	if err := tr.dm.QueryRowxContext(ctx, q, id, owner).StructScan(&dbth); err != nil {
+	if err := tr.db.QueryRowxContext(ctx, q, id, owner).StructScan(&dbth); err != nil {
 		empty := things.Thing{}
 
 		pqErr, ok := err.(*pq.Error)
@@ -161,7 +161,7 @@ func (tr thingRepository) RetrieveByKey(ctx context.Context, key string) (string
 	q := `SELECT id FROM things WHERE key = $1;`
 
 	var id string
-	if err := tr.dm.QueryRowxContext(ctx, q, key).Scan(&id); err != nil {
+	if err := tr.db.QueryRowxContext(ctx, q, key).Scan(&id); err != nil {
 		if err == sql.ErrNoRows {
 			return "", things.ErrNotFound
 		}
@@ -189,7 +189,7 @@ func (tr thingRepository) RetrieveAll(_ context.Context, owner string, offset, l
 		"metadata": m,
 	}
 
-	rows, err := tr.dm.NamedQueryContext(ctx, q, params)
+	rows, err := tr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return things.ThingsPage{}, err
 	}
@@ -220,11 +220,11 @@ func (tr thingRepository) RetrieveAll(_ context.Context, owner string, offset, l
 	total := uint64(0)
 	switch name {
 	case "":
-		if err := tr.dm.GetContext(ctx, &total, q, owner); err != nil {
+		if err := tr.db.GetContext(ctx, &total, q, owner); err != nil {
 			return things.ThingsPage{}, err
 		}
 	default:
-		if err := tr.dm.GetContext(ctx, &total, q, owner, name); err != nil {
+		if err := tr.db.GetContext(ctx, &total, q, owner, name); err != nil {
 			return things.ThingsPage{}, err
 		}
 	}
@@ -263,7 +263,7 @@ func (tr thingRepository) RetrieveByChannel(ctx context.Context, owner, channel 
 		"offset":  offset,
 	}
 
-	rows, err := tr.dm.NamedQueryContext(ctx, q, params)
+	rows, err := tr.db.NamedQueryContext(ctx, q, params)
 	if err != nil {
 		return things.ThingsPage{}, err
 	}
@@ -291,7 +291,7 @@ func (tr thingRepository) RetrieveByChannel(ctx context.Context, owner, channel 
 	     WHERE th.owner = $1 AND co.channel_id = $2;`
 
 	var total uint64
-	if err := tr.dm.GetContext(ctx, &total, q, owner, channel); err != nil {
+	if err := tr.db.GetContext(ctx, &total, q, owner, channel); err != nil {
 		return things.ThingsPage{}, err
 	}
 
@@ -311,7 +311,7 @@ func (tr thingRepository) Remove(ctx context.Context, owner, id string) error {
 		Owner: owner,
 	}
 	q := `DELETE FROM things WHERE id = :id AND owner = :owner;`
-	tr.dm.NamedExecContext(ctx, q, dbth)
+	tr.db.NamedExecContext(ctx, q, dbth)
 	return nil
 }
 

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -26,7 +26,7 @@ const maxNameSize = 1024
 var invalidName = strings.Repeat("m", maxNameSize+1)
 
 func TestThingSave(t *testing.T) {
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	email := "thing-save@example.com"
@@ -97,7 +97,7 @@ func TestThingSave(t *testing.T) {
 }
 
 func TestThingUpdate(t *testing.T) {
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	email := "thing-update@example.com"
@@ -185,7 +185,7 @@ func TestThingUpdate(t *testing.T) {
 func TestUpdateKey(t *testing.T) {
 	email := "thing-update=key@example.com"
 	newKey := "new-key"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	ethid, err := uuid.New().ID()
@@ -270,7 +270,7 @@ func TestUpdateKey(t *testing.T) {
 
 func TestSingleThingRetrieval(t *testing.T) {
 	email := "thing-single-retrieval@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
@@ -325,7 +325,7 @@ func TestSingleThingRetrieval(t *testing.T) {
 
 func TestThingRetrieveByKey(t *testing.T) {
 	email := "thing-retrieved-by-key@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
@@ -373,7 +373,7 @@ func TestMultiThingRetrieval(t *testing.T) {
 	metadata["serial"] = "123456"
 	metadata["type"] = "test"
 	idp := uuid.New()
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	n := uint64(10)
@@ -466,7 +466,7 @@ func TestMultiThingRetrieval(t *testing.T) {
 func TestMultiThingRetrievalByChannel(t *testing.T) {
 	email := "thing-multi-retrieval-by-channel@example.com"
 	idp := uuid.New()
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 	channelRepo := postgres.NewChannelRepository(dbMiddleware)
 
@@ -556,7 +556,7 @@ func TestMultiThingRetrievalByChannel(t *testing.T) {
 
 func TestThingRemoval(t *testing.T) {
 	email := "thing-removal@example.com"
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -26,7 +26,8 @@ const maxNameSize = 1024
 var invalidName = strings.Repeat("m", maxNameSize+1)
 
 func TestThingSave(t *testing.T) {
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	email := "thing-save@example.com"
 
@@ -96,7 +97,8 @@ func TestThingSave(t *testing.T) {
 }
 
 func TestThingUpdate(t *testing.T) {
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	email := "thing-update@example.com"
 	validName := "mfx_device"
@@ -183,7 +185,8 @@ func TestThingUpdate(t *testing.T) {
 func TestUpdateKey(t *testing.T) {
 	email := "thing-update=key@example.com"
 	newKey := "new-key"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	ethid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -267,7 +270,8 @@ func TestUpdateKey(t *testing.T) {
 
 func TestSingleThingRetrieval(t *testing.T) {
 	email := "thing-single-retrieval@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -321,7 +325,8 @@ func TestSingleThingRetrieval(t *testing.T) {
 
 func TestThingRetrieveByKey(t *testing.T) {
 	email := "thing-retrieved-by-key@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -368,7 +373,8 @@ func TestMultiThingRetrieval(t *testing.T) {
 	metadata["serial"] = "123456"
 	metadata["type"] = "test"
 	idp := uuid.New()
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	n := uint64(10)
 	for i := uint64(0); i < n; i++ {
@@ -460,8 +466,9 @@ func TestMultiThingRetrieval(t *testing.T) {
 func TestMultiThingRetrievalByChannel(t *testing.T) {
 	email := "thing-multi-retrieval-by-channel@example.com"
 	idp := uuid.New()
-	thingRepo := postgres.NewThingRepository(db)
-	channelRepo := postgres.NewChannelRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
+	channelRepo := postgres.NewChannelRepository(dbMiddleware)
 
 	n := uint64(10)
 
@@ -549,7 +556,8 @@ func TestMultiThingRetrievalByChannel(t *testing.T) {
 
 func TestThingRemoval(t *testing.T) {
 	email := "thing-removal@example.com"
-	thingRepo := postgres.NewThingRepository(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	thingRepo := postgres.NewThingRepository(dbMiddleware)
 
 	thid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -148,12 +148,19 @@ func (tcm thingCacheMiddleware) Remove(ctx context.Context, thingID string) erro
 }
 
 func createSpan(ctx context.Context, tracer opentracing.Tracer, opName string) opentracing.Span {
+	var span opentracing.Span
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
-		return tracer.StartSpan(
+		span = tracer.StartSpan(
 			opName,
 			opentracing.ChildOf(parentSpan.Context()),
 		)
+	} else {
+		span = tracer.StartSpan(opName)
 	}
 
-	return tracer.StartSpan(opName)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return span
 }

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -148,19 +148,11 @@ func (tcm thingCacheMiddleware) Remove(ctx context.Context, thingID string) erro
 }
 
 func createSpan(ctx context.Context, tracer opentracing.Tracer, opName string) opentracing.Span {
-	var span opentracing.Span
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
-		span = tracer.StartSpan(
+		return tracer.StartSpan(
 			opName,
 			opentracing.ChildOf(parentSpan.Context()),
 		)
-	} else {
-		span = tracer.StartSpan(opName)
 	}
-
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
-	return span
+	return tracer.StartSpan(opName)
 }

--- a/users/postgres/database.go
+++ b/users/postgres/database.go
@@ -30,45 +30,31 @@ func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
 }
 
 func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.NamedExec(query, args)
 }
 
 func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.QueryRowx(query, args...)
 }
 
 func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.NamedQuery(query, args)
 }
 
 func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
-	span := opentracing.SpanFromContext(ctx)
-
-	span.SetTag("sql.statement", query)
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
+	addSpanTags(ctx, query)
 	return dm.db.Get(dest, query, args...)
+}
+
+func addSpanTags(ctx context.Context, query string) {
+	span := opentracing.SpanFromContext(ctx)
+	if span != nil {
+		span.SetTag("sql.statement", query)
+		span.SetTag("span.kind", "client")
+		span.SetTag("peer.service", "postgres")
+		span.SetTag("db.type", "sql")
+	}
 }

--- a/users/postgres/database.go
+++ b/users/postgres/database.go
@@ -8,45 +8,45 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-var _ DatabaseMiddleware = (*databaseMiddleware)(nil)
+var _ Database = (*database)(nil)
 
-type databaseMiddleware struct {
+type database struct {
 	db *sqlx.DB
 }
 
-// DatabaseMiddleware provides a database interface
-type DatabaseMiddleware interface {
-	NamedExec(context.Context, string, interface{}) (sql.Result, error)
-	QueryRowx(context.Context, string, ...interface{}) *sqlx.Row
-	NamedQuery(context.Context, string, interface{}) (*sqlx.Rows, error)
-	Get(context.Context, interface{}, string, ...interface{}) error
+// Database provides a database interface
+type Database interface {
+	NamedExecContext(context.Context, string, interface{}) (sql.Result, error)
+	QueryRowxContext(context.Context, string, ...interface{}) *sqlx.Row
+	NamedQueryContext(context.Context, string, interface{}) (*sqlx.Rows, error)
+	GetContext(context.Context, interface{}, string, ...interface{}) error
 }
 
-// NewDatabaseMiddleware creates a ThingDatabase instance
-func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
-	return &databaseMiddleware{
+// NewDatabase creates a ThingDatabase instance
+func NewDatabase(db *sqlx.DB) Database {
+	return &database{
 		db: db,
 	}
 }
 
-func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
+func (dm database) NamedExecContext(ctx context.Context, query string, args interface{}) (sql.Result, error) {
 	addSpanTags(ctx, query)
-	return dm.db.NamedExec(query, args)
+	return dm.db.NamedExecContext(ctx, query, args)
 }
 
-func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+func (dm database) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
 	addSpanTags(ctx, query)
-	return dm.db.QueryRowx(query, args...)
+	return dm.db.QueryRowxContext(ctx, query, args...)
 }
 
-func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
+func (dm database) NamedQueryContext(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
 	addSpanTags(ctx, query)
-	return dm.db.NamedQuery(query, args)
+	return dm.db.NamedQueryContext(ctx, query, args)
 }
 
-func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+func (dm database) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	addSpanTags(ctx, query)
-	return dm.db.Get(dest, query, args...)
+	return dm.db.GetContext(ctx, dest, query, args...)
 }
 
 func addSpanTags(ctx context.Context, query string) {

--- a/users/postgres/database.go
+++ b/users/postgres/database.go
@@ -1,0 +1,74 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/opentracing/opentracing-go"
+)
+
+var _ DatabaseMiddleware = (*databaseMiddleware)(nil)
+
+type databaseMiddleware struct {
+	db *sqlx.DB
+}
+
+// DatabaseMiddleware provides a database interface
+type DatabaseMiddleware interface {
+	NamedExec(context.Context, string, interface{}) (sql.Result, error)
+	QueryRowx(context.Context, string, ...interface{}) *sqlx.Row
+	NamedQuery(context.Context, string, interface{}) (*sqlx.Rows, error)
+	Get(context.Context, interface{}, string, ...interface{}) error
+}
+
+// NewDatabaseMiddleware creates a ThingDatabase instance
+func NewDatabaseMiddleware(db *sqlx.DB) DatabaseMiddleware {
+	return &databaseMiddleware{
+		db: db,
+	}
+}
+
+func (dm databaseMiddleware) NamedExec(ctx context.Context, query string, args interface{}) (sql.Result, error) {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.NamedExec(query, args)
+}
+
+func (dm databaseMiddleware) QueryRowx(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.QueryRowx(query, args...)
+}
+
+func (dm databaseMiddleware) NamedQuery(ctx context.Context, query string, args interface{}) (*sqlx.Rows, error) {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.NamedQuery(query, args)
+}
+
+func (dm databaseMiddleware) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	span := opentracing.SpanFromContext(ctx)
+
+	span.SetTag("sql.statement", query)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return dm.db.Get(dest, query, args...)
+}

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -22,12 +22,12 @@ var _ users.UserRepository = (*userRepository)(nil)
 const errDuplicate = "unique_violation"
 
 type userRepository struct {
-	dm DatabaseMiddleware
+	dm Database
 }
 
 // New instantiates a PostgreSQL implementation of user
 // repository.
-func New(dm DatabaseMiddleware) users.UserRepository {
+func New(dm Database) users.UserRepository {
 	return &userRepository{
 		dm: dm,
 	}
@@ -37,7 +37,7 @@ func (ur userRepository) Save(ctx context.Context, user users.User) error {
 	q := `INSERT INTO users (email, password, metadata) VALUES (:email, :password, :metadata)`
 
 	dbu := toDBUser(user)
-	if _, err := ur.dm.NamedExec(ctx, q, dbu); err != nil {
+	if _, err := ur.dm.NamedExecContext(ctx, q, dbu); err != nil {
 		if pqErr, ok := err.(*pq.Error); ok && errDuplicate == pqErr.Code.Name() {
 			return users.ErrConflict
 		}
@@ -53,7 +53,7 @@ func (ur userRepository) RetrieveByID(ctx context.Context, email string) (users.
 	dbu := dbUser{
 		Email: email,
 	}
-	if err := ur.dm.QueryRowx(ctx, q, email).StructScan(&dbu); err != nil {
+	if err := ur.dm.QueryRowxContext(ctx, q, email).StructScan(&dbu); err != nil {
 		if err == sql.ErrNoRows {
 			return users.User{}, users.ErrNotFound
 		}

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -22,14 +22,14 @@ var _ users.UserRepository = (*userRepository)(nil)
 const errDuplicate = "unique_violation"
 
 type userRepository struct {
-	dm Database
+	db Database
 }
 
 // New instantiates a PostgreSQL implementation of user
 // repository.
-func New(dm Database) users.UserRepository {
+func New(db Database) users.UserRepository {
 	return &userRepository{
-		dm: dm,
+		db: db,
 	}
 }
 
@@ -37,7 +37,7 @@ func (ur userRepository) Save(ctx context.Context, user users.User) error {
 	q := `INSERT INTO users (email, password, metadata) VALUES (:email, :password, :metadata)`
 
 	dbu := toDBUser(user)
-	if _, err := ur.dm.NamedExecContext(ctx, q, dbu); err != nil {
+	if _, err := ur.db.NamedExecContext(ctx, q, dbu); err != nil {
 		if pqErr, ok := err.(*pq.Error); ok && errDuplicate == pqErr.Code.Name() {
 			return users.ErrConflict
 		}
@@ -53,7 +53,7 @@ func (ur userRepository) RetrieveByID(ctx context.Context, email string) (users.
 	dbu := dbUser{
 		Email: email,
 	}
-	if err := ur.dm.QueryRowxContext(ctx, q, email).StructScan(&dbu); err != nil {
+	if err := ur.db.QueryRowxContext(ctx, q, email).StructScan(&dbu); err != nil {
 		if err == sql.ErrNoRows {
 			return users.User{}, users.ErrNotFound
 		}

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -44,7 +44,7 @@ func TestUserSave(t *testing.T) {
 		},
 	}
 
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.New(dbMiddleware)
 
 	for _, tc := range cases {
@@ -56,7 +56,7 @@ func TestUserSave(t *testing.T) {
 func TestSingleUserRetrieval(t *testing.T) {
 	email := "user-retrieval@example.com"
 
-	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.New(dbMiddleware)
 	err := repo.Save(context.Background(), users.User{
 		Email:    email,

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -44,7 +44,8 @@ func TestUserSave(t *testing.T) {
 		},
 	}
 
-	repo := postgres.New(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	repo := postgres.New(dbMiddleware)
 
 	for _, tc := range cases {
 		err := repo.Save(context.Background(), tc.user)
@@ -55,7 +56,8 @@ func TestUserSave(t *testing.T) {
 func TestSingleUserRetrieval(t *testing.T) {
 	email := "user-retrieval@example.com"
 
-	repo := postgres.New(db)
+	dbMiddleware := postgres.NewDatabaseMiddleware(db)
+	repo := postgres.New(dbMiddleware)
 	err := repo.Save(context.Background(), users.User{
 		Email:    email,
 		Password: "pass",

--- a/users/tracing/users.go
+++ b/users/tracing/users.go
@@ -54,19 +54,11 @@ func (urm userRepositoryMiddleware) RetrieveByID(ctx context.Context, id string)
 }
 
 func createSpan(ctx context.Context, tracer opentracing.Tracer, opName string) opentracing.Span {
-	var span opentracing.Span
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
-		span = tracer.StartSpan(
+		return tracer.StartSpan(
 			opName,
 			opentracing.ChildOf(parentSpan.Context()),
 		)
-	} else {
-		span = tracer.StartSpan(opName)
 	}
-
-	span.SetTag("span.kind", "client")
-	span.SetTag("peer.service", "postgres")
-	span.SetTag("db.type", "sql")
-
-	return span
+	return tracer.StartSpan(opName)
 }

--- a/users/tracing/users.go
+++ b/users/tracing/users.go
@@ -54,12 +54,19 @@ func (urm userRepositoryMiddleware) RetrieveByID(ctx context.Context, id string)
 }
 
 func createSpan(ctx context.Context, tracer opentracing.Tracer, opName string) opentracing.Span {
+	var span opentracing.Span
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
-		return tracer.StartSpan(
+		span = tracer.StartSpan(
 			opName,
 			opentracing.ChildOf(parentSpan.Context()),
 		)
+	} else {
+		span = tracer.StartSpan(opName)
 	}
 
-	return tracer.StartSpan(opName)
+	span.SetTag("span.kind", "client")
+	span.SetTag("peer.service", "postgres")
+	span.SetTag("db.type", "sql")
+
+	return span
 }


### PR DESCRIPTION
### What does this do?
Adds tags to tracing spans created for users, things, and channels.  The tags added in the database functions are placeholders since the data recommended in the span convention document is not available.

### Which issue(s) does this PR fix/relate to?
Relates to #787 

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
I will update the official documents showing users how to use Jaeger and open tracing once the related issue is completed.

### Notes
