### PR TITLE
NOISSUE - Remove ARM multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ define make_docker
 
 	# If ARCH is `amd64` then retag image for convinience of devlopment
 	if [ $(GOARCH) = amd64 ]; then \
-            docker tag mainflux/$(svc)-$(2) mainflux/$(svc); \
-    fi
+		docker tag mainflux/$(svc)-$(2) mainflux/$(svc); \
+	fi
 endef
 
 define make_docker_dev

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,8 @@ define make_docker
 		--build-arg SVC=$(svc) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg GOARM=$(GOARM) \
-		--tag=mainflux/$(svc)-$(2) \
+		--tag=mainflux/$(svc) \
 		-f docker/Dockerfile .
-
-	# If ARCH is `amd64` then retag image for convinience of devlopment
-	if [ $(GOARCH) = amd64 ]; then \
-		docker tag mainflux/$(svc)-$(2) mainflux/$(svc); \
-	fi
 endef
 
 define make_docker_dev
@@ -91,11 +86,7 @@ docker_ui:
 
 docker_mqtt:
 	# MQTT Docker build must be done from root dir because it copies .proto files
-ifeq ($(GOARCH), arm)
-	docker build --tag=mainflux/mqtt-arm -f mqtt/aedes/Dockerfile.arm .
-else
-	docker build --tag=mainflux/mqtt-amd64 -f mqtt/aedes/Dockerfile .
-endif
+	docker build --tag=mainflux/mqtt -f mqtt/aedes/Dockerfile.arm .
 
 docker_mqtt_verne:
 	docker build --tag=mainflux/mqtt-verne -f mqtt/verne/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 BUILD_DIR = build
-SERVICES = users things http ws coap lora normalizer influxdb-writer influxdb-reader mongodb-writer mongodb-reader cassandra-writer cassandra-reader postgres-writer postgres-reader cli bootstrap opcua
+SERVICES = users things http ws coap lora normalizer influxdb-writer influxdb-reader mongodb-writer \
+	mongodb-reader cassandra-writer cassandra-reader postgres-writer postgres-reader cli bootstrap opcua
 DOCKERS = $(addprefix docker_,$(SERVICES))
 DOCKERS_DEV = $(addprefix docker_dev_,$(SERVICES))
 CGO_ENABLED ?= 0
@@ -13,26 +14,35 @@ define compile_service
 endef
 
 define make_docker
+	$(eval svc=$(subst docker_,,$(1)))
+
 	docker build \
 		--no-cache \
-		--build-arg SVC=$(subst docker_,,$(1)) \
+		--build-arg SVC=$(svc) \
 		--build-arg GOARCH=$(GOARCH) \
 		--build-arg GOARM=$(GOARM) \
-		--tag=mainflux/$(subst docker_,,$(1))-$(2) \
+		--tag=mainflux/$(svc)-$(2) \
 		-f docker/Dockerfile .
+
+	# If ARCH is `amd64` then retag image for convinience of devlopment
+	if [ $(GOARCH) = amd64 ]; then \
+            docker tag mainflux/$(svc)-$(2) mainflux/$(svc); \
+    fi
 endef
 
 define make_docker_dev
+	$(eval svc=$(subst docker_,,$(1)))
+
 	docker build \
 		--no-cache \
-		--build-arg SVC=$(subst docker_dev_,,$(1)) \
-		--tag=mainflux/$(subst docker_dev_,,$(1)) \
+		--build-arg SVC=$(svc) \
+		--tag=mainflux/$(svc) \
 		-f docker/Dockerfile.dev ./build
 endef
 
 all: $(SERVICES) mqtt
 
-.PHONY: all $(SERVICES) dockers dockers_dev latest release mqtt ui latest_manifest
+.PHONY: all $(SERVICES) dockers dockers_dev latest release mqtt ui
 
 clean:
 	rm -rf ${BUILD_DIR}
@@ -57,6 +67,7 @@ ifdef pv
 	# Remove unused volumes
 	docker volume ls -f name=mainflux -f dangling=true -q | xargs -r docker volume rm
 endif
+
 install:
 	cp ${BUILD_DIR}/* $(GOBIN)
 
@@ -101,46 +112,28 @@ mqtt:
 
 define docker_push
 	for svc in $(SERVICES); do \
-		docker push mainflux/$$svc-$(1):$(2); \
+		docker push mainflux/$$svc:$(1); \
 	done
-	docker push mainflux/ui-$(1):$(2)
-	docker push mainflux/mqtt-$(1):$(2)
+	docker push mainflux/ui:$(1)
+	docker push mainflux/mqtt:$(1)
 endef
 
 changelog:
 	git log $(shell git describe --tags --abbrev=0)..HEAD --pretty=format:"- %s"
 
-define docker_manifest
-	for svc in $(SERVICES); do \
-		docker manifest create mainflux/$$svc:$(1) mainflux/$$svc-amd64:$(1) mainflux/$$svc-arm:$(1); \
-		docker manifest annotate mainflux/$$svc:$(1) mainflux/$$svc-arm:$(1) --arch arm --variant v7; \
-		docker manifest push mainflux/$$svc:$(1); \
-	done
-	docker manifest create mainflux/ui:$(1) mainflux/ui-amd64:$(1) mainflux/ui-arm:$(1)
-	docker manifest annotate mainflux/ui:$(1) mainflux/ui-arm:$(1) --arch arm --variant v7
-	docker manifest push mainflux/ui:$(1)
-	docker manifest create mainflux/mqtt:$(1) mainflux/mqtt-amd64:$(1) mainflux/mqtt-arm:$(1)
-	docker manifest annotate mainflux/mqtt:$(1) mainflux/mqtt-arm:$(1) --arch arm --variant v7
-	docker manifest push mainflux/mqtt:$(1)
-endef
-
 latest: dockers
-	$(call docker_push,$(GOARCH),latest)
-
-latest_manifest:
-	$(call docker_manifest,latest)
+	$(call docker_push,latest)
 
 release:
 	$(eval version = $(shell git describe --abbrev=0 --tags))
 	git checkout $(version)
-	GOARCH=$(GOARCH) GOARM=$(GOARM) $(MAKE) dockers
+	$(MAKE) dockers
 	for svc in $(SERVICES); do \
-		docker tag mainflux/$$svc-$(GOARCH) mainflux/$$svc-$(GOARCH):$(version); \
+		docker tag mainflux/$$svc mainflux/$$svc:$(version); \
 	done
-	docker tag mainflux/ui mainflux/ui-$(GOARCH):$(version)
-	docker tag mainflux/mqtt mainflux/mqtt-$(GOARCH):$(version)
-	$(call docker_push,$(GOARCH),$(version))
-	$(call docker_manifest,$(version))
+	docker tag mainflux/ui mainflux/ui:$(version)
+	docker tag mainflux/mqtt mainflux/mqtt:$(version)
+	$(call docker_push,$(version))
 
 rundev:
 	cd scripts && ./run.sh

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,11 @@ docker_ui:
 
 docker_mqtt:
 	# MQTT Docker build must be done from root dir because it copies .proto files
+ifeq ($(GOARCH), arm)
 	docker build --tag=mainflux/mqtt -f mqtt/aedes/Dockerfile.arm .
+else
+	docker build --tag=mainflux/mqtt -f mqtt/aedes/Dockerfile .
+endif
 
 docker_mqtt_verne:
 	docker build --tag=mainflux/mqtt-verne -f mqtt/verne/Dockerfile .

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -92,26 +92,10 @@ run_test() {
 	done
 }
 
-install_qemu() {
-	echo "Installing qemu..."
-	MF_PATH=$GOPATH/src/github.com/mainflux/mainflux
-	cd $MF_PATH
-	sudo apt-get update && sudo apt-get -y install qemu-user-static
-	wget https://github.com/multiarch/qemu-user-static/releases/download/v2.11.1/qemu-arm-static.tar.gz  \
-		&& tar -xzf qemu-arm-static.tar.gz \
-		&& rm qemu-arm-static.tar.gz
-	sudo cp qemu-arm-static /usr/bin/
-}
-
 push() {
 	if test -n "$BRANCH_NAME" && test "$BRANCH_NAME" = "master"; then
 		echo "Pushing Docker images..."
 		make -j$NPROC latest
-		docker system prune -a -f
-		install_qemu
-		GOARCH=arm GOARM=7 make -j$NPROC latest
-		export DOCKER_CLI_EXPERIMENTAL=enabled
-		make latest_manifest
 	fi
 }
 


### PR DESCRIPTION
Signed-off-by: Drasko DRASKOVIC <drasko.draskovic@gmail.com>

Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](./CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?

Removes multi-arch image push to DockerHub.
Only `amd64` images are produced and pushed.

It should be noted that manifest currently was hard-coded to ARMv7, and besides that it is suitable for RPi, it does not have too much benefit, nor it is generic. It should be left to developers to produce Docker images for their particular architectures.

Also removes CI build of ARM images.

Local build of ARM images can still be executed by adding just ENV vars to Makefile prefix:

```
GOARCH=arm GOARM=7 make docker_<service>
```

### Which issue(s) does this PR fix/relate to?
Put here `Resolves #XXX` to auto-close the issue that your PR fixes (if such)

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
