### PR TITLE
NOISSUE - Fix minimal password length

### DIFF
--- a/cli/provision.go
+++ b/cli/provision.go
@@ -122,7 +122,7 @@ var cmdProvision = []cobra.Command{
 			// Create test user
 			user := mfxsdk.User{
 				Email:    un,
-				Password: "123456",
+				Password: "12345678",
 			}
 			if err := sdk.CreateUser(user); err != nil {
 				logError(err)

--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -23,6 +23,8 @@ const (
 	CTBinary ContentType = "application/octet-stream"
 )
 
+const minPassLen = 8
+
 var (
 	// ErrConflict indicates that create or update of entity failed because
 	// entity with same name already exists.
@@ -75,6 +77,20 @@ var _ SDK = (*mfSDK)(nil)
 type User struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
+}
+
+// Validate returns an error if user representation is invalid.
+func (u User) validate() error {
+	if u.Email == "" {
+		return ErrInvalidArgs
+
+	}
+
+	if len(u.Password) < minPassLen {
+		return ErrInvalidArgs
+	}
+
+	return nil
 }
 
 // Thing represents mainflux thing.

--- a/sdk/go/users.go
+++ b/sdk/go/users.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (sdk mfSDK) CreateUser(user User) error {
+	if err := user.validate(); err != nil {
+		return err
+	}
+
 	data, err := json.Marshal(user)
 	if err != nil {
 		return ErrInvalidArgs

--- a/users/api/endpoint_test.go
+++ b/users/api/endpoint_test.go
@@ -138,7 +138,7 @@ func TestLogin(t *testing.T) {
 	})
 	nonexistentData := toJSON(users.User{
 		Email:    "non-existentuser@example.com",
-		Password: "pass",
+		Password: "password",
 	})
 	svc.Register(context.Background(), user)
 
@@ -225,7 +225,7 @@ func TestPasswordResetRequest(t *testing.T) {
 
 	nonexistentData := toJSON(users.User{
 		Email:    "non-existentuser@example.com",
-		Password: "pass",
+		Password: "password",
 	})
 
 	expectedExisting := toJSON(struct {

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mainflux/mainflux/users"
 )
 
+const minPassLen = 8
+
 type apiReq interface {
 	validate() error
 }
@@ -84,7 +86,7 @@ func (req passwChangeReq) validate() errors.Error {
 	if req.Token == "" {
 		return users.ErrUnauthorizedAccess
 	}
-	if req.Password == "" {
+	if len(req.Password) < minPassLen {
 		return users.ErrMalformedEntity
 	}
 	if req.OldPassword == "" {

--- a/users/swagger.yaml
+++ b/users/swagger.yaml
@@ -212,6 +212,7 @@ definitions:
       password:
         type: string
         format: password
+        minimum: 8
         description: Free-form account password used for acquiring auth token(s).
     required:
       - email
@@ -277,9 +278,11 @@ definitions:
       password:
         type: string
         description: New password
+        minimum: 8
       confirm_password:
         type: string
         description: New password confirmed
+        minimum: 8
       token:
         type: string
         description: Reset token generated and sent in email

--- a/users/users.go
+++ b/users/users.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mainflux/mainflux/errors"
 )
 
+const minPassLen = 8
+
 var (
 	userRegexp    = regexp.MustCompile("^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+$")
 	hostRegexp    = regexp.MustCompile("^[^\\s]+\\.[^\\s]+$")
@@ -27,12 +29,11 @@ type User struct {
 
 // Validate returns an error if user representation is invalid.
 func (u User) Validate() errors.Error {
-	if u.Email == "" || u.Password == "" {
+	if !isEmail(u.Email) {
 		return ErrMalformedEntity
-
 	}
 
-	if !isEmail(u.Email) {
+	if len(u.Password) < minPassLen {
 		return ErrMalformedEntity
 	}
 


### PR DESCRIPTION
### What does this do?
Updates minimal password length to 8, and adds password length validation to the users API.

### Which issue(s) does this PR fix/relate to?
There is no issue for this PR.

### List any changes that modify/break current functionality
Now it's required that users use passwords that are at least 8 characters long.

### Have you included tests for your changes?
I've updated an existing tests.

### Did you document any new/modified functionality?
I've updated existing swagger for `users` service.

