### PR TITLE
MF-898 - Change thing's service to use bulk connect

### DIFF
--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -70,7 +70,7 @@ func (svc *mainfluxThings) ViewThing(_ context.Context, owner, id string) (thing
 	return things.Thing{}, things.ErrNotFound
 }
 
-func (svc *mainfluxThings) Connect(_ context.Context, owner, chanID, thingID string) error {
+func (svc *mainfluxThings) Connect(_ context.Context, owner, chID string, thIDs ...string) error {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 
@@ -79,11 +79,13 @@ func (svc *mainfluxThings) Connect(_ context.Context, owner, chanID, thingID str
 		return things.ErrUnauthorizedAccess
 	}
 
-	if svc.channels[chanID].Owner != userID.Value {
-		return things.ErrNotFound
-	}
+	for _, thID := range thIDs {
+		if svc.channels[chID].Owner != userID.Value {
+			return things.ErrNotFound
+		}
 
-	svc.connections[chanID] = append(svc.connections[chanID], thingID)
+		svc.connections[chID] = append(svc.connections[chID], thID)
+	}
 	return nil
 }
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -78,14 +78,13 @@ func (svc *mainfluxThings) Connect(_ context.Context, owner, chID string, thIDs 
 	if err != nil {
 		return things.ErrUnauthorizedAccess
 	}
-
+	if svc.channels[chID].Owner != userID.Value {
+		return things.ErrNotFound
+	}
 	for _, thID := range thIDs {
-		if svc.channels[chID].Owner != userID.Value {
-			return things.ErrNotFound
-		}
-
 		svc.connections[chID] = append(svc.connections[chID], thID)
 	}
+
 	return nil
 }
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -79,7 +79,7 @@ func (svc *mainfluxThings) Connect(_ context.Context, owner, chID string, thIDs 
 		return things.ErrUnauthorizedAccess
 	}
 	if svc.channels[chID].Owner != userID.Value {
-		return things.ErrNotFound
+		return things.ErrUnauthorizedAccess
 	}
 	for _, thID := range thIDs {
 		svc.connections[chID] = append(svc.connections[chID], thID)

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -201,9 +201,9 @@ func (lm *loggingMiddleware) RemoveChannel(ctx context.Context, token, id string
 	return lm.svc.RemoveChannel(ctx, token, id)
 }
 
-func (lm *loggingMiddleware) Connect(ctx context.Context, token, chanID, thingID string) (err error) {
+func (lm *loggingMiddleware) Connect(ctx context.Context, token, chID string, thIDs ...string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method connect for token %s, channel %s and thing %s took %s to complete", token, chanID, thingID, time.Since(begin))
+		message := fmt.Sprintf("Method connect for token %s, channel %s and things %s took %s to complete", token, chID, thIDs, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -211,7 +211,7 @@ func (lm *loggingMiddleware) Connect(ctx context.Context, token, chanID, thingID
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.Connect(ctx, token, chanID, thingID)
+	return lm.svc.Connect(ctx, token, chID, thIDs...)
 }
 
 func (lm *loggingMiddleware) Disconnect(ctx context.Context, token, chanID, thingID string) (err error) {

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -148,13 +148,13 @@ func (ms *metricsMiddleware) RemoveChannel(ctx context.Context, token, id string
 	return ms.svc.RemoveChannel(ctx, token, id)
 }
 
-func (ms *metricsMiddleware) Connect(ctx context.Context, token, chanID, thingID string) error {
+func (ms *metricsMiddleware) Connect(ctx context.Context, token, chanID string, thIDs ...string) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "connect").Add(1)
 		ms.latency.With("method", "connect").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.Connect(ctx, token, chanID, thingID)
+	return ms.svc.Connect(ctx, token, chanID, thIDs...)
 }
 
 func (ms *metricsMiddleware) Disconnect(ctx context.Context, token, chanID, thingID string) error {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -186,21 +186,23 @@ func (es eventStore) RemoveChannel(ctx context.Context, token, id string) error 
 	return nil
 }
 
-func (es eventStore) Connect(ctx context.Context, token, chanID, thingID string) error {
-	if err := es.svc.Connect(ctx, token, chanID, thingID); err != nil {
+func (es eventStore) Connect(ctx context.Context, token, chID string, thIDs ...string) error {
+	if err := es.svc.Connect(ctx, token, chID, thIDs...); err != nil {
 		return err
 	}
 
-	event := connectThingEvent{
-		chanID:  chanID,
-		thingID: thingID,
+	for _, thID := range thIDs {
+		event := connectThingEvent{
+			chanID:  chID,
+			thingID: thID,
+		}
+		record := &redis.XAddArgs{
+			Stream:       streamID,
+			MaxLenApprox: streamLen,
+			Values:       event.Encode(),
+		}
+		es.client.XAdd(record).Err()
 	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
-	}
-	es.client.XAdd(record).Err()
 
 	return nil
 }

--- a/things/service.go
+++ b/things/service.go
@@ -84,8 +84,8 @@ type Service interface {
 	// belongs to the user identified by the provided key.
 	RemoveChannel(context.Context, string, string) error
 
-	// Connect adds thing to the channel's list of connected things.
-	Connect(context.Context, string, string, string) error
+	// Connect adds things to the channel's list of connected things.
+	Connect(context.Context, string, string, ...string) error
 
 	// Disconnect removes thing from the channel's list of connected
 	// things.
@@ -283,13 +283,13 @@ func (ts *thingsService) RemoveChannel(ctx context.Context, token, id string) er
 	return ts.channels.Remove(ctx, res.GetValue(), id)
 }
 
-func (ts *thingsService) Connect(ctx context.Context, token, chanID, thingID string) error {
+func (ts *thingsService) Connect(ctx context.Context, token, chID string, thIDs ...string) error {
 	res, err := ts.users.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
 		return ErrUnauthorizedAccess
 	}
 
-	return ts.channels.Connect(ctx, res.GetValue(), chanID, thingID)
+	return ts.channels.Connect(ctx, res.GetValue(), chID, thIDs...)
 }
 
 func (ts *thingsService) Disconnect(ctx context.Context, token, chanID, thingID string) error {


### PR DESCRIPTION
Signed-off-by: Nick Neisen <nwneisen@gmail.com>

### What does this do?
Add bulk connect to the thing's service.

### Which issue(s) does this PR fix/relate to?
Related to #898.

### List any changes that modify/break current functionality
Things can now be connected to a channel at a service level.

### Have you included tests for your changes?
Tests for single creation modified as needed.

### Did you document any new/modified functionality?
Documentation will be modified in the final PR when the user's endpoint is changed.

### Notes
