### PR TITLE
NOISSUE - Remove defers from TestMain

### DIFF
--- a/authn/postgres/setup_test.go
+++ b/authn/postgres/setup_test.go
@@ -65,10 +65,11 @@ func TestMain(m *testing.M) {
 	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err := pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}

--- a/bootstrap/postgres/setup_test.go
+++ b/bootstrap/postgres/setup_test.go
@@ -69,10 +69,11 @@ func TestMain(m *testing.M) {
 	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err := pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}

--- a/readers/postgres/setup_test.go
+++ b/readers/postgres/setup_test.go
@@ -71,10 +71,11 @@ func TestMain(m *testing.M) {
 	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err = pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -71,10 +71,11 @@ func TestMain(m *testing.M) {
 	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err := pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}

--- a/users/postgres/setup_test.go
+++ b/users/postgres/setup_test.go
@@ -65,10 +65,11 @@ func TestMain(m *testing.M) {
 	if db, err = postgres.Connect(dbConfig); err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err := pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}

--- a/writers/postgres/setup_test.go
+++ b/writers/postgres/setup_test.go
@@ -72,10 +72,11 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Could not setup test DB connection: %s", err)
 	}
-	defer db.Close()
 
 	code := m.Run()
 
+	// defers will not be run when using os.Exit
+	db.Close()
 	if err := pool.Purge(container); err != nil {
 		log.Fatalf("Could not purge container: %s", err)
 	}


### PR DESCRIPTION
Defers will not be run when using os.Exit (https://github.com/golang/go/issues/34129)

Signed-off-by: Alexander Obukhov <dev@sprql.space>