### PR TITLE
NOISSUE - Add `Expire` to running containers via dockertest

### DIFF
--- a/authn/postgres/setup_test.go
+++ b/authn/postgres/setup_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 const wrong string = "wrong-value"
+const expInterval = 60 // in seconds
 
 var db *sqlx.DB
 
@@ -35,6 +36,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")

--- a/bootstrap/postgres/setup_test.go
+++ b/bootstrap/postgres/setup_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	wrongID    = "0"
-	wrongValue = "wrong-value"
+	wrongID     = "0"
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 var (
@@ -39,6 +40,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")

--- a/bootstrap/postgres/setup_test.go
+++ b/bootstrap/postgres/setup_test.go
@@ -15,11 +15,7 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
-const (
-	wrongID     = "0"
-	wrongValue  = "wrong-value"
-	expInterval = 60 // in seconds
-)
+const expInterval = 60 // in seconds
 
 var (
 	testLog, _ = logger.New(os.Stdout, logger.Info.String())

--- a/bootstrap/redis/producer/setup_test.go
+++ b/bootstrap/redis/producer/setup_test.go
@@ -13,11 +13,7 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
-const (
-	wrongID     = 0
-	wrongValue  = "wrong-value"
-	expInterval = 60 // in seconds
-)
+const expInterval = 60 // in seconds
 
 var redisClient *redis.Client
 

--- a/bootstrap/redis/producer/setup_test.go
+++ b/bootstrap/redis/producer/setup_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	wrongID    = 0
-	wrongValue = "wrong-value"
+	wrongID     = 0
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 var redisClient *redis.Client
@@ -29,6 +30,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("redis", "5.0-alpine", nil)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	if err := pool.Retry(func() error {

--- a/readers/influxdb/setup_test.go
+++ b/readers/influxdb/setup_test.go
@@ -10,6 +10,8 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
+const expInterval = 60 // in seconds
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -24,6 +26,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("influxdb", "1.6.4-alpine", cfg)
 	if err != nil {
 		testLog.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		testLog.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port = container.GetPort("8086/tcp")

--- a/readers/mongodb/setup_test.go
+++ b/readers/mongodb/setup_test.go
@@ -15,6 +15,8 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
+const expInterval = 60 // in seconds
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -28,6 +30,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("mongo", "3.6-jessie", cfg)
 	if err != nil {
 		testLog.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		testLog.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port = container.GetPort("27017/tcp")

--- a/readers/postgres/setup_test.go
+++ b/readers/postgres/setup_test.go
@@ -27,6 +27,8 @@ var (
 	db         *sqlx.DB
 )
 
+const expInterval = 60 // in seconds
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -41,6 +43,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	wrongID     = "0"
 	wrongValue  = "wrong-value"
 	expInterval = 60 // in seconds
 )

--- a/things/postgres/setup_test.go
+++ b/things/postgres/setup_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	wrongID    = "0"
-	wrongValue = "wrong-value"
+	wrongID     = "0"
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 var (
@@ -41,6 +42,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")

--- a/things/redis/setup_test.go
+++ b/things/redis/setup_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	wrongID    = 0
-	wrongValue = "wrong-value"
+	wrongID     = 0
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 var redisClient *redis.Client
@@ -29,6 +30,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("redis", "5.0-alpine", nil)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	if err := pool.Retry(func() error {

--- a/things/redis/setup_test.go
+++ b/things/redis/setup_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	wrongID     = 0
 	wrongValue  = "wrong-value"
 	expInterval = 60 // in seconds
 )

--- a/twins/mongodb/setup_test.go
+++ b/twins/mongodb/setup_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	wrongID     = "0"
 	wrongValue  = "wrong-value"
 	expInterval = 60 // in seconds
 )

--- a/twins/mongodb/setup_test.go
+++ b/twins/mongodb/setup_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	wrongID    = "0"
-	wrongValue = "wrong-value"
+	wrongID     = "0"
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 func TestMain(m *testing.M) {
@@ -33,6 +34,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("mongo", "3.6-jessie", cfg)
 	if err != nil {
 		testLog.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		testLog.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port = container.GetPort("27017/tcp")

--- a/users/postgres/setup_test.go
+++ b/users/postgres/setup_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 const wrong string = "wrong-value"
+const expInterval = 60 // in seconds
 
 var db *sqlx.DB
 
@@ -35,6 +36,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")

--- a/writers/cassandra/setup_test.go
+++ b/writers/cassandra/setup_test.go
@@ -14,6 +14,8 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
+const expInterval = 60 // in seconds
+
 var logger, _ = log.New(os.Stdout, log.Info.String())
 
 func TestMain(m *testing.M) {
@@ -25,6 +27,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("cassandra", "3.11.3", []string{})
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		logger.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port := container.GetPort("9042/tcp")

--- a/writers/influxdb/setup_test.go
+++ b/writers/influxdb/setup_test.go
@@ -13,6 +13,8 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
+const expInterval = 60 // in seconds
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -27,6 +29,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("influxdb", "1.6.4-alpine", cfg)
 	if err != nil {
 		testLog.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		testLog.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port = container.GetPort("8086/tcp")

--- a/writers/mongodb/setup_test.go
+++ b/writers/mongodb/setup_test.go
@@ -15,6 +15,8 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
+const expInterval = 60 // in seconds
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -28,6 +30,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("mongo", "3.6-jessie", cfg)
 	if err != nil {
 		testLog.Error(fmt.Sprintf("Could not start container: %s", err))
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		testLog.Error(fmt.Sprintf("Could not expire container: %s", err))
 	}
 
 	port = container.GetPort("27017/tcp")

--- a/writers/postgres/setup_test.go
+++ b/writers/postgres/setup_test.go
@@ -17,11 +17,7 @@ import (
 	dockertest "gopkg.in/ory/dockertest.v3"
 )
 
-const (
-	wrongID     = "0"
-	wrongValue  = "wrong-value"
-	expInterval = 60 // in seconds
-)
+const expInterval = 60 // in seconds
 
 var (
 	testLog, _ = logger.New(os.Stdout, logger.Info.String())

--- a/writers/postgres/setup_test.go
+++ b/writers/postgres/setup_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	wrongID    = "0"
-	wrongValue = "wrong-value"
+	wrongID     = "0"
+	wrongValue  = "wrong-value"
+	expInterval = 60 // in seconds
 )
 
 var (
@@ -41,6 +42,11 @@ func TestMain(m *testing.M) {
 	container, err := pool.Run("postgres", "10.2-alpine", cfg)
 	if err != nil {
 		log.Fatalf("Could not start container: %s", err)
+	}
+
+	// Force remove the container after the interval
+	if err := container.Expire(expInterval); err != nil {
+		log.Printf("Could not expire container: %s", err)
 	}
 
 	port := container.GetPort("5432/tcp")


### PR DESCRIPTION
If a test failed by a panic, purging a container would fail too.
To prevent it, we can use `Expire()` for a container. In this case, docker daemon will auto-remove it after a specified time.
