### PR TITLE
MF-1091 - Use channels. as broker prefix

### DIFF
--- a/broker/nats.go
+++ b/broker/nats.go
@@ -28,9 +28,10 @@ type Nats interface {
 }
 
 const (
-	prefix = "channel"
+	chansPrefix = "channels"
+
 	// SubjectAllChannels define the subject to subscribe to all channels messages
-	SubjectAllChannels = "channel.>"
+	SubjectAllChannels = "channels.>"
 )
 
 var (
@@ -64,7 +65,7 @@ func (b broker) Publish(_ context.Context, _ string, msg Message) error {
 		return err
 	}
 
-	subject := fmt.Sprintf("%s.%s", prefix, msg.Channel)
+	subject := fmt.Sprintf("%s.%s", chansPrefix, msg.Channel)
 	if msg.Subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, msg.Subtopic)
 	}
@@ -76,7 +77,7 @@ func (b broker) Publish(_ context.Context, _ string, msg Message) error {
 }
 
 func (b broker) Subscribe(subject string, f func(msg *nats.Msg)) (*nats.Subscription, error) {
-	ps := fmt.Sprintf("%s.%s", prefix, subject)
+	ps := fmt.Sprintf("%s.%s", chansPrefix, subject)
 	sub, err := b.conn.Subscribe(ps, f)
 	if err != nil {
 		return nil, errors.Wrap(errNatsSub, err)

--- a/docker/addons/cassandra-writer/subjects.toml
+++ b/docker/addons/cassandra-writer/subjects.toml
@@ -1,4 +1,4 @@
-# If you want to listen on all subjects, just pass one element ["channel.>"], otherwise
-# pass the list of subjects (e.g ["channel.<channel_id>", "channel.<channel_id>.sub.topic.x", ...]).
+# If you want to listen on all subjects, just pass one element ["channels.>"], otherwise
+# pass the list of subjects (e.g ["channels.<channel_id>", "channels.<channel_id>.sub.topic.x", ...]).
 [subjects]
-filter = ["channel.>"]
+filter = ["channels.>"]

--- a/docker/addons/influxdb-writer/subjects.toml
+++ b/docker/addons/influxdb-writer/subjects.toml
@@ -1,4 +1,4 @@
-# If you want to listen on all subjects, just pass one element ["channel.>"], otherwise
-# pass the list of subjects (e.g ["channel.<channel_id>", "channel.<channel_id>.sub.topic.x", ...]).
+# If you want to listen on all subjects, just pass one element ["channels.>"], otherwise
+# pass the list of subjects (e.g ["channels.<channel_id>", "channels.<channel_id>.sub.topic.x", ...]).
 [subjects]
-filter = ["channel.>"]
+filter = ["channels.>"]

--- a/docker/addons/mongodb-writer/subjects.toml
+++ b/docker/addons/mongodb-writer/subjects.toml
@@ -1,4 +1,4 @@
-# If you want to listen on all subjects, just pass one element ["channel.>"], otherwise
-# pass the list of subjects (e.g ["channel.<channel_id>", "channel.<channel_id>.sub.topic.x", ...]).
+# If you want to listen on all subjects, just pass one element ["channels.>"], otherwise
+# pass the list of subjects (e.g ["channels.<channel_id>", "channels.<channel_id>.sub.topic.x", ...]).
 [subjects]
-filter = ["channel.>"]
+filter = ["channels.>"]

--- a/docker/addons/postgres-writer/subjects.toml
+++ b/docker/addons/postgres-writer/subjects.toml
@@ -1,4 +1,4 @@
-# If you want to listen on all subjects, just pass one element ["channel.>"], otherwise
-# pass the list of subjects (e.g ["channel.<channel_id>", "channel.<channel_id>.sub.topic.x", ...]).
+# If you want to listen on all subjects, just pass one element ["channels.>"], otherwise
+# pass the list of subjects (e.g ["channels.<channel_id>", "channels.<channel_id>.sub.topic.x", ...]).
 [subjects]
-filter = ["channel.>"]
+filter = ["channels.>"]


### PR DESCRIPTION
Signed-off-by: Manuel Imperiale <manuel.imperiale@gmail.com>

* Use "channels" instead of "channel" as subject prefix of the NATS message broker.
