### PR TITLE
MF-1103 - API key should ignore empty expiration time

### DIFF
--- a/authn/keys.go
+++ b/authn/keys.go
@@ -38,6 +38,9 @@ type Key struct {
 
 // Expired verifies if the key is expired.
 func (k Key) Expired() bool {
+	if k.Type == APIKey && k.ExpiresAt.IsZero() {
+		return false
+	}
 	return k.ExpiresAt.UTC().Before(time.Now().UTC())
 }
 

--- a/authn/keys_test.go
+++ b/authn/keys_test.go
@@ -37,11 +37,19 @@ func TestExpired(t *testing.T) {
 			expired: true,
 		},
 		{
-			desc: "key with no expiration date",
+			desc: "login key with no expiration date",
 			key: authn.Key{
 				IssuedAt: time.Now(),
 			},
 			expired: true,
+		},
+		{
+			desc: "API key with no expiration date",
+			key: authn.Key{
+				IssuedAt: time.Now(),
+				Type:     authn.APIKey,
+			},
+			expired: false,
 		},
 	}
 

--- a/authn/keys_test.go
+++ b/authn/keys_test.go
@@ -37,7 +37,7 @@ func TestExpired(t *testing.T) {
 			expired: true,
 		},
 		{
-			desc: "login key with no expiration date",
+			desc: "user key with no expiration date",
 			key: authn.Key{
 				IssuedAt: time.Now(),
 			},

--- a/authn/swagger.yaml
+++ b/authn/swagger.yaml
@@ -21,7 +21,7 @@ paths:
           description: JSON-formatted document describing the new key.
           in: body
           schema:
-            $ref: "#/definitions/Key"
+            $ref: "#/definitions/KeyRequest"
           required: true
       responses:
         201:
@@ -111,8 +111,23 @@ definitions:
         format: date-time
         example: "2019-11-26 13:31:52"
         description: Time when the Key expires
-    required:
-      - type
+  KeyRequest:
+    type: object
+    properties:
+      type:
+        type: integer
+        example: 0
+        description: API key type. Keys of different type are processed differently
+      issuer:
+        type: string
+        format: e-mail
+        example: "test@example.com"
+        description: User's email or service identifier of API key issuer
+      duration:
+        type: number
+        format: integer
+        example: 23456
+        description: Number of seconds issued token is valid for.
 
 parameters:
   Authorization:


### PR DESCRIPTION
Signed-off-by: Dušan Borovčanin <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes API key expiration validation.

### Which issue(s) does this PR fix/relate to?
This pull request fixes #1103.

### List any changes that modify/break current functionality
API key validation should allow using tokens with an indefinite duration.

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
Yes, API docs are updated.