### PR TITLE
MF-798 - Length of an email validation

### DIFF
--- a/users/users.go
+++ b/users/users.go
@@ -5,16 +5,21 @@ package users
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/mainflux/mainflux/errors"
 )
 
+const (
+	// Allowed email address character class (ascii + non-ascii(utf8))
+	emailCharClass = "[\\w\\d!#$%&'*+-/=?^_`{|}~]" + // acceptable ascii characters: alpha, numeric, subset of special characters
+		"[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]" // non-ascii
+)
+
 var (
-	userRegexp    = regexp.MustCompile("^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+$")
-	hostRegexp    = regexp.MustCompile("^[^\\s]+\\.[^\\s]+$")
-	userDotRegexp = regexp.MustCompile("(^[.]{1})|([.]{1}$)|([.]{2,})")
+	emailRe = regexp.MustCompile(fmt.Sprintf("^(%s)+(\\.(%s))*@(%s)+(\\.(%s))*$", emailCharClass, emailCharClass, emailCharClass, emailCharClass))
 )
 
 // User represents a Mainflux user account. Each user is identified given its
@@ -56,23 +61,19 @@ type UserRepository interface {
 }
 
 func isEmail(email string) bool {
-	if len(email) < 6 || len(email) > 254 {
-		return false
-	}
-
 	at := strings.LastIndex(email, "@")
-	if at <= 0 || at > len(email)-3 {
+	if at < 1 {
 		return false
 	}
 
-	user := email[:at]
+	local := email[:at]
 	host := email[at+1:]
 
-	if len(user) > 64 {
+	if len(local) > 64 || len(host) > 255 {
 		return false
 	}
 
-	if userDotRegexp.MatchString(user) || !userRegexp.MatchString(user) || !hostRegexp.MatchString(host) {
+	if !emailRe.MatchString(email) {
 		return false
 	}
 

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -5,6 +5,7 @@ package users_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mainflux/mainflux/errors"
@@ -13,12 +14,14 @@ import (
 )
 
 const (
-	email    = "user@example.com"
-	password = "password"
-	metadata = `{"role":"manager"}`
+	email           = "user@example.com"
+	password        = "password"
+	sampleUtfString = "\xe7\x94\xa8\xe6\x88\xb7" // 用户
 )
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		user users.User
 		err  error
@@ -44,9 +47,107 @@ func TestValidate(t *testing.T) {
 			},
 			err: users.ErrMalformedEntity,
 		},
-		"validate user with invalid email": {
+		"validate email without at": {
 			user: users.User{
 				Email:    "userexample.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email with unexpected characters in local": {
+			user: users.User{
+				Email:    "<user>@xample.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email without local": {
+			user: users.User{
+				Email:    " @example.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email without host": {
+			user: users.User{
+				Email:    "user@ ",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email with consecutive dots in local": {
+			user: users.User{
+				Email:    "user..email@example.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email with consecutive dots in host": {
+			user: users.User{
+				Email:    "useremail@example..com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email starting with dot": {
+			user: users.User{
+				Email:    ".useremail@example.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email ending with dot": {
+			user: users.User{
+				Email:    "useremail.@example.com",
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email with dots": {
+			user: users.User{
+				Email:    "user.ema.ill@example.com",
+				Password: password,
+			},
+			err: nil,
+		},
+		"validate email with utf-8": {
+			user: users.User{
+				Email:    "用户+“偽名”@例子.广告",
+				Password: password,
+			},
+			err: nil,
+		},
+		"validate email with single letter segments": {
+			user: users.User{
+				Email:    "u@e",
+				Password: password,
+			},
+			err: nil,
+		},
+		"validate email with 64B local": {
+			user: users.User{
+				Email:    fmt.Sprintf("%s%s@example.com", sampleUtfString, strings.Repeat("a", 64-len(sampleUtfString))),
+				Password: password,
+			},
+			err: nil,
+		},
+		"validate email with 255B host": {
+			user: users.User{
+				Email:    fmt.Sprintf("user@%s%s", sampleUtfString, strings.Repeat("a", 255-len(sampleUtfString))),
+				Password: password,
+			},
+			err: nil,
+		},
+		"validate email with 65B local": {
+			user: users.User{
+				Email:    fmt.Sprintf("%s%s@example.com`", sampleUtfString, strings.Repeat(sampleUtfString, 65-len(sampleUtfString))),
+				Password: password,
+			},
+			err: users.ErrMalformedEntity,
+		},
+		"validate email with 256B host": {
+			user: users.User{
+				Email:    fmt.Sprintf("user@%s%s", sampleUtfString, strings.Repeat(sampleUtfString, 256-len(sampleUtfString))),
 				Password: password,
 			},
 			err: users.ErrMalformedEntity,


### PR DESCRIPTION
### What does this do?
Fix email address segments legth validation.
Adds validation of email addresses with utf8 encoded characters.

### Which issue(s) does this PR fix/relate to?
Resolves issue #tbd.

### List any changes that modify/break current functionality
Email addresses with non-ascii utf-8 characters will now pass validation.

### Have you included tests for your changes?
Existing test is extended to cover additional cases.

### Did you document any new/modified functionality?
No

### Notes
Email address is validated by subset of restrictions from RFC3696 (section 3):

* host and local part may contain ASCII letters (A-z), digits (0-9)
  and ASCII special chars (! # $ % & ' * + - / = ?  ^ _ ` { | } ~)
* period (".") may appear in local and host part, but it cannot be used
  to start or end any of parts, nor may two or more consecutive periods appear
* length of host part may be from 1 to 255 octets
* length of local part may be from 1 to 64 octets

In addition to subset of rules from RFC3696 host and local part are also alowed to
contain utf8 encoded characters.

Signed-off-by: Lazar Ivanovic <laza@opencores.org>