### PR TITLE
NOISSUE - Add aggregate attribute-based search for twin retrieval

### DIFF
--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -145,6 +145,11 @@ func main() {
 	defer closer.Close()
 
 	svc := newService(nc, ncTracer, mc, mcTracer, auth, dbTracer, db, logger)
+	if err := svc.MakeAttributeMap(); err != nil {
+		logger.Error(fmt.Sprintf("Failed to make attribute map: %s", err))
+		os.Exit(1)
+	}
+
 	errs := make(chan error, 2)
 
 	go startHTTPServer(twapi.MakeHandler(tracer, svc), cfg.httpPort, cfg, logger, errs)
@@ -257,6 +262,7 @@ func connectToAuth(cfg config, logger logger.Logger) *grpc.ClientConn {
 
 func newService(nc *nats.Conn, ncTracer opentracing.Tracer, mc mqtt.Mqtt, mcTracer opentracing.Tracer, users mainflux.AuthNServiceClient, dbTracer opentracing.Tracer, db *mongo.Database, logger logger.Logger) twins.Service {
 	twinRepo := twmongodb.NewTwinRepository(db)
+
 	stateRepo := twmongodb.NewStateRepository(db)
 	idp := uuid.New()
 

--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -145,10 +145,6 @@ func main() {
 	defer closer.Close()
 
 	svc := newService(nc, ncTracer, mc, mcTracer, auth, dbTracer, db, logger)
-	if err := svc.MakeAttributeMap(); err != nil {
-		logger.Error(fmt.Sprintf("Failed to make attribute map: %s", err))
-		os.Exit(1)
-	}
 
 	errs := make(chan error, 2)
 

--- a/twins/api/http/endpoint.go
+++ b/twins/api/http/endpoint.go
@@ -20,7 +20,6 @@ func addTwinEndpoint(svc twins.Service) endpoint.Endpoint {
 
 		twin := twins.Twin{
 			Name:     req.Name,
-			ThingID:  req.ThingID,
 			Metadata: req.Metadata,
 		}
 		saved, err := svc.AddTwin(ctx, req.token, twin, req.Definition)

--- a/twins/api/http/endpoint_test.go
+++ b/twins/api/http/endpoint_test.go
@@ -124,8 +124,8 @@ func TestAddTwin(t *testing.T) {
 			req:         "{}",
 			contentType: contentType,
 			auth:        token,
-			status:      http.StatusBadRequest,
-			location:    "",
+			status:      http.StatusCreated,
+			location:    "/twins/123e4567-e89b-12d3-a456-000000000002",
 		},
 		{
 			desc:        "add twin with invalid auth token",

--- a/twins/api/http/requests.go
+++ b/twins/api/http/requests.go
@@ -17,7 +17,6 @@ type apiReq interface {
 type addTwinReq struct {
 	token      string
 	Name       string                 `json:"name,omitempty"`
-	ThingID    string                 `json:"thing_id"`
 	Definition twins.Definition       `json:"definition,omitempty"`
 	Metadata   map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/twins/api/http/requests.go
+++ b/twins/api/http/requests.go
@@ -27,10 +27,6 @@ func (req addTwinReq) validate() error {
 		return twins.ErrUnauthorizedAccess
 	}
 
-	if req.ThingID == "" {
-		return twins.ErrMalformedEntity
-	}
-
 	if len(req.Name) > maxNameSize {
 		return twins.ErrMalformedEntity
 	}

--- a/twins/api/logging.go
+++ b/twins/api/logging.go
@@ -27,19 +27,6 @@ func LoggingMiddleware(svc twins.Service, logger log.Logger) twins.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
-func (lm *loggingMiddleware) MakeAttributeMap() (err error) {
-	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method make_attribute_map took %s to complete", time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.MakeAttributeMap()
-}
-
 func (lm *loggingMiddleware) AddTwin(ctx context.Context, token string, twin twins.Twin, def twins.Definition) (saved twins.Twin, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method add_twin for token %s and twin %s took %s to complete", token, twin.ID, time.Since(begin))

--- a/twins/api/logging.go
+++ b/twins/api/logging.go
@@ -27,6 +27,19 @@ func LoggingMiddleware(svc twins.Service, logger log.Logger) twins.Service {
 	return &loggingMiddleware{logger, svc}
 }
 
+func (lm *loggingMiddleware) MakeAttributeMap() (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method make_attribute_map took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.MakeAttributeMap()
+}
+
 func (lm *loggingMiddleware) AddTwin(ctx context.Context, token string, twin twins.Twin, def twins.Definition) (saved twins.Twin, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method add_twin for token %s and twin %s took %s to complete", token, twin.ID, time.Since(begin))
@@ -79,9 +92,9 @@ func (lm *loggingMiddleware) ListTwins(ctx context.Context, token string, offset
 	return lm.svc.ListTwins(ctx, token, offset, limit, name, metadata)
 }
 
-func (lm *loggingMiddleware) SaveState(msg *mainflux.Message) (err error) {
+func (lm *loggingMiddleware) SaveStates(msg *mainflux.Message) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method save_state took %s to complete", time.Since(begin))
+		message := fmt.Sprintf("Method save_states took %s to complete", time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -89,7 +102,7 @@ func (lm *loggingMiddleware) SaveState(msg *mainflux.Message) (err error) {
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.SaveState(msg)
+	return lm.svc.SaveStates(msg)
 }
 
 func (lm *loggingMiddleware) ListStates(ctx context.Context, token string, offset uint64, limit uint64, id string) (st twins.StatesPage, err error) {

--- a/twins/api/metrics.go
+++ b/twins/api/metrics.go
@@ -32,15 +32,6 @@ func MetricsMiddleware(svc twins.Service, counter metrics.Counter, latency metri
 	}
 }
 
-func (ms *metricsMiddleware) MakeAttributeMap() (err error) {
-	defer func(begin time.Time) {
-		ms.counter.With("method", "make_attribute_map").Add(1)
-		ms.latency.With("method", "make_attribute_map").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return ms.svc.MakeAttributeMap()
-}
-
 func (ms *metricsMiddleware) AddTwin(ctx context.Context, token string, twin twins.Twin, def twins.Definition) (saved twins.Twin, err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "add_twin").Add(1)

--- a/twins/api/metrics.go
+++ b/twins/api/metrics.go
@@ -32,6 +32,15 @@ func MetricsMiddleware(svc twins.Service, counter metrics.Counter, latency metri
 	}
 }
 
+func (ms *metricsMiddleware) MakeAttributeMap() (err error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "make_attribute_map").Add(1)
+		ms.latency.With("method", "make_attribute_map").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.MakeAttributeMap()
+}
+
 func (ms *metricsMiddleware) AddTwin(ctx context.Context, token string, twin twins.Twin, def twins.Definition) (saved twins.Twin, err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "add_twin").Add(1)
@@ -68,13 +77,13 @@ func (ms *metricsMiddleware) ListTwins(ctx context.Context, token string, offset
 	return ms.svc.ListTwins(ctx, token, offset, limit, name, metadata)
 }
 
-func (ms *metricsMiddleware) SaveState(msg *mainflux.Message) error {
+func (ms *metricsMiddleware) SaveStates(msg *mainflux.Message) error {
 	defer func(begin time.Time) {
-		ms.counter.With("method", "save_state").Add(1)
-		ms.latency.With("method", "save_state").Observe(time.Since(begin).Seconds())
+		ms.counter.With("method", "save_states").Add(1)
+		ms.latency.With("method", "save_states").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.SaveState(msg)
+	return ms.svc.SaveStates(msg)
 }
 
 func (ms *metricsMiddleware) ListStates(ctx context.Context, token string, offset uint64, limit uint64, id string) (st twins.StatesPage, err error) {

--- a/twins/mocks/twins.go
+++ b/twins/mocks/twins.go
@@ -71,6 +71,21 @@ func (trm *twinRepositoryMock) RetrieveByID(_ context.Context, id string) (twins
 	return twins.Twin{}, twins.ErrNotFound
 }
 
+func (trm *twinRepositoryMock) RetrieveByAttribute(ctx context.Context, channel, subtopic string) ([]string, error) {
+	var ids []string
+	for _, twin := range trm.twins {
+		def := twin.Definitions[len(twin.Definitions)-1]
+		for _, attr := range def.Attributes {
+			if attr.Channel == channel && attr.Subtopic == subtopic {
+				ids = append(ids, twin.ID)
+				break
+			}
+		}
+	}
+
+	return ids, nil
+}
+
 func (trm *twinRepositoryMock) RetrieveByThing(_ context.Context, thingid string) (twins.Twin, error) {
 	trm.mu.Lock()
 	defer trm.mu.Unlock()

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -88,6 +88,57 @@ func (tr *twinRepository) RetrieveByThing(ctx context.Context, thingid string) (
 	return tw, nil
 }
 
+func (tr *twinRepository) RetrieveByAttribute(ctx context.Context, channel, subtopic string) ([]string, error) {
+	coll := tr.db.Collection(twinsCollection)
+
+	findOptions := options.Aggregate()
+	prj1 := bson.M{
+		"$project": bson.M{
+			"definition": bson.M{
+				"$arrayElemAt": []interface{}{"$definitions.attributes", -1},
+			},
+			"id":  true,
+			"_id": 0,
+		},
+	}
+	match := bson.M{
+		"$match": bson.M{
+			"definition.channel":  channel,
+			"definition.subtopic": subtopic,
+		},
+	}
+	prj2 := bson.M{
+		"$project": bson.M{
+			"id": true,
+		},
+	}
+
+	cur, err := coll.Aggregate(ctx, []bson.M{prj1, match, prj2}, findOptions)
+
+	var ids []string
+	if err != nil {
+		return ids, err
+	}
+	defer cur.Close(ctx)
+
+	if err := cur.Err(); err != nil {
+		return ids, nil
+	}
+
+	for cur.Next(ctx) {
+		var elem struct {
+			ID string `json:"id"`
+		}
+		err := cur.Decode(&elem)
+		if err != nil {
+			return ids, nil
+		}
+		ids = append(ids, elem.ID)
+	}
+
+	return ids, nil
+}
+
 func (tr *twinRepository) RetrieveAll(ctx context.Context, owner string, offset uint64, limit uint64, name string, metadata twins.Metadata) (twins.TwinsPage, error) {
 	coll := tr.db.Collection(twinsCollection)
 
@@ -163,28 +214,6 @@ func (tr *twinRepository) RetrieveAllByThing(ctx context.Context, thingid string
 		},
 	}, nil
 }
-
-// func (tr *twinRepository) RetrieveAllByAttribute(ctx context.Context, chanid string, subtopic string) ([]twins.Twin, error) {
-// 	coll := tr.db.Collection(twinsCollection)
-// 	tw := twins.Twin{}
-// 	filter := bson.D{{"thingid", thingid}}
-// 	if err := coll.FindOne(context.Background(), filter).Decode(&tw); err != nil {
-// 		return tw, twins.ErrNotFound
-// 	}
-
-// 	filter := bson.D{{"thingid", thingid}}
-// 	cur, err := coll.Find(ctx, filter, findOptions)
-// 	if err != nil {
-// 		return twins.TwinsPage{}, err
-// 	}
-
-// 	results, err := decodeTwins(ctx, cur)
-// 	if err != nil {
-// 		return twins.TwinsPage{}, err
-// 	}
-
-// 	return tw, nil
-// }
 
 func (tr *twinRepository) Remove(ctx context.Context, id string) error {
 	coll := tr.db.Collection(twinsCollection)

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -164,6 +164,28 @@ func (tr *twinRepository) RetrieveAllByThing(ctx context.Context, thingid string
 	}, nil
 }
 
+// func (tr *twinRepository) RetrieveAllByAttribute(ctx context.Context, chanid string, subtopic string) ([]twins.Twin, error) {
+// 	coll := tr.db.Collection(twinsCollection)
+// 	tw := twins.Twin{}
+// 	filter := bson.D{{"thingid", thingid}}
+// 	if err := coll.FindOne(context.Background(), filter).Decode(&tw); err != nil {
+// 		return tw, twins.ErrNotFound
+// 	}
+
+// 	filter := bson.D{{"thingid", thingid}}
+// 	cur, err := coll.Find(ctx, filter, findOptions)
+// 	if err != nil {
+// 		return twins.TwinsPage{}, err
+// 	}
+
+// 	results, err := decodeTwins(ctx, cur)
+// 	if err != nil {
+// 		return twins.TwinsPage{}, err
+// 	}
+
+// 	return tw, nil
+// }
+
 func (tr *twinRepository) Remove(ctx context.Context, id string) error {
 	coll := tr.db.Collection(twinsCollection)
 

--- a/twins/nats/subscriber.go
+++ b/twins/nats/subscriber.go
@@ -39,10 +39,11 @@ func Subscribe(nc *nats.Conn, mc mqtt.Mqtt, svc twins.Service, logger log.Logger
 		logger:     logger,
 		svc:        svc,
 	}
+
 	ps.natsClient.QueueSubscribe(input, queue, ps.handleMsg)
 }
 
-func (ps pubsub) handleMsg(m *nats.Msg) {
+func (ps *pubsub) handleMsg(m *nats.Msg) {
 	var msg mainflux.Message
 	if err := proto.Unmarshal(m.Data, &msg); err != nil {
 		ps.logger.Warn(fmt.Sprintf("Unmarshalling failed: %s", err))
@@ -53,5 +54,5 @@ func (ps pubsub) handleMsg(m *nats.Msg) {
 		return
 	}
 
-	ps.svc.SaveState(&msg)
+	ps.svc.SaveStates(&msg)
 }

--- a/twins/nats/subscriber.go
+++ b/twins/nats/subscriber.go
@@ -54,5 +54,8 @@ func (ps *pubsub) handleMsg(m *nats.Msg) {
 		return
 	}
 
-	ps.svc.SaveStates(&msg)
+	if err := ps.svc.SaveStates(&msg); err != nil {
+		ps.logger.Error(fmt.Sprintf("State save failed: %s", err))
+		return
+	}
 }

--- a/twins/service.go
+++ b/twins/service.go
@@ -152,7 +152,7 @@ func (ts *twinsService) AddTwin(ctx context.Context, token string, twin Twin, de
 
 	if len(def.Attributes) == 0 {
 		def = Definition{}
-		def.Attributes = make(map[string]Attribute)
+		def.Attributes = []Attribute{}
 	}
 	def.Created = time.Now()
 	def.ID = 0
@@ -349,23 +349,33 @@ func prepareState(st *State, tw *Twin, recs []senml.Record, msg *mainflux.Messag
 		st.Payload = make(map[string]interface{})
 	} else {
 		for k := range st.Payload {
-			if _, ok := def.Attributes[k]; !ok || !def.Attributes[k].PersistState {
+			idx := findAttribute(k, def.Attributes)
+			if idx < 0 || !def.Attributes[idx].PersistState {
 				delete(st.Payload, k)
 			}
 		}
 	}
 
 	save := false
-	for k, a := range def.Attributes {
-		if !a.PersistState {
+	for _, attr := range def.Attributes {
+		if !attr.PersistState {
 			continue
 		}
-		if a.Channel == msg.Channel && a.Subtopic == msg.Subtopic {
-			st.Payload[k] = recs[0].Value
+		if attr.Channel == msg.Channel && attr.Subtopic == msg.Subtopic {
+			st.Payload[attr.Name] = recs[0].Value
 			save = true
 			break
 		}
 	}
 
 	return save
+}
+
+func findAttribute(name string, attrs []Attribute) (idx int) {
+	for idx, attr := range attrs {
+		if attr.Name == name {
+			return idx
+		}
+	}
+	return -1
 }

--- a/twins/service.go
+++ b/twins/service.go
@@ -85,7 +85,6 @@ type twinsService struct {
 	twins      TwinRepository
 	states     StateRepository
 	idp        IdentityProvider
-	attrMap    map[string][]string
 }
 
 var _ Service = (*twinsService)(nil)

--- a/twins/twins.go
+++ b/twins/twins.go
@@ -13,6 +13,7 @@ type Metadata map[string]interface{}
 
 // Attribute stores individual attribute data
 type Attribute struct {
+	Name         string `json:"name"`
 	Channel      string `json:"channel"`
 	Subtopic     string `json:"subtopic"`
 	PersistState bool   `json:"persist_state"`
@@ -20,9 +21,9 @@ type Attribute struct {
 
 // Definition stores entity's attributes
 type Definition struct {
-	ID         int                  `json:"id"`
-	Created    time.Time            `json:"created"`
-	Attributes map[string]Attribute `json:"attributes"`
+	ID         int         `json:"id"`
+	Created    time.Time   `json:"created"`
+	Attributes []Attribute `json:"attributes"`
 }
 
 // Twin represents a Mainflux thing digital twin. Each twin is owned by one thing, and

--- a/twins/twins.go
+++ b/twins/twins.go
@@ -67,6 +67,10 @@ type TwinRepository interface {
 	// RetrieveByID retrieves the twin having the provided identifier.
 	RetrieveByID(ctx context.Context, id string) (Twin, error)
 
+	// RetrieveByAttribute retrieves twin ids whose definition contains
+	// the attribute with given channel and subtopic
+	RetrieveByAttribute(ctx context.Context, channel, subtopic string) ([]string, error)
+
 	// RetrieveAll retrieves the subset of things owned by the specified user.
 	RetrieveAll(context.Context, string, uint64, uint64, string, Metadata) (TwinsPage, error)
 


### PR DESCRIPTION
Signed-off-by: Darko Draskovic <darko.draskovic@gmail.com>

### What does this do?

Currently, twin has to be associated with a thing and twin is identified via message publisher (an id of a thing twin is associated to). We want that twin be identified solely by a channel and subtopic: if a twin has an attribute uniquely defined by a channel and subtopic, then the twin is concerned by the corresponding message.

This makes it possible to construct a twin that picks up messages from any channel and any subtopic and is not relient on the concept of Mainflux thing.