### PR TITLE
NOISSUE - Update state based on SenML time value

### DIFF
--- a/twins/mocks/states.go
+++ b/twins/mocks/states.go
@@ -38,6 +38,16 @@ func (srm *stateRepositoryMock) Save(ctx context.Context, st twins.State) error 
 	return nil
 }
 
+// UpdateState updates the state
+func (srm *stateRepositoryMock) Update(ctx context.Context, st twins.State) error {
+	srm.mu.Lock()
+	defer srm.mu.Unlock()
+
+	srm.states[key(st.TwinID, string(st.ID))] = st
+
+	return nil
+}
+
 // CountStates returns the number of states related to twin
 func (srm *stateRepositoryMock) Count(ctx context.Context, tw twins.Twin) (int64, error) {
 	return int64(len(srm.states)), nil

--- a/twins/mongodb/states.go
+++ b/twins/mongodb/states.go
@@ -45,8 +45,7 @@ func (sr *stateRepository) Update(ctx context.Context, st twins.State) error {
 
 	filter := bson.D{{"id", st.ID}, {"twinid", st.TwinID}}
 	update := bson.D{{"$set", st}}
-	_, err := coll.UpdateOne(context.Background(), filter, update)
-	if err != nil {
+	if _, err := coll.UpdateOne(context.Background(), filter, update); err != nil {
 		return err
 	}
 

--- a/twins/mongodb/states.go
+++ b/twins/mongodb/states.go
@@ -43,8 +43,8 @@ func (sr *stateRepository) Save(ctx context.Context, st twins.State) error {
 func (sr *stateRepository) Update(ctx context.Context, st twins.State) error {
 	coll := sr.db.Collection(statesCollection)
 
-	filter := bson.D{{"id", st.ID}, {"twinid", st.TwinID}}
-	update := bson.D{{"$set", st}}
+	filter := bson.M{"id": st.ID, "twinid": st.TwinID}
+	update := bson.M{"$set": st}
 	if _, err := coll.UpdateOne(context.Background(), filter, update); err != nil {
 		return err
 	}

--- a/twins/mongodb/states.go
+++ b/twins/mongodb/states.go
@@ -39,6 +39,20 @@ func (sr *stateRepository) Save(ctx context.Context, st twins.State) error {
 	return nil
 }
 
+// Update persists the state
+func (sr *stateRepository) Update(ctx context.Context, st twins.State) error {
+	coll := sr.db.Collection(statesCollection)
+
+	filter := bson.D{{"id", st.ID}, {"twinid", st.TwinID}}
+	update := bson.D{{"$set", st}}
+	_, err := coll.UpdateOne(context.Background(), filter, update)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CountStates returns the number of states related to twin
 func (sr *stateRepository) Count(ctx context.Context, tw twins.Twin) (int64, error) {
 	coll := sr.db.Collection(statesCollection)

--- a/twins/service.go
+++ b/twins/service.go
@@ -308,13 +308,13 @@ func (ts *twinsService) saveState(msg *mainflux.Message, id string) error {
 	for _, rec := range recs {
 		action := prepareState(&st, &tw, rec, msg)
 		switch action {
-		case 0:
+		case noop:
 			return nil
-		case 1:
+		case update:
 			if err := ts.states.Update(context.TODO(), st); err != nil {
 				return fmt.Errorf("Update state for %s failed: %s", msg.Publisher, err)
 			}
-		case 2:
+		case save:
 			if err := ts.states.Save(context.TODO(), st); err != nil {
 				return fmt.Errorf("Save state for %s failed: %s", msg.Publisher, err)
 			}

--- a/twins/states.go
+++ b/twins/states.go
@@ -29,6 +29,9 @@ type StateRepository interface {
 	// Save persists the state
 	Save(context.Context, State) error
 
+	// Update updates the state
+	Update(context.Context, State) error
+
 	// Count returns the number of states related to state
 	Count(context.Context, Twin) (int64, error)
 

--- a/twins/twins.go
+++ b/twins/twins.go
@@ -24,6 +24,7 @@ type Definition struct {
 	ID         int         `json:"id"`
 	Created    time.Time   `json:"created"`
 	Attributes []Attribute `json:"attributes"`
+	Delta      int64       `json:"delta"`
 }
 
 // Twin represents a Mainflux thing digital twin. Each twin is owned by one thing, and


### PR DESCRIPTION
Currently, every SenML record triggers new state save. Compare record timestamp with state timestamp to decide whether to save or update state.

Signed-off-by: Darko Draskovic <darko.draskovic@gmail.com>