### PR TITLE
NOISSUE - Implement errors package in Authentication service

### DIFF
--- a/authn/api/grpc/endpoint_test.go
+++ b/authn/api/grpc/endpoint_test.go
@@ -58,42 +58,50 @@ func TestIssue(t *testing.T) {
 		id   string
 		kind uint32
 		err  error
+		code codes.Code
 	}{
 		{
 			desc: "issue for user with valid token",
 			id:   email,
 			kind: authn.UserKey,
 			err:  nil,
+			code: codes.OK,
 		},
 		{
 			desc: "issue recovery key",
 			id:   email,
 			kind: authn.RecoveryKey,
 			err:  nil,
+			code: codes.OK,
 		},
 		{
 			desc: "issue API key",
 			id:   userKey.Secret,
 			kind: authn.APIKey,
 			err:  nil,
+			code: codes.OK,
 		},
 		{
 			desc: "issue for invalid key type",
 			id:   email,
 			kind: 32,
 			err:  status.Error(codes.InvalidArgument, "received invalid token request"),
+			code: codes.InvalidArgument,
 		},
 		{
 			desc: "issue for user that  exist",
 			id:   "",
 			kind: authn.APIKey,
 			err:  status.Error(codes.Unauthenticated, "unauthorized access"),
+			code: codes.Unauthenticated,
 		},
 	}
 
 	for _, tc := range cases {
 		_, err := client.Issue(context.Background(), &mainflux.IssueReq{Issuer: tc.id, Type: tc.kind})
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
+		e, ok := status.FromError(err)
+		assert.True(t, ok, "OK expected to be true")
+		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.code, e.Code()))
 	}
 }
 
@@ -116,36 +124,43 @@ func TestIdentify(t *testing.T) {
 		token string
 		id    string
 		err   error
+		code  codes.Code
 	}{
 		{
 			desc:  "identify user with recovery token",
 			token: recoveryKey.Secret,
 			id:    email,
 			err:   nil,
+			code:  codes.OK,
 		},
 		{
 			desc:  "identify user with API token",
 			token: apiKey.Secret,
 			id:    email,
 			err:   nil,
+			code:  codes.OK,
 		},
 		{
 			desc:  "identify user with invalid user token",
 			token: "invalid",
 			id:    "",
 			err:   status.Error(codes.Unauthenticated, "unauthorized access"),
+			code:  codes.Unauthenticated,
 		},
 		{
 			desc:  "identify user that doesn't exist",
 			token: "",
 			id:    "",
 			err:   status.Error(codes.InvalidArgument, "received invalid token request"),
+			code:  codes.InvalidArgument,
 		},
 	}
 
 	for _, tc := range cases {
 		id, err := client.Identify(context.Background(), &mainflux.Token{Value: tc.token})
 		assert.Equal(t, tc.id, id.GetValue(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.id, id.GetValue()))
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.err, err))
+		e, ok := status.FromError(err)
+		assert.True(t, ok, "OK expected to be true")
+		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.code, e.Code()))
 	}
 }

--- a/authn/api/grpc/endpoint_test.go
+++ b/authn/api/grpc/endpoint_test.go
@@ -100,7 +100,7 @@ func TestIssue(t *testing.T) {
 	for _, tc := range cases {
 		_, err := client.Issue(context.Background(), &mainflux.IssueReq{Issuer: tc.id, Type: tc.kind})
 		e, ok := status.FromError(err)
-		assert.True(t, ok, "OK expected to be true")
+		assert.True(t, ok, "gRPC status can't be extracted from the error")
 		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.code, e.Code()))
 	}
 }
@@ -160,7 +160,7 @@ func TestIdentify(t *testing.T) {
 		id, err := client.Identify(context.Background(), &mainflux.Token{Value: tc.token})
 		assert.Equal(t, tc.id, id.GetValue(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.id, id.GetValue()))
 		e, ok := status.FromError(err)
-		assert.True(t, ok, "OK expected to be true")
+		assert.True(t, ok, "gRPC status can't be extracted from the error")
 		assert.Equal(t, tc.code, e.Code(), fmt.Sprintf("%s: expected %s got %s", tc.desc, tc.code, e.Code()))
 	}
 }

--- a/authn/api/grpc/server.go
+++ b/authn/api/grpc/server.go
@@ -76,6 +76,8 @@ func encodeIdentifyResponse(_ context.Context, grpcRes interface{}) (interface{}
 
 func encodeError(err error) error {
 	switch {
+	case errors.Contains(err, nil):
+		return nil
 	case errors.Contains(err, authn.ErrMalformedEntity):
 		return status.Error(codes.InvalidArgument, "received invalid token request")
 	case errors.Contains(err, authn.ErrUnauthorizedAccess):

--- a/authn/api/grpc/server.go
+++ b/authn/api/grpc/server.go
@@ -76,8 +76,6 @@ func encodeIdentifyResponse(_ context.Context, grpcRes interface{}) (interface{}
 
 func encodeError(err error) error {
 	switch {
-	case errors.Contains(err, nil):
-		return nil
 	case errors.Contains(err, authn.ErrMalformedEntity):
 		return status.Error(codes.InvalidArgument, "received invalid token request")
 	case errors.Contains(err, authn.ErrUnauthorizedAccess):

--- a/authn/api/http/requests.go
+++ b/authn/api/http/requests.go
@@ -4,6 +4,7 @@
 package http
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/mainflux/mainflux/authn"

--- a/authn/api/http/requests.go
+++ b/authn/api/http/requests.go
@@ -4,7 +4,6 @@
 package http
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/mainflux/mainflux/authn"

--- a/authn/api/http/responses.go
+++ b/authn/api/http/responses.go
@@ -48,3 +48,7 @@ func (res revokeKeyRes) Headers() map[string]string {
 func (res revokeKeyRes) Empty() bool {
 	return true
 }
+
+type errorRes struct {
+	Err string `json:"error"`
+}

--- a/authn/jwt/token_test.go
+++ b/authn/jwt/token_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mainflux/mainflux/authn"
 	"github.com/mainflux/mainflux/authn/jwt"
+	"github.com/mainflux/mainflux/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,7 +49,7 @@ func TestIssue(t *testing.T) {
 
 	for _, tc := range cases {
 		_, err := tokenizer.Issue(tc.key)
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
 	}
 }
 
@@ -104,7 +105,7 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range cases {
 		key, err := tokenizer.Parse(tc.token)
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.key, key, fmt.Sprintf("%s expected %v, got %v", tc.desc, tc.key, key))
 	}
 }

--- a/authn/jwt/tokenizer.go
+++ b/authn/jwt/tokenizer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/mainflux/mainflux/authn"
+	"github.com/mainflux/mainflux/errors"
 )
 
 type claims struct {
@@ -68,9 +69,9 @@ func (svc tokenizer) Parse(token string) (authn.Key, error) {
 			if c.Type != nil && *c.Type == authn.APIKey {
 				return c.toKey(), nil
 			}
-			return authn.Key{}, authn.ErrKeyExpired
+			return authn.Key{}, errors.Wrap(authn.ErrKeyExpired, err)
 		}
-		return authn.Key{}, authn.ErrUnauthorizedAccess
+		return authn.Key{}, errors.Wrap(authn.ErrUnauthorizedAccess, err)
 	}
 
 	return c.toKey(), nil

--- a/authn/postgres/key_test.go
+++ b/authn/postgres/key_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mainflux/mainflux/authn"
 	"github.com/mainflux/mainflux/authn/postgres"
 	"github.com/mainflux/mainflux/authn/uuid"
+	"github.com/mainflux/mainflux/errors"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -53,7 +54,7 @@ func TestKeySave(t *testing.T) {
 
 	for _, tc := range cases {
 		_, err := repo.Save(context.Background(), tc.key)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 
@@ -101,7 +102,7 @@ func TestKeyRetrieve(t *testing.T) {
 
 	for _, tc := range cases {
 		_, err := repo.Retrieve(context.Background(), tc.issuer, tc.id)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 
@@ -143,6 +144,6 @@ func TestKeyRemove(t *testing.T) {
 
 	for _, tc := range cases {
 		err := repo.Remove(context.Background(), tc.issuer, tc.id)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }

--- a/authn/service_test.go
+++ b/authn/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mainflux/mainflux/authn"
 	"github.com/mainflux/mainflux/authn/jwt"
 	"github.com/mainflux/mainflux/authn/mocks"
+	"github.com/mainflux/mainflux/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,7 +103,7 @@ func TestIssue(t *testing.T) {
 
 	for _, tc := range cases {
 		_, err := svc.Issue(context.Background(), tc.issuer, tc.key)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 func TestRevoke(t *testing.T) {
@@ -144,7 +145,7 @@ func TestRevoke(t *testing.T) {
 
 	for _, tc := range cases {
 		err := svc.Revoke(context.Background(), tc.issuer, tc.id)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 func TestRetrieve(t *testing.T) {
@@ -205,7 +206,7 @@ func TestRetrieve(t *testing.T) {
 
 	for _, tc := range cases {
 		_, err := svc.Retrieve(context.Background(), tc.issuer, tc.id)
-		assert.Equal(t, err, tc.err, fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 	}
 }
 func TestIdentify(t *testing.T) {
@@ -272,7 +273,7 @@ func TestIdentify(t *testing.T) {
 
 	for _, tc := range cases {
 		id, err := svc.Identify(context.Background(), tc.key)
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 		assert.Equal(t, tc.id, id, fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.id, id))
 	}
 }

--- a/authn/uuid/idp.go
+++ b/authn/uuid/idp.go
@@ -7,7 +7,11 @@ package uuid
 import (
 	"github.com/gofrs/uuid"
 	"github.com/mainflux/mainflux/authn"
+	"github.com/mainflux/mainflux/errors"
 )
+
+// errGeneratingID indicates error in generating UUID
+var errGeneratingID = errors.New("failed to generate uuid")
 
 var _ authn.IdentityProvider = (*uuidIdentityProvider)(nil)
 
@@ -21,7 +25,8 @@ func New() authn.IdentityProvider {
 func (idp *uuidIdentityProvider) ID() (string, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errGeneratingID, err)
+
 	}
 
 	return id.String(), nil

--- a/authn/uuid/idp.go
+++ b/authn/uuid/idp.go
@@ -26,7 +26,6 @@ func (idp *uuidIdentityProvider) ID() (string, error) {
 	id, err := uuid.NewV4()
 	if err != nil {
 		return "", errors.Wrap(errGeneratingID, err)
-
 	}
 
 	return id.String(), nil


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>

### What does this do?
Use mainflux errors package in Authentication service

### Which issue(s) does this PR fix/relate to?
Related to issues #538 and #870

### List any changes that modify/break current functionality
API endpoints return error message in response body for errors (not just status response code in header)

### Have you included tests for your changes?
Yes

