### PR TITLE
NOISSUE - Remove Normalizer service from compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -162,21 +162,6 @@ services:
     networks:
       - mainflux-base-net
 
-  normalizer:
-    image: mainflux/normalizer:latest
-    container_name: mainflux-normalizer
-    restart: on-failure
-    depends_on:
-      - nats
-    environment:
-      MF_NORMALIZER_LOG_LEVEL: ${MF_NORMALIZER_LOG_LEVEL}
-      MF_NATS_URL: ${MF_NATS_URL}
-      MF_NORMALIZER_PORT: ${MF_NORMALIZER_PORT}
-    ports:
-      - ${MF_NORMALIZER_PORT}:${MF_NORMALIZER_PORT}
-    networks:
-      - mainflux-base-net
-
   ws-adapter:
     image: mainflux/ws:latest
     container_name: mainflux-ws


### PR DESCRIPTION
Signed-off-by: Dušan Borovčanin <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request removes Normalizer service from the docker-compose.yml.

### List any changes that modify/break current functionality
There are no such changes.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No.