### PR TITLE
NOISSUE - Fix opcua-adapter events decode

### DIFF
--- a/cmd/opcua/nodes.csv
+++ b/cmd/opcua/nodes.csv
@@ -1,0 +1,4 @@
+opc.tcp://opcua.rocks:4840, 0, 2255
+opc.tcp://opcua.rocks:4840, 0, 2256
+opc.tcp://opcua.rocks:4840, 1, 2255
+opc.tcp://opcua.rocks:4840, 1, 2256

--- a/cmd/opcua/nodes.csv
+++ b/cmd/opcua/nodes.csv
@@ -1,4 +1,0 @@
-opc.tcp://opcua.rocks:4840, 0, 2255
-opc.tcp://opcua.rocks:4840, 0, 2256
-opc.tcp://opcua.rocks:4840, 1, 2255
-opc.tcp://opcua.rocks:4840, 1, 2256

--- a/docker/addons/opcua-adapter/docker-compose.yml
+++ b/docker/addons/opcua-adapter/docker-compose.yml
@@ -46,3 +46,5 @@ services:
       - ${MF_OPCUA_ADAPTER_HTTP_PORT}:${MF_OPCUA_ADAPTER_HTTP_PORT}
     networks:
       - docker_mainflux-base-net
+    volumes:
+      - ./nodes.csv:/nodes.csv

--- a/docker/addons/opcua-adapter/nodes.csv
+++ b/docker/addons/opcua-adapter/nodes.csv
@@ -1,0 +1,4 @@
+opc.tcp://opcua.rocks:4840,0,2255
+opc.tcp://opcua.rocks:4840,0,2256
+opc.tcp://opcua.rocks:4840,1,2255
+opc.tcp://opcua.rocks:4840,1,2256

--- a/opcua/redis/events.go
+++ b/opcua/redis/events.go
@@ -4,37 +4,19 @@
 package redis
 
 type createThingEvent struct {
-	id       string
-	metadata thingMetadata
-}
-
-type updateThingEvent struct {
-	id       string
-	metadata thingMetadata
+	id                  string
+	opcuaNodeIdentifier string
 }
 
 type removeThingEvent struct {
 	id string
 }
 
-type thingMetadata struct {
-	ID string `json:"id"`
-}
-
 type createChannelEvent struct {
-	id       string
-	metadata channelMetadata
-}
-
-type updateChannelEvent struct {
-	id       string
-	metadata channelMetadata
+	id                 string
+	opcuaNodeNamespace string
 }
 
 type removeChannelEvent struct {
 	id string
-}
-
-type channelMetadata struct {
-	Namespace string `json:"namespace"`
 }


### PR DESCRIPTION
With an existing event processing implementation, whenever the processor receives a new event with some unexpected format it will break. This implementation should be able to handle unexpected metadata formats in a better way.