### PR TITLE
MF-701: Use adapters/services graceful shutdown to close all underlying servers/clients used by adapters/services

### DIFF
--- a/cmd/mongodb-reader/main.go
+++ b/cmd/mongodb-reader/main.go
@@ -9,15 +9,13 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
 
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/internal/pkg/server"
 	"github.com/mainflux/mainflux/logger"
 	"github.com/mainflux/mainflux/readers"
 	"github.com/mainflux/mainflux/readers/api"
@@ -33,6 +31,8 @@ import (
 )
 
 const (
+	serviceName = "mongodb-reader"
+
 	defThingsURL     = "localhost:8181"
 	defLogLevel      = "error"
 	defPort          = "8180"
@@ -95,16 +95,13 @@ func main() {
 	repo := newService(db, logger)
 
 	errs := make(chan error, 2)
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, syscall.SIGINT)
-		errs <- fmt.Errorf("%s", <-c)
-	}()
 
-	go startHTTPServer(repo, tc, cfg, logger, errs)
+	httpServer := server.NewHTTPServer(fmt.Sprintf(":%s", cfg.port), api.MakeHandler(repo, tc, serviceName), cfg.serverCert, cfg.serverKey)
+	go httpServer.Start(logger, errs)
 
-	err = <-errs
-	logger.Error(fmt.Sprintf("MongoDB reader service terminated: %s", err))
+	server.Monitor(logger, errs, httpServer)
+
+	logger.Info("MongoDB reader service terminated")
 }
 
 func loadConfigs() config {
@@ -213,16 +210,4 @@ func newService(db *mongo.Database, logger logger.Logger) readers.MessageReposit
 	)
 
 	return repo
-}
-
-func startHTTPServer(repo readers.MessageRepository, tc mainflux.ThingsServiceClient, cfg config, logger logger.Logger, errs chan error) {
-	p := fmt.Sprintf(":%s", cfg.port)
-	if cfg.serverCert != "" || cfg.serverKey != "" {
-		logger.Info(fmt.Sprintf("Mongo reader service started using https on port %s with cert %s key %s",
-			cfg.port, cfg.serverCert, cfg.serverKey))
-		errs <- http.ListenAndServeTLS(p, cfg.serverCert, cfg.serverKey, api.MakeHandler(repo, tc, "mongodb-reader"))
-		return
-	}
-	logger.Info(fmt.Sprintf("Mongo reader service started, exposed port %s", cfg.port))
-	errs <- http.ListenAndServe(p, api.MakeHandler(repo, tc, "mongodb-reader"))
 }

--- a/cmd/mongodb-writer/main.go
+++ b/cmd/mongodb-writer/main.go
@@ -8,14 +8,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/BurntSushi/toml"
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/internal/pkg/server"
 	"github.com/mainflux/mainflux/logger"
 	"github.com/mainflux/mainflux/transformers/senml"
 	"github.com/mainflux/mainflux/writers"
@@ -86,22 +84,20 @@ func main() {
 	repo = api.LoggingMiddleware(repo, logger)
 	repo = api.MetricsMiddleware(repo, counter, latency)
 	st := senml.New()
+	// TODO: consider adding graceful Stop method
 	if err := writers.Start(nc, repo, st, svcName, cfg.channels, logger); err != nil {
 		logger.Error(fmt.Sprintf("Failed to start MongoDB writer: %s", err))
 		os.Exit(1)
 	}
 
 	errs := make(chan error, 2)
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, syscall.SIGINT)
-		errs <- fmt.Errorf("%s", <-c)
-	}()
 
-	go startHTTPService(cfg.port, logger, errs)
+	httpServer := server.NewHTTPServer(fmt.Sprintf(":%s", cfg.port), api.MakeHandler(svcName), "", "")
+	go httpServer.Start(logger, errs)
 
-	err = <-errs
-	logger.Error(fmt.Sprintf("MongoDB writer service terminated: %s", err))
+	server.Monitor(logger, errs, httpServer)
+
+	logger.Info("MongoDB writer service terminated")
 }
 
 func loadConfigs() config {
@@ -160,10 +156,4 @@ func makeMetrics() (*kitprometheus.Counter, *kitprometheus.Summary) {
 	}, []string{"method"})
 
 	return counter, latency
-}
-
-func startHTTPService(port string, logger logger.Logger, errs chan error) {
-	p := fmt.Sprintf(":%s", port)
-	logger.Info(fmt.Sprintf("Mongodb writer service started, exposed port %s", p))
-	errs <- http.ListenAndServe(p, api.MakeHandler(svcName))
 }

--- a/internal/pkg/server/grpc.go
+++ b/internal/pkg/server/grpc.go
@@ -1,0 +1,88 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/mainflux/mainflux/logger"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// GRPCServer wrapper around grpc.Sserver that fullfils GracefulServer interface
+type GRPCServer struct {
+	*grpc.Server
+	address string
+}
+
+var _ GracefulServer = (*GRPCServer)(nil)
+
+// NewGRPCServer creates new GRPCServer
+func NewGRPCServer(address string, certPath string, keyPath string, log logger.Logger) *GRPCServer {
+	srv := &GRPCServer{address: address}
+
+	if certPath != "" || keyPath != "" {
+		creds, err := credentials.NewServerTLSFromFile(certPath, keyPath)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to load authn certificates: %s", err))
+		}
+		log.Info(fmt.Sprintf("gRPC service created using https with cert %s key %s", certPath, keyPath))
+		srv.Server = grpc.NewServer(grpc.Creds(creds))
+	} else {
+		log.Info(fmt.Sprintf("gRPC service created using http"))
+		srv.Server = grpc.NewServer()
+	}
+
+	return srv
+}
+
+// Start starts GRPC listenner
+func (s *GRPCServer) Start(log logger.Logger, errs chan<- error, registerServiceFn func()) {
+	if registerServiceFn == nil {
+		errs <- fmt.Errorf("Register service function is nil")
+		return
+	}
+
+	// Bind service to grpc server
+	registerServiceFn()
+
+	listener, err := net.Listen("tcp", s.address)
+	if err != nil {
+		errs <- fmt.Errorf("Failed to listen on address %s: %s", s.address, err)
+		return
+	}
+
+	log.Info(fmt.Sprintf("gRPC service started on %s", s.address))
+	errs <- s.Serve(listener)
+}
+
+// Stop stops listenning for new GRPC connections and waits for existing service calls to complete or timeout to exceed
+func (s *GRPCServer) Stop(log logger.Logger, timeout time.Duration) error {
+	log.Info(fmt.Sprintf("Stopping gRPC server on %q", s.address))
+
+	serverStopped := make(chan struct{})
+	go func() {
+		s.GracefulStop()
+		close(serverStopped)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+loop:
+	for {
+		select {
+		case <-serverStopped:
+			break loop
+		case <-ctx.Done():
+			log.Error(fmt.Sprintf("Stop timeout of %v exceeded - some calls are still active", timeout))
+			break loop
+		}
+	}
+
+	log.Info(fmt.Sprintf("gRPC server on %q stopped", s.address))
+	return nil
+}

--- a/internal/pkg/server/http.go
+++ b/internal/pkg/server/http.go
@@ -1,0 +1,61 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mainflux/mainflux/logger"
+)
+
+// HTTPServer wraper around http.Server that fulfill GracefulServer interface
+type HTTPServer struct {
+	*http.Server
+	certPath string
+	keyPath  string
+}
+
+var _ GracefulServer = (*HTTPServer)(nil)
+
+// NewHTTPServer creates new http server
+func NewHTTPServer(address string, handler http.Handler, certPath string, keyPath string) *HTTPServer {
+	return &HTTPServer{
+		Server: &http.Server{
+			Addr:    address,
+			Handler: handler,
+		},
+		certPath: certPath,
+		keyPath:  keyPath,
+	}
+}
+
+// Start starts http or https server, depending on cert/key value
+func (s *HTTPServer) Start(log logger.Logger, errs chan<- error) {
+	if s.certPath != "" || s.keyPath != "" {
+		log.Info(fmt.Sprintf("HTTPS service started on address %s, cert %s key %s", s.Addr, s.certPath, s.keyPath))
+		errs <- s.ListenAndServeTLS(s.certPath, s.keyPath)
+		return
+	}
+	log.Info(fmt.Sprintf("HTTP service started on address %s", s.Addr))
+	errs <- s.ListenAndServe()
+}
+
+// Stop stops http listenning and waits for existing handler calls to complete or timeout to occur
+func (s *HTTPServer) Stop(log logger.Logger, timeout time.Duration) error {
+	log.Info(fmt.Sprintf("Stopping http server on %q", s.Addr))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := s.Shutdown(ctx); err == context.DeadlineExceeded {
+		log.Error("HTTP shutdown timeout - existing connections are not completed yet")
+	} else if err != nil {
+		return fmt.Errorf("Error stopping http server: %s", err)
+	}
+
+	log.Info(fmt.Sprintf("HTTP server on %q stopped", s.Addr))
+	return nil
+}

--- a/internal/pkg/server/mocks/server.go
+++ b/internal/pkg/server/mocks/server.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"time"
+
+	"github.com/mainflux/mainflux/internal/pkg/server"
+	"github.com/mainflux/mainflux/logger"
+)
+
+var _ server.GracefulServer = (*Server)(nil)
+
+// Server mocked server
+type Server struct {
+	StartErr error
+	StopErr  error
+}
+
+func (s *Server) Start(logger logger.Logger, errChan chan<- error) {
+	logger.Info("mocked server started")
+
+	if s.StartErr != nil {
+		errChan <- s.StartErr
+		return
+	}
+
+}
+
+func (s *Server) Stop(logger logger.Logger, timeout time.Duration) error {
+	if s.StopErr == nil {
+		logger.Info("mocked server stopped")
+		return nil
+	}
+
+	return s.StopErr
+}

--- a/internal/pkg/server/monitor.go
+++ b/internal/pkg/server/monitor.go
@@ -1,0 +1,51 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mainflux/mainflux/logger"
+)
+
+const defaultServerStopTimeout = 30 * time.Second
+
+var monitorSignals = []os.Signal{syscall.SIGINT}
+
+// GracefulServer interface with method to start and gracefully stop server
+type GracefulServer interface {
+	// Stop terminates server listenning and waits for existing handler calls to complete or timeout to occur
+	Stop(logger logger.Logger, timeout time.Duration) error
+}
+
+// Monitor is blocking function that listens for SIGINT signal and errors on errChan channel.
+// When SIGINT signal is received it tries to gracefully stop all passed servers within passed timeout and then terminates monitoring.
+// If error is received on errors channel error is logged and monitoring is terminated.
+func Monitor(log logger.Logger, errChan <-chan error, servers ...GracefulServer) {
+	log.Info("Graceful server monitor started")
+
+	signalChan := make(chan os.Signal, len(monitorSignals))
+	signal.Notify(signalChan, monitorSignals...)
+
+	for {
+		select {
+		case receivedSignal := <-signalChan:
+			log.Info(fmt.Sprintf("Received signal: %s", receivedSignal))
+			for _, srv := range servers {
+				if err := srv.Stop(log, defaultServerStopTimeout); err != nil {
+					log.Error(fmt.Sprintf("Error during server stop: %s", err))
+				}
+			}
+			log.Info("Graceful server monitor exit")
+			return
+		case err := <-errChan:
+			log.Error(fmt.Sprintf("Graceful server monitor exiting due to error: %s", err))
+			return
+		}
+	}
+}

--- a/internal/pkg/server/monitor_test.go
+++ b/internal/pkg/server/monitor_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/mainflux/mainflux/internal/pkg/server"
+	"github.com/mainflux/mainflux/internal/pkg/server/mocks"
+	log "github.com/mainflux/mainflux/logger/mocks"
+)
+
+var (
+	errChan = make(chan error)
+	logger  = log.Logger{}
+)
+
+func ExampleMonitor_noServerError() {
+	srv := &mocks.Server{}
+	go srv.Start(logger, errChan)
+	time.Sleep(50 * time.Millisecond) // ensure Start is called
+	go func() {
+		_ = syscall.Kill(os.Getpid(), syscall.SIGINT)
+	}()
+	server.Monitor(logger, errChan, srv)
+
+	// Output:
+	// Info: mocked server started
+	// Info: Graceful server monitor started
+	// Info: Received signal: interrupt
+	// Info: mocked server stopped
+	// Info: Graceful server monitor exit
+}
+
+func ExampleMonitor_errorWhileRunning() {
+	srv := &mocks.Server{StartErr: errors.New("server error")}
+	go srv.Start(logger, errChan)
+	server.Monitor(logger, errChan, srv)
+
+	// Output:
+	// Info: Graceful server monitor started
+	// Info: mocked server started
+	// Error: Graceful server monitor exiting due to error: server error
+}
+
+func ExampleMonitor_errorStoppingServer() {
+	srv := &mocks.Server{StopErr: errors.New("error stopping server")}
+	go srv.Start(logger, errChan)
+	time.Sleep(50 * time.Millisecond) // ensure Start is called
+	go func() {
+		_ = syscall.Kill(os.Getpid(), syscall.SIGINT)
+	}()
+	server.Monitor(logger, errChan, srv)
+
+	// Output:
+	// Info: mocked server started
+	// Info: Graceful server monitor started
+	// Info: Received signal: interrupt
+	// Error: Error during server stop: error stopping server
+	// Info: Graceful server monitor exit
+}

--- a/logger/mocks/logger.go
+++ b/logger/mocks/logger.go
@@ -1,0 +1,32 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/mainflux/mainflux/logger"
+)
+
+// Logger mock implementation of logger.Logger interface
+type Logger struct{}
+
+var _ logger.Logger = Logger{}
+
+// Debug logs any object in JSON format on debug level.
+func (l Logger) Debug(msg string) {
+	fmt.Printf("Debug: %s\n", msg)
+}
+
+// Info logs any object in JSON format on info level.
+func (l Logger) Info(msg string) {
+	fmt.Printf("Info: %s\n", msg)
+}
+
+// Warn logs any object in JSON format on warning level.
+func (l Logger) Warn(msg string) {
+	fmt.Printf("Warn: %s\n", msg)
+}
+
+// Error logs any object in JSON format on error level.
+func (l Logger) Error(msg string) {
+	fmt.Printf("Error: %s\n", msg)
+}


### PR DESCRIPTION
### What does this do?
Adds mechanism for graceful shutdown of underlying servers.

(Currently http and grpc are covered and some others like writers, ES listeners will be covered with later commits.)

### Which issue(s) does this PR fix/relate to?
Resolves #701 

### List any changes that modify/break current functionality
Some log messages are slightly changed to follow code changes.
This potentially could be the issue if for example some external tool (like log parser) depends on logs that have been changed.

### Have you included tests for your changes?
TBD

### Did you document any new/modified functionality?
No

### Notes
Common logic for monitoring and graceful shutdown is placed in 'internal/pkg/server' package.
Not sure if 'servers' is good name for this package as I'm planning also to use logic from that package for graceful termination of nats/es subscriptions.