### PR TITLE
NOISSUE - Change channels to chs

### DIFF
--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -197,7 +197,7 @@ func (svc *mainfluxThings) CreateChannel(context.Context, string, things.Channel
 	panic("not implemented")
 }
 
-func (svc *mainfluxThings) CreateChannels(_ context.Context, owner string, channels []things.Channel) ([]things.Channel, error) {
+func (svc *mainfluxThings) CreateChannels(_ context.Context, owner string, chs []things.Channel) ([]things.Channel, error) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 
@@ -205,14 +205,14 @@ func (svc *mainfluxThings) CreateChannels(_ context.Context, owner string, chann
 	if err != nil {
 		return []things.Channel{}, things.ErrUnauthorizedAccess
 	}
-	for i := range channels {
+	for i := range chs {
 		svc.counter++
-		channels[i].Owner = userID.Value
-		channels[i].ID = strconv.FormatUint(svc.counter, 10)
-		svc.channels[channels[i].ID] = channels[i]
+		chs[i].Owner = userID.Value
+		chs[i].ID = strconv.FormatUint(svc.counter, 10)
+		svc.channels[chs[i].ID] = chs[i]
 	}
 
-	return channels, nil
+	return chs, nil
 }
 
 func (svc *mainfluxThings) UpdateChannel(context.Context, string, things.Channel) error {

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -111,7 +111,6 @@ func TestCreateThing(t *testing.T) {
 
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.location, loc, fmt.Sprintf("%s: expected location %s got %s", tc.desc, tc.location, loc))
-
 	}
 }
 


### PR DESCRIPTION
### What does this do?
Cleanup changes from #889 

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
NA

### Did you document any new/modified functionality?
NA

### Notes
There are additional areas in the things folder that could be changed to use `chs` and `ths`.  Independent variables should be changed to `chs` while structure parameters should be left as `channels`.  Same goes for `things`.