### PR TITLE
MF-788 - Remove date and minimize copyright comments

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mainflux
 

--- a/bootstrap/api/doc.go
+++ b/bootstrap/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains implementation of bootstrap service HTTP API.
 package api

--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api_test
 

--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/bootstrap/api/responses.go
+++ b/bootstrap/api/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap
 

--- a/bootstrap/doc.go
+++ b/bootstrap/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package bootstrap contains the domain concept definitions needed to support
 // Mainflux bootstrap service functionality.

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/bootstrap/mocks/users.go
+++ b/bootstrap/mocks/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/bootstrap/postgres/doc.go
+++ b/bootstrap/postgres/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres contains repository implementations using PostgreSQL as
 // the underlying database.

--- a/bootstrap/postgres/init.go
+++ b/bootstrap/postgres/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/bootstrap/postgres/setup_test.go
+++ b/bootstrap/postgres/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/bootstrap/reader.go
+++ b/bootstrap/reader.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap
 

--- a/bootstrap/reader_test.go
+++ b/bootstrap/reader_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap_test
 

--- a/bootstrap/redis/consumer/doc.go
+++ b/bootstrap/redis/consumer/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package consumer contains events consumer for events
 // published by Things service.

--- a/bootstrap/redis/consumer/events.go
+++ b/bootstrap/redis/consumer/events.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package consumer
 

--- a/bootstrap/redis/consumer/streams.go
+++ b/bootstrap/redis/consumer/streams.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package consumer
 

--- a/bootstrap/redis/producer/doc.go
+++ b/bootstrap/redis/producer/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package producer contains the domain events needed to support
 // event sourcing of Bootstrap service actions.

--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package producer
 

--- a/bootstrap/redis/producer/setup_test.go
+++ b/bootstrap/redis/producer/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package producer_test
 

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package producer
 

--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package producer_test
 

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap_test
 

--- a/bootstrap/state.go
+++ b/bootstrap/state.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package bootstrap
 

--- a/cli/channels.go
+++ b/cli/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/message.go
+++ b/cli/message.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/sdk.go
+++ b/cli/sdk.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/things.go
+++ b/cli/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/users.go
+++ b/cli/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cli
 

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 package main
 
 import (

--- a/cmd/cassandra-reader/main.go
+++ b/cmd/cassandra-reader/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/cassandra-writer/main.go
+++ b/cmd/cassandra-writer/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/influxdb-writer/main.go
+++ b/cmd/influxdb-writer/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/mongodb-reader/main.go
+++ b/cmd/mongodb-reader/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/mongodb-writer/main.go
+++ b/cmd/mongodb-writer/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/normalizer/main.go
+++ b/cmd/normalizer/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/postgres-reader/main.go
+++ b/cmd/postgres-reader/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/postgres-writer/main.go
+++ b/cmd/postgres-writer/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package main
 

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package coap contains the domain concept definitions needed to support
 // Mainflux coap adapter service functionality. All constant values are taken

--- a/coap/api/doc.go
+++ b/coap/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains API-related concerns: endpoint definitions, middlewares
 // and all resource representations.

--- a/coap/api/logging.go
+++ b/coap/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/coap/api/metrics.go
+++ b/coap/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/coap/api/util.go
+++ b/coap/api/util.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/coap/nats/publisher.go
+++ b/coap/nats/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package nats contains NATS message publisher implementation.
 package nats

--- a/coap/observer.go
+++ b/coap/observer.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package coap
 

--- a/doc.go
+++ b/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package mainflux acts as an umbrella package containing multiple different
 // microservices and defines all shared domain concepts.

--- a/env.go
+++ b/env.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mainflux
 

--- a/http/adapter.go
+++ b/http/adapter.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package http contains the domain concept definitions needed to support
 // Mainflux http adapter service functionality.

--- a/http/api/doc.go
+++ b/http/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains API-related concerns: endpoint definitions, middlewares
 // and all resource representations.

--- a/http/api/endpoint.go
+++ b/http/api/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/http/api/endpoint_test.go
+++ b/http/api/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api_test
 

--- a/http/api/logging.go
+++ b/http/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/http/api/metrics.go
+++ b/http/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/http/api/requests.go
+++ b/http/api/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/http/mocks/publisher.go
+++ b/http/mocks/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/http/mocks/things.go
+++ b/http/mocks/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/http/nats/publisher.go
+++ b/http/nats/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package nats contains NATS message publisher implementation.
 package nats

--- a/internal.proto
+++ b/internal.proto
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 syntax = "proto3";
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/CreateAndRetrieveThings.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/CreateAndRetrieveThings.scala
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2018
- * Mainflux
- *
+ * Copyright (c) Mainflux
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/PublishHttpMessages.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/PublishHttpMessages.scala
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2018
- * Mainflux
- *
+ * Copyright (c) 2018 Mainflux *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/PublishHttpMessages.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/PublishHttpMessages.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Mainflux *
+ * Copyright (c) Mainflux
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/PublishMessages.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/PublishMessages.scala
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2018
- * Mainflux
- *
+ * Copyright (c) Mainflux
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/PublishWsMessages.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/PublishWsMessages.scala
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2018
- * Mainflux
- *
+ * Copyright (c) Mainflux
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/load-test/src/test/scala/com/mainflux/loadtest/TestCase.scala
+++ b/load-test/src/test/scala/com/mainflux/loadtest/TestCase.scala
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2018
- * Mainflux
- *
+ * Copyright (c) Mainflux
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/logger/doc.go
+++ b/logger/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package logger contains logger API definition, wrapper that
 // can be used around any other logger.

--- a/logger/level.go
+++ b/logger/level.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package logger
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package logger
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package logger_test
 

--- a/lora/api/api.go
+++ b/lora/api/api.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/lora/api/logging.go
+++ b/lora/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/lora/api/metrics.go
+++ b/lora/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/lora/nats/publisher.go
+++ b/lora/nats/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package nats contains NATS message publisher implementation.
 package nats

--- a/lora/redis/routemap.go
+++ b/lora/redis/routemap.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis
 

--- a/lora/routemap.go
+++ b/lora/routemap.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package lora
 

--- a/message.proto
+++ b/message.proto
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 syntax = "proto3";
 package mainflux;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,9 @@
 #
-# Copyright (c) 2018
-# Mainflux
-#
+# Copyright (c) Mainflux
 # SPDX-License-Identifier: Apache-2.0
 #
 
-copyright: Copyright (c) 2015-2019 Mainflux
+copyright: Copyright (c) Mainflux
 repo_url: https://github.com/mainflux/mainflux
 site_description: Mainflux IoT System
 site_name: Mainflux
@@ -20,23 +18,23 @@ extra:
 markdown_extensions:
   - admonition
   - toc:
-      permalink: '#'
+      permalink: "#"
 
 pages:
-- Overview:
-    - About: index.md
-    - Contributing: CONTRIBUTING.md
-    - License: LICENSE.txt
-- Architecture: architecture.md
-- Getting Started: getting-started.md
-- Provisioning: provisioning.md
-- Messaging: messaging.md
-- Storage: storage.md
-- LoRa: lora.md
-- Security: 
-    - Secure communication: security.md
-    - Authentication: authentication.md
-- CLI: cli.md
-- Bootstrap: bootstrap.md
-- Developer's Guide: dev-guide.md
-- Load Test: load-test.md
+  - Overview:
+      - About: index.md
+      - Contributing: CONTRIBUTING.md
+      - License: LICENSE.txt
+  - Architecture: architecture.md
+  - Getting Started: getting-started.md
+  - Provisioning: provisioning.md
+  - Messaging: messaging.md
+  - Storage: storage.md
+  - LoRa: lora.md
+  - Security:
+      - Secure communication: security.md
+      - Authentication: authentication.md
+  - CLI: cli.md
+  - Bootstrap: bootstrap.md
+  - Developer's Guide: dev-guide.md
+  - Load Test: load-test.md

--- a/normalizer/api/api.go
+++ b/normalizer/api/api.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/normalizer/api/logging.go
+++ b/normalizer/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/normalizer/api/metrics.go
+++ b/normalizer/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/normalizer/doc.go
+++ b/normalizer/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package normalizer contains the domain concept definitions needed to
 // support Mainflux normalizer service functionality.

--- a/normalizer/nats/pubsub.go
+++ b/normalizer/nats/pubsub.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package nats
 

--- a/normalizer/normalizer.go
+++ b/normalizer/normalizer.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package normalizer
 

--- a/normalizer/service.go
+++ b/normalizer/service.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package normalizer
 

--- a/publisher.go
+++ b/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mainflux
 

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api_test
 

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/readers/api/metrics.go
+++ b/readers/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/readers/cassandra/doc.go
+++ b/readers/cassandra/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package cassandra contains Cassandra specific reader implementation.
 package cassandra

--- a/readers/cassandra/init.go
+++ b/readers/cassandra/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra
 

--- a/readers/cassandra/messages.go
+++ b/readers/cassandra/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra
 

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra_test
 

--- a/readers/cassandra/setup_test.go
+++ b/readers/cassandra/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra_test
 

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package readers
 

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/readers/mocks/things.go
+++ b/readers/mocks/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/readers/mongodb/doc.go
+++ b/readers/mongodb/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package mongodb contains the domain concept definitions needed to
 // support Mainflux MondoDB reader service functionality.

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb
 

--- a/readers/mongodb/messages_test.go
+++ b/readers/mongodb/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb_test
 

--- a/readers/mongodb/setup_test.go
+++ b/readers/mongodb/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb_test
 

--- a/readers/postgres/doc.go
+++ b/readers/postgres/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres contains repository implementations using Postgres as
 // the underlying database.

--- a/readers/postgres/init.go
+++ b/readers/postgres/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/readers/postgres/setup_test.go
+++ b/readers/postgres/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres_test contains tests for PostgreSQL repository
 // implementations.

--- a/scripts/provision-dev.sh
+++ b/scripts/provision-dev.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2018
-# Mainflux
-#
+# Copyright (c) Mainflux
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -15,7 +13,7 @@
 ###
 
 if [ $# -lt 4 ]
-  then
+then
     echo "Usage: $0 user_email user_password device_name channel_name"
     exit 1
 fi

--- a/sdk/go/channels.go
+++ b/sdk/go/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/channels_test.go
+++ b/sdk/go/channels_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk_test
 

--- a/sdk/go/message.go
+++ b/sdk/go/message.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/message_test.go
+++ b/sdk/go/message_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk_test
 

--- a/sdk/go/responses.go
+++ b/sdk/go/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/things.go
+++ b/sdk/go/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk_test
 

--- a/sdk/go/users.go
+++ b/sdk/go/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/sdk/go/users_test.go
+++ b/sdk/go/users_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk_test
 

--- a/sdk/go/version.go
+++ b/sdk/go/version.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package sdk
 

--- a/things/api/auth/grpc/client.go
+++ b/things/api/auth/grpc/client.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/things/api/auth/grpc/doc.go
+++ b/things/api/auth/grpc/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package grpc contains implementation of things service gRPC API.
 package grpc

--- a/things/api/auth/grpc/endpoint.go
+++ b/things/api/auth/grpc/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/things/api/auth/grpc/endpoint_test.go
+++ b/things/api/auth/grpc/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc_test
 

--- a/things/api/auth/grpc/requests.go
+++ b/things/api/auth/grpc/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/things/api/auth/grpc/responses.go
+++ b/things/api/auth/grpc/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/things/api/auth/grpc/server.go
+++ b/things/api/auth/grpc/server.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/things/api/auth/grpc/setup_test.go
+++ b/things/api/auth/grpc/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc_test
 

--- a/things/api/auth/http/doc.go
+++ b/things/api/auth/http/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package http contains implementation of things auth service HTTP API.
 package http

--- a/things/api/auth/http/endpoint.go
+++ b/things/api/auth/http/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/auth/http/endpoint_test.go
+++ b/things/api/auth/http/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http_test
 

--- a/things/api/auth/http/requests.go
+++ b/things/api/auth/http/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/auth/http/responses.go
+++ b/things/api/auth/http/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/auth/http/transport.go
+++ b/things/api/auth/http/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/doc.go
+++ b/things/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains API-related concerns: endpoint definitions, middlewares
 // and all resource representations.

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/things/api/things/http/doc.go
+++ b/things/api/things/http/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package http contains implementation of things service HTTP API.
 package http

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http_test
 

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/things/http/responses.go
+++ b/things/api/things/http/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/things/channels.go
+++ b/things/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package things
 

--- a/things/doc.go
+++ b/things/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package things contains the domain concept definitions needed to support
 // Mainflux things service functionality.

--- a/things/idp.go
+++ b/things/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package things
 

--- a/things/mocks/channels.go
+++ b/things/mocks/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/things/mocks/commons.go
+++ b/things/mocks/commons.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/things/mocks/idp.go
+++ b/things/mocks/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/things/mocks/things.go
+++ b/things/mocks/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/things/mocks/users.go
+++ b/things/mocks/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/things/postgres/doc.go
+++ b/things/postgres/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres contains repository implementations using PostgreSQL as
 // the underlying database.

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres_test contains tests for PostgreSQL repository
 // implementations.

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/things/redis/channels.go
+++ b/things/redis/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis
 

--- a/things/redis/channels_test.go
+++ b/things/redis/channels_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis_test
 

--- a/things/redis/doc.go
+++ b/things/redis/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package redis contains cache implementations using Redis as
 // the underlying database.

--- a/things/redis/setup_test.go
+++ b/things/redis/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis_test
 

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis
 

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis_test
 

--- a/things/redis/things.go
+++ b/things/redis/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis
 

--- a/things/redis/things_test.go
+++ b/things/redis/things_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package redis_test
 

--- a/things/service.go
+++ b/things/service.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package things
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package things_test
 

--- a/things/things.go
+++ b/things/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package things
 

--- a/things/tracing/channels.go
+++ b/things/tracing/channels.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package tracing
 

--- a/things/tracing/doc.go
+++ b/things/tracing/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package tracing contains middlewares that will add spans
 // to existing traces.

--- a/things/tracing/things.go
+++ b/things/tracing/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package tracing
 

--- a/things/users/users.go
+++ b/things/users/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package users contains implementation for users service in
 // single user scenario.

--- a/things/users/users_test.go
+++ b/things/users/users_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users_test
 

--- a/things/uuid/idp.go
+++ b/things/uuid/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package uuid provides a UUID identity provider.
 package uuid

--- a/topics.go
+++ b/topics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mainflux
 

--- a/ui/css/mainflux.css
+++ b/ui/css/mainflux.css
@@ -1,16 +1,22 @@
-/* Copyright (c) 2019
-   Mainflux
-   SPDX-License-Identifier: Apache-2.0 */
+/* 
+ * Copyright (c) Mainflux
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 @import url('https://fonts.googleapis.com/css?family=Montserrat:400,600,800');
-  
+
 .btn-primary {
   color: #fff;
   background-color: #113f67;
   border-color: #113f67;
 }
-.btn-primary:hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open>.dropdown-toggle.btn-primary {
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary.active,
+.open>.dropdown-toggle.btn-primary {
   color: #fff;
   background-color: #408ab4;
   border-color: #408ab4;
@@ -21,17 +27,23 @@
   background-color: #408ab4;
   border-color: #408ab4;
 }
-.btn-secondary:hover, .btn-secondary:focus, .btn-secondary:active, .btn-secondary.active, .open>.dropdown-toggle.btn-secondary {
+
+.btn-secondary:hover,
+.btn-secondary:focus,
+.btn-secondary:active,
+.btn-secondary.active,
+.open>.dropdown-toggle.btn-secondary {
   color: #fff;
   background-color: #113f67;
   border-color: #113f67;
 }
-  
+
 body {
   background-color: #f3f3f4 !important;
   font-family: 'Montserrat', sans-serif !important;
 }
-.title{
+
+.title {
   font-family: 'Montserrat', sans-serif;
   font-weight: 800;
   transform: scaleY(0.95);
@@ -39,24 +51,24 @@ body {
   margin: 1rem 0;
 }
 
-.page-link{
+.page-link {
   color: #113f67;
 }
 
 .page-item.active .page-link {
   background-color: #408ab4;
-  border-color: #408ab4; 
+  border-color: #408ab4;
 }
 
-ul.nav a:hover { 
-  color: #fff !important; 
-  background-color: #408ab4 !important; 
+ul.nav a:hover {
+  color: #fff !important;
+  background-color: #408ab4 !important;
   cursor: pointer;
-  transition: color .15s ease-in-out,background-color .15s ease-in-out;
+  transition: color .15s ease-in-out, background-color .15s ease-in-out;
   border-radius: 0;
 }
 
-.nav-pills .nav-link.active{
+.nav-pills .nav-link.active {
   background-color: #408ab4 !important;
   border-radius: 0;
 }
@@ -88,9 +100,9 @@ ul.nav a:hover {
   border-top: none;
 }
 
-.table-hover tbody tr:hover > td {
+.table-hover tbody tr:hover>td {
   cursor: pointer;
-  background:#408ab4;
+  background: #408ab4;
   color: white;
 }
 

--- a/ui/docker/Dockerfile
+++ b/ui/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2015-2019 Mainflux
+# Copyright (c) Mainflux
 #
 # Mainflux is licensed under an Apache license, version 2.0 license.
 # All rights not explicitly granted in the Apache license, version 2.0 are reserved.

--- a/ui/docker/Dockerfile.arm
+++ b/ui/docker/Dockerfile.arm
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2015-2019 Mainflux
+# Copyright (c) Mainflux
 #
 # Mainflux is licensed under an Apache license, version 2.0 license.
 # All rights not explicitly granted in the Apache license, version 2.0 are reserved.

--- a/ui/src/Channel.elm
+++ b/ui/src/Channel.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux--
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Connection.elm
+++ b/ui/src/Connection.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Env.elm
+++ b/ui/src/Env.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Error.elm
+++ b/ui/src/Error.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Helpers.elm
+++ b/ui/src/Helpers.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/HttpMF.elm
+++ b/ui/src/HttpMF.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/JsonMF.elm
+++ b/ui/src/JsonMF.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Message.elm
+++ b/ui/src/Message.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/ModalMF.elm
+++ b/ui/src/ModalMF.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Ports.elm
+++ b/ui/src/Ports.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Thing.elm
+++ b/ui/src/Thing.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/User.elm
+++ b/ui/src/User.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/ui/src/Version.elm
+++ b/ui/src/Version.elm
@@ -1,6 +1,4 @@
--- Copyright (c) 2019
--- Mainflux
---
+-- Copyright (c) Mainflux
 -- SPDX-License-Identifier: Apache-2.0
 
 

--- a/users/api/doc.go
+++ b/users/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains API-related concerns: endpoint definitions, middlewares
 // and all resource representations.

--- a/users/api/grpc/client.go
+++ b/users/api/grpc/client.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/users/api/grpc/doc.go
+++ b/users/api/grpc/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package grpc contains implementation of users service gRPC API.
 package grpc

--- a/users/api/grpc/endpoint.go
+++ b/users/api/grpc/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/users/api/grpc/endpoint_test.go
+++ b/users/api/grpc/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc_test
 

--- a/users/api/grpc/requests.go
+++ b/users/api/grpc/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/users/api/grpc/responses.go
+++ b/users/api/grpc/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/users/api/grpc/server.go
+++ b/users/api/grpc/server.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc
 

--- a/users/api/grpc/setup_test.go
+++ b/users/api/grpc/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package grpc_test
 

--- a/users/api/http/doc.go
+++ b/users/api/http/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package http contains implementation of users service HTTP API.
 package http

--- a/users/api/http/endpoint.go
+++ b/users/api/http/endpoint.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/users/api/http/endpoint_test.go
+++ b/users/api/http/endpoint_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http_test
 

--- a/users/api/http/requests.go
+++ b/users/api/http/requests.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/users/api/http/responses.go
+++ b/users/api/http/responses.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/users/api/http/transport.go
+++ b/users/api/http/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package http
 

--- a/users/api/logging.go
+++ b/users/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/users/api/metrics.go
+++ b/users/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/users/bcrypt/hasher.go
+++ b/users/bcrypt/hasher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package bcrypt provides a hasher implementation utilising bcrypt.
 package bcrypt

--- a/users/hasher.go
+++ b/users/hasher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users
 

--- a/users/idp.go
+++ b/users/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users
 

--- a/users/jwt/idp.go
+++ b/users/jwt/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package jwt provides a JWT identity provider.
 package jwt

--- a/users/mocks/hasher.go
+++ b/users/mocks/hasher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/users/mocks/idp.go
+++ b/users/mocks/idp.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/users/mocks/users.go
+++ b/users/mocks/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/users/postgres/doc.go
+++ b/users/postgres/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres contains repository implementations using PostgreSQL as
 // the underlying database.

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/users/postgres/setup_test.go
+++ b/users/postgres/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres_test contains tests for PostgreSQL repository
 // implementations.

--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/users/service.go
+++ b/users/service.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users_test
 

--- a/users/tracing/users.go
+++ b/users/tracing/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package tracing contains middlewares that will add spans
 // to existing traces.

--- a/users/users.go
+++ b/users/users.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users
 

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package users_test
 

--- a/version.go
+++ b/version.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mainflux
 

--- a/writers/api/logging.go
+++ b/writers/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/writers/api/metrics.go
+++ b/writers/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/writers/api/transport.go
+++ b/writers/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/writers/cassandra/doc.go
+++ b/writers/cassandra/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package cassandra contains the domain concept definitions needed to
 // support Mainflux Cassandra writer service.

--- a/writers/cassandra/init.go
+++ b/writers/cassandra/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra
 

--- a/writers/cassandra/messages.go
+++ b/writers/cassandra/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra
 

--- a/writers/cassandra/messages_test.go
+++ b/writers/cassandra/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra_test
 

--- a/writers/cassandra/setup_test.go
+++ b/writers/cassandra/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package cassandra_test
 

--- a/writers/docs.go
+++ b/writers/docs.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package writers contain the domain concept definitions needed to
 // support Mainflux writer services functionality.

--- a/writers/influxdb/doc.go
+++ b/writers/influxdb/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package influxdb contains the domain concept definitions needed to
 // support Mainflux InfluxDB writer service functionality.

--- a/writers/influxdb/messages.go
+++ b/writers/influxdb/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package influxdb
 

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package influxdb_test
 

--- a/writers/influxdb/setup_test.go
+++ b/writers/influxdb/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package influxdb_test
 

--- a/writers/messages.go
+++ b/writers/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package writers
 

--- a/writers/mongodb/doc.go
+++ b/writers/mongodb/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package mongodb contains the domain concept definitions needed to
 // support Mainflux MondoDB writer service functionality.

--- a/writers/mongodb/messages.go
+++ b/writers/mongodb/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb
 

--- a/writers/mongodb/messages_test.go
+++ b/writers/mongodb/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb_test
 

--- a/writers/mongodb/setup_test.go
+++ b/writers/mongodb/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mongodb_test
 

--- a/writers/postgres/doc.go
+++ b/writers/postgres/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres contains repository implementations using Postgres as
 // the underlying database.

--- a/writers/postgres/init.go
+++ b/writers/postgres/init.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/writers/postgres/messages.go
+++ b/writers/postgres/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres
 

--- a/writers/postgres/messages_test.go
+++ b/writers/postgres/messages_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package postgres_test
 

--- a/writers/postgres/setup_test.go
+++ b/writers/postgres/setup_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2019
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package postgres_test contains tests for PostgreSQL repository
 // implementations.

--- a/writers/writer.go
+++ b/writers/writer.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package writers
 

--- a/ws/adapter.go
+++ b/ws/adapter.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package ws contains the domain concept definitions needed to support
 // Mainflux ws adapter service functionality.

--- a/ws/adapter_test.go
+++ b/ws/adapter_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package ws_test
 

--- a/ws/api/doc.go
+++ b/ws/api/doc.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package api contains API-related concerns: endpoint definitions, middlewares
 // and all resource representations.

--- a/ws/api/logging.go
+++ b/ws/api/logging.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/ws/api/metrics.go
+++ b/ws/api/metrics.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // +build !test
 

--- a/ws/api/transport.go
+++ b/ws/api/transport.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api
 

--- a/ws/api/transport_test.go
+++ b/ws/api/transport_test.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package api_test
 

--- a/ws/mocks/messages.go
+++ b/ws/mocks/messages.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/ws/mocks/things.go
+++ b/ws/mocks/things.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 package mocks
 

--- a/ws/nats/publisher.go
+++ b/ws/nats/publisher.go
@@ -1,9 +1,5 @@
-//
-// Copyright (c) 2018
-// Mainflux
-//
+// Copyright (c) Mainflux
 // SPDX-License-Identifier: Apache-2.0
-//
 
 // Package nats contains NATS message publisher implementation.
 package nats


### PR DESCRIPTION
###  What does this do?
Removes the date from copyright comments to reduce maintenance.  Also minimizes and fixes formatting where needed.

### Which issue(s) does this PR fix/relate to?
Resolves #788 

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
NA

### Did you document any new/modified functionality?
NA

### Notes
