### PR TITLE
MF-898 - Add bulk connect to CLI and SDK

### DIFF
--- a/cli/provision.go
+++ b/cli/provision.go
@@ -265,7 +265,7 @@ func channelsFromFile(path string) ([]mfxsdk.Channel, error) {
 
 	channels := []mfxsdk.Channel{}
 	switch filepath.Ext(path) {
-	case ".csv":
+	case csvExt:
 		reader := csv.NewReader(file)
 
 		for {
@@ -287,7 +287,7 @@ func channelsFromFile(path string) ([]mfxsdk.Channel, error) {
 
 			channels = append(channels, channel)
 		}
-	case ".json":
+	case jsonExt:
 		err := json.NewDecoder(file).Decode(&channels)
 		if err != nil {
 			return []mfxsdk.Channel{}, err
@@ -312,7 +312,7 @@ func connectionsFromFile(path string) (mfxsdk.ConnectionIDs, error) {
 
 	connections := mfxsdk.ConnectionIDs{}
 	switch filepath.Ext(path) {
-	case ".csv":
+	case csvExt:
 		reader := csv.NewReader(file)
 
 		for {
@@ -331,7 +331,7 @@ func connectionsFromFile(path string) (mfxsdk.ConnectionIDs, error) {
 			connections.ThingIDs = append(connections.ThingIDs, l[0])
 			connections.ChannelIDs = append(connections.ChannelIDs, l[1])
 		}
-	case ".json":
+	case jsonExt:
 		err := json.NewDecoder(file).Decode(&connections)
 		if err != nil {
 			return mfxsdk.ConnectionIDs{}, err

--- a/cli/things.go
+++ b/cli/things.go
@@ -119,7 +119,12 @@ var cmdThings = []cobra.Command{
 				return
 			}
 
-			if err := sdk.ConnectThing(args[0], args[1], args[2]); err != nil {
+			connIDs := mfxsdk.ConnectionIDs{
+				[]string{args[0]},
+				[]string{args[1]},
+			}
+
+			if err := sdk.Connect(connIDs, args[2]); err != nil {
 				logError(err)
 				return
 			}

--- a/docker/nginx/nginx-key.conf
+++ b/docker/nginx/nginx-key.conf
@@ -57,7 +57,7 @@ http {
         }
 
         # Proxy pass to things service
-        location ~ ^/(things|channels) {
+        location ~ ^/(things|channels|connect) {
             include snippets/proxy-headers.conf;
             add_header Access-Control-Expose-Headers Location;
             proxy_pass http://things:${MF_THINGS_HTTP_PORT};

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,14 +164,29 @@ mainflux-cli provision connect <file> <user_auth_token>
 * `file` - A CSV or JSON file containing thing and channel ids
 * `user_auth_token` - A valid user auth token for the current system
 
-An example file might be
+An example CSV file might be
 
 ```csv
-7f3216a2-f5c8-4410-a37e-a1bbd7f48231,f5dc42c8-0bf1-4850-bb0e-ddea435e7814
-f26688e7-8bdf-4ec8-b1dc-1bfb764cfa3a,ca3365f9-2202-40a6-a9d6-75b6690df466
+<thing_id>,<channel_id>
+<thing_id>,<channel_id>
 ```
 
-in which the first column is thingIDs and the second column is channelIDs.  A connection will be created for each thing to each channel.  This example would result in 4 connections being created.
+in which the first column is thing IDs and the second column is channel IDs.  A connection will be created for each thing to each channel.  This example would result in 4 connections being created.
+
+A comparable JSON file would be
+
+```json
+{
+    "thing_ids": [
+        "<thing_id>",
+        "<thing_id>"
+    ],
+    "channel_ids": [
+        "<channel_id>",
+        "<channel_id>"
+    ]
+}
+```
 
 #### Disconnect Thing from Channel
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,6 +164,15 @@ mainflux-cli provision connect <file> <user_auth_token>
 * `file` - A CSV or JSON file containing thing and channel ids
 * `user_auth_token` - A valid user auth token for the current system
 
+An example file might be
+
+```csv
+7f3216a2-f5c8-4410-a37e-a1bbd7f48231,f5dc42c8-0bf1-4850-bb0e-ddea435e7814
+f26688e7-8bdf-4ec8-b1dc-1bfb764cfa3a,ca3365f9-2202-40a6-a9d6-75b6690df466
+```
+
+in which the first column is thingIDs and the second column is channelIDs.  A connection will be created for each thing to each channel.  This example would result in 4 connections being created.
+
 #### Disconnect Thing from Channel
 ```
 mainflux-cli things disconnect <thing_id> <channel_id> <user_auth_token>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,15 @@ mainflux-cli channels get <channel_id> <user_auth_token>
 mainflux-cli things connect <thing_id> <channel_id> <user_auth_token>
 ```
 
+#### Bulk Connect Things to Channels
+
+```bash
+mainflux-cli provision connect <file> <user_auth_token>
+```
+
+* `file` - A CSV or JSON file containing thing and channel ids
+* `user_auth_token` - A valid user auth token for the current system
+
 #### Disconnect Thing from Channel
 ```
 mainflux-cli things disconnect <thing_id> <channel_id> <user_auth_token>

--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -116,6 +116,12 @@ type MessagesPage struct {
 	Messages []mainflux.Message `json:"messages,omitempty"`
 }
 
+// ConnectionIDs contains ID lists of things and channels to be connected
+type ConnectionIDs struct {
+	ChannelIDs []string `json:"channel_ids"`
+	ThingIDs   []string `json:"thing_ids"`
+}
+
 // SDK contains Mainflux API.
 type SDK interface {
 	// CreateUser registers mainflux user.
@@ -148,6 +154,9 @@ type SDK interface {
 
 	// ConnectThing connects thing to specified channel by id.
 	ConnectThing(thingID, chanID, token string) error
+
+	// Connect bulk connects things to channels specified by id.
+	Connect(conns ConnectionIDs, token string) error
 
 	// DisconnectThing disconnect thing from specified channel by id.
 	DisconnectThing(thingID, chanID, token string) error

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -26,6 +26,7 @@ const (
 	token       = "token"
 	otherToken  = "other_token"
 	wrongValue  = "wrong_value"
+	badID       = "999"
 	emptyValue  = ""
 
 	keyPrefix = "123e4567-e89b-12d3-a456-"
@@ -740,13 +741,13 @@ func TestConnect(t *testing.T) {
 		{
 			desc:    "connect existing things to non-existing channels",
 			thingID: thingID,
-			chanID:  wrongValue,
+			chanID:  badID,
 			token:   token,
 			err:     sdk.ErrNotFound,
 		},
 		{
 			desc:    "connect non-existing things to existing channels",
-			thingID: wrongValue,
+			thingID: badID,
 			chanID:  chanID1,
 			token:   token,
 			err:     sdk.ErrNotFound,

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -26,6 +26,7 @@ const (
 	token       = "token"
 	otherToken  = "other_token"
 	wrongValue  = "wrong_value"
+	emptyValue  = ""
 
 	keyPrefix = "123e4567-e89b-12d3-a456-"
 )
@@ -739,13 +740,13 @@ func TestConnect(t *testing.T) {
 		{
 			desc:    "connect existing things to non-existing channels",
 			thingID: thingID,
-			chanID:  "9",
+			chanID:  wrongValue,
 			token:   token,
 			err:     sdk.ErrNotFound,
 		},
 		{
 			desc:    "connect non-existing things to existing channels",
-			thingID: "9",
+			thingID: wrongValue,
 			chanID:  chanID1,
 			token:   token,
 			err:     sdk.ErrNotFound,
@@ -753,13 +754,13 @@ func TestConnect(t *testing.T) {
 		{
 			desc:    "connect existing things to channels with invalid ID",
 			thingID: thingID,
-			chanID:  "",
+			chanID:  emptyValue,
 			token:   token,
 			err:     sdk.ErrFailedConnection,
 		},
 		{
 			desc:    "connect things with invalid ID to existing channels",
-			thingID: "",
+			thingID: emptyValue,
 			chanID:  chanID1,
 			token:   token,
 			err:     sdk.ErrFailedConnection,
@@ -776,7 +777,7 @@ func TestConnect(t *testing.T) {
 			desc:    "connect existing things to existing channels with empty token",
 			thingID: thingID,
 			chanID:  chanID1,
-			token:   "",
+			token:   emptyValue,
 			err:     sdk.ErrUnauthorized,
 		},
 		{

--- a/sdk/go/things_test.go
+++ b/sdk/go/things_test.go
@@ -694,6 +694,111 @@ func TestConnectThing(t *testing.T) {
 	}
 }
 
+func TestConnect(t *testing.T) {
+	svc := newThingsService(map[string]string{
+		token:      email,
+		otherToken: otherEmail,
+	})
+
+	ts := newThingsServer(svc)
+	defer ts.Close()
+	sdkConf := sdk.Config{
+		BaseURL:           ts.URL,
+		UsersPrefix:       "",
+		ThingsPrefix:      "",
+		HTTPAdapterPrefix: "",
+		MsgContentType:    contentType,
+		TLSVerification:   false,
+	}
+
+	mainfluxSDK := sdk.NewSDK(sdkConf)
+	thingID, err := mainfluxSDK.CreateThing(thing, token)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+
+	chanID1, err := mainfluxSDK.CreateChannel(channel, token)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+
+	chanID2, err := mainfluxSDK.CreateChannel(channel, otherToken)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+
+	cases := []struct {
+		desc    string
+		thingID string
+		chanID  string
+		token   string
+		err     error
+	}{
+		{
+			desc:    "connect existing things to existing channels",
+			thingID: thingID,
+			chanID:  chanID1,
+			token:   token,
+			err:     nil,
+		},
+
+		{
+			desc:    "connect existing things to non-existing channels",
+			thingID: thingID,
+			chanID:  "9",
+			token:   token,
+			err:     sdk.ErrNotFound,
+		},
+		{
+			desc:    "connect non-existing things to existing channels",
+			thingID: "9",
+			chanID:  chanID1,
+			token:   token,
+			err:     sdk.ErrNotFound,
+		},
+		{
+			desc:    "connect existing things to channels with invalid ID",
+			thingID: thingID,
+			chanID:  "",
+			token:   token,
+			err:     sdk.ErrFailedConnection,
+		},
+		{
+			desc:    "connect things with invalid ID to existing channels",
+			thingID: "",
+			chanID:  chanID1,
+			token:   token,
+			err:     sdk.ErrFailedConnection,
+		},
+
+		{
+			desc:    "connect existing things to existing channels with invalid token",
+			thingID: thingID,
+			chanID:  chanID1,
+			token:   wrongValue,
+			err:     sdk.ErrUnauthorized,
+		},
+		{
+			desc:    "connect existing things to existing channels with empty token",
+			thingID: thingID,
+			chanID:  chanID1,
+			token:   "",
+			err:     sdk.ErrUnauthorized,
+		},
+		{
+			desc:    "connect things from owner to channels of other user",
+			thingID: thingID,
+			chanID:  chanID2,
+			token:   token,
+			err:     sdk.ErrNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		connIDs := sdk.ConnectionIDs{
+			[]string{tc.thingID},
+			[]string{tc.chanID},
+		}
+
+		err := mainfluxSDK.Connect(connIDs, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+	}
+}
+
 func TestDisconnectThing(t *testing.T) {
 	svc := newThingsService(map[string]string{
 		token:      email,


### PR DESCRIPTION
### What does this do?
Adds bulk connect functionality to the SDK and CLI

### Which issue(s) does this PR fix/relate to?
Resolves #898 

### List any changes that modify/break current functionality
Multiple connections can now be created using the SDK or CLI

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
Yes

### Notes
