### PR TITLE
NOISSUE - Use `StatusUnauthorized` instead of `StatusForbidden`

### DIFF
--- a/authn/api/grpc/requests.go
+++ b/authn/api/grpc/requests.go
@@ -30,7 +30,7 @@ type issueReq struct {
 
 func (req issueReq) validate() error {
 	if req.issuer == "" {
-		return authn.ErrUnauthorizedAccess
+		return authn.ErrUnauthenticated
 	}
 	if req.keyType != authn.UserKey &&
 		req.keyType != authn.APIKey &&

--- a/authn/api/grpc/server.go
+++ b/authn/api/grpc/server.go
@@ -81,7 +81,7 @@ func encodeError(err error) error {
 		return nil
 	case errors.Contains(err, authn.ErrMalformedEntity):
 		return status.Error(codes.InvalidArgument, "received invalid token request")
-	case errors.Contains(err, authn.ErrUnauthorizedAccess):
+	case errors.Contains(err, authn.ErrUnauthenticated):
 		return status.Error(codes.Unauthenticated, err.Error())
 	case errors.Contains(err, authn.ErrKeyExpired):
 		return status.Error(codes.Unauthenticated, err.Error())

--- a/authn/api/http/endpoint_test.go
+++ b/authn/api/http/endpoint_test.go
@@ -121,9 +121,10 @@ func TestIssue(t *testing.T) {
 			status: http.StatusBadRequest,
 		},
 		{
-			desc: "issue user key wrong content type",
-			req:  toJSON(uk),
-			ct:   "", token: userKey.Secret,
+			desc:   "issue user key wrong content type",
+			req:    toJSON(uk),
+			ct:     "",
+			token:  userKey.Secret,
 			status: http.StatusUnsupportedMediaType,
 		},
 		{
@@ -134,11 +135,11 @@ func TestIssue(t *testing.T) {
 			status: http.StatusUnsupportedMediaType,
 		},
 		{
-			desc:   "issue key unauthorized",
+			desc:   "issue key with an unauthorized token",
 			req:    toJSON(ak),
 			ct:     contentType,
 			token:  "wrong",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "issue recovery key with empty token",
@@ -217,10 +218,10 @@ func TestRetrieve(t *testing.T) {
 			status: http.StatusNotFound,
 		},
 		{
-			desc:   "retrieve a key unauthorized",
+			desc:   "retrieve an unauthorized token",
 			id:     k.ID,
 			token:  "wrong",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 	}
 
@@ -269,10 +270,10 @@ func TestRevoke(t *testing.T) {
 			status: http.StatusNoContent,
 		},
 		{
-			desc:   "revoke a key unauthorized",
+			desc:   "revoke an unauthorized token",
 			id:     k.ID,
 			token:  "wrong",
-			status: http.StatusForbidden},
+			status: http.StatusUnauthorized},
 	}
 
 	for _, tc := range cases {

--- a/authn/api/http/transport.go
+++ b/authn/api/http/transport.go
@@ -103,7 +103,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch {
 	case errors.Contains(err, authn.ErrMalformedEntity):
 		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, authn.ErrUnauthorizedAccess):
+	case errors.Contains(err, authn.ErrUnauthenticated):
+		w.WriteHeader(http.StatusUnauthorized)
+	case errors.Contains(err, authn.ErrUnauthorized):
 		w.WriteHeader(http.StatusForbidden)
 	case errors.Contains(err, authn.ErrNotFound):
 		w.WriteHeader(http.StatusNotFound)

--- a/authn/jwt/token_test.go
+++ b/authn/jwt/token_test.go
@@ -86,7 +86,7 @@ func TestParse(t *testing.T) {
 			desc:  "parse ivalid key",
 			key:   authn.Key{},
 			token: "invalid",
-			err:   authn.ErrUnauthorizedAccess,
+			err:   authn.ErrUnauthenticated,
 		},
 
 		{

--- a/authn/jwt/tokenizer.go
+++ b/authn/jwt/tokenizer.go
@@ -58,7 +58,7 @@ func (svc tokenizer) Parse(token string) (authn.Key, error) {
 	c := claims{}
 	_, err := jwt.ParseWithClaims(token, &c, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, authn.ErrUnauthorizedAccess
+			return nil, authn.ErrUnauthenticated
 		}
 		return []byte(svc.secret), nil
 	})
@@ -71,7 +71,7 @@ func (svc tokenizer) Parse(token string) (authn.Key, error) {
 			}
 			return authn.Key{}, errors.Wrap(authn.ErrKeyExpired, err)
 		}
-		return authn.Key{}, errors.Wrap(authn.ErrUnauthorizedAccess, err)
+		return authn.Key{}, errors.Wrap(authn.ErrUnauthenticated, err)
 	}
 
 	return c.toKey(), nil

--- a/authn/service.go
+++ b/authn/service.go
@@ -18,8 +18,13 @@ const (
 )
 
 var (
-	// ErrUnauthorizedAccess represents unauthorized access.
-	ErrUnauthorizedAccess = errors.New("unauthorized access")
+	// ErrUnauthenticated indicates missing or invalid
+	// authentication credentials.
+	ErrUnauthenticated = errors.New("unauthenticated access")
+
+	// ErrUnauthorized indicates unauthorized access
+	// when accessing a protected resource.
+	ErrUnauthorized = errors.New("unauthorized access")
 
 	// ErrMalformedEntity indicates malformed entity specification (e.g.
 	// invalid owner or ID).
@@ -129,11 +134,11 @@ func (svc service) Identify(ctx context.Context, token string) (string, error) {
 		return c.Issuer, nil
 	case RecoveryKey, UserKey:
 		if c.Issuer != issuerName {
-			return "", ErrUnauthorizedAccess
+			return "", ErrUnauthenticated
 		}
 		return c.Secret, nil
 	default:
-		return "", ErrUnauthorizedAccess
+		return "", ErrUnauthenticated
 	}
 }
 
@@ -183,11 +188,11 @@ func (svc service) login(token string) (string, error) {
 	}
 	// Only user key token is valid for login.
 	if c.Type != UserKey {
-		return "", ErrUnauthorizedAccess
+		return "", ErrUnauthenticated
 	}
 
 	if c.Secret == "" {
-		return "", ErrUnauthorizedAccess
+		return "", ErrUnauthenticated
 	}
 	return c.Secret, nil
 }

--- a/authn/service_test.go
+++ b/authn/service_test.go
@@ -73,7 +73,7 @@ func TestIssue(t *testing.T) {
 				IssuedAt: time.Now(),
 			},
 			issuer: "",
-			err:    authn.ErrUnauthorizedAccess,
+			err:    authn.ErrUnauthenticated,
 		},
 		{
 			desc: "issue API key no issue time",
@@ -140,7 +140,7 @@ func TestRevoke(t *testing.T) {
 			desc:   "revoke unauthorized",
 			id:     newKey.ID,
 			issuer: "",
-			err:    authn.ErrUnauthorizedAccess,
+			err:    authn.ErrUnauthenticated,
 		},
 	}
 
@@ -189,19 +189,19 @@ func TestRetrieve(t *testing.T) {
 			desc:   "retrieve unauthorized",
 			id:     newKey.ID,
 			issuer: "wrong",
-			err:    authn.ErrUnauthorizedAccess,
+			err:    authn.ErrUnauthenticated,
 		},
 		{
 			desc:   "retrieve with user key",
 			id:     newKey.ID,
 			issuer: userKey.Secret,
-			err:    authn.ErrUnauthorizedAccess,
+			err:    authn.ErrUnauthenticated,
 		},
 		{
 			desc:   "retrieve with reset key",
 			id:     newKey.ID,
 			issuer: resetKey.Secret,
-			err:    authn.ErrUnauthorizedAccess,
+			err:    authn.ErrUnauthenticated,
 		},
 	}
 
@@ -225,7 +225,7 @@ func TestIdentify(t *testing.T) {
 	expKey, err := svc.Issue(context.Background(), loginKey.Secret, authn.Key{Type: authn.APIKey, IssuedAt: time.Now(), ExpiresAt: exp1})
 	assert.Nil(t, err, fmt.Sprintf("Issuing expired user key expected to succeed: %s", err))
 
-	invalidKey, err := svc.Issue(context.Background(), loginKey.Secret, authn.Key{Type: 22, IssuedAt: time.Now()})
+	invalidTypeKey, err := svc.Issue(context.Background(), loginKey.Secret, authn.Key{Type: 22, IssuedAt: time.Now()})
 	assert.Nil(t, err, fmt.Sprintf("Issuing user key expected to succeed: %s", err))
 
 	cases := []struct {
@@ -259,16 +259,16 @@ func TestIdentify(t *testing.T) {
 			err:  authn.ErrKeyExpired,
 		},
 		{
-			desc: "identify expired key",
-			key:  invalidKey.Secret,
+			desc: "identify invalid type key",
+			key:  invalidTypeKey.Secret,
 			id:   "",
-			err:  authn.ErrUnauthorizedAccess,
+			err:  authn.ErrUnauthenticated,
 		},
 		{
 			desc: "identify invalid key",
 			key:  "invalid",
 			id:   "",
-			err:  authn.ErrUnauthorizedAccess,
+			err:  authn.ErrUnauthenticated,
 		},
 	}
 

--- a/authn/swagger.yaml
+++ b/authn/swagger.yaml
@@ -54,8 +54,10 @@ paths:
             $ref: "#/definitions/Key"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
     delete:
@@ -74,8 +76,10 @@ paths:
       responses:
         204:
           description: Key revoked.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
 

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -80,7 +80,7 @@ var (
 	}
 
 	bsErrorRes           = toJSON(errorRes{bootstrap.ErrBootstrap.Error()})
-	unauthRes            = toJSON(errorRes{bootstrap.ErrUnauthorizedAccess.Error()})
+	unauthRes            = toJSON(errorRes{bootstrap.ErrUnauthenticated.Error()})
 	malformedRes         = toJSON(errorRes{bootstrap.ErrMalformedEntity.Error()})
 	extKeyNotFoundRes    = toJSON(errorRes{bootstrap.ErrExternalKeyNotFound.Error()})
 	extSecKeyNotFoundRes = toJSON(errorRes{bootstrap.ErrSecureBootstrap.Error()})
@@ -228,7 +228,7 @@ func TestAdd(t *testing.T) {
 			req:         data,
 			auth:        invalidToken,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -369,7 +369,7 @@ func TestView(t *testing.T) {
 			desc:   "view a config unauthorized",
 			auth:   invalidToken,
 			id:     saved.MFThing,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    config{},
 		},
 		{
@@ -390,7 +390,7 @@ func TestView(t *testing.T) {
 			desc:   "view a config with an empty token",
 			auth:   "",
 			id:     saved.MFThing,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    config{},
 		},
 	}
@@ -447,7 +447,7 @@ func TestUpdate(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        invalidToken,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update with an empty token",
@@ -455,7 +455,7 @@ func TestUpdate(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        "",
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update a valid config",
@@ -541,7 +541,7 @@ func TestUpdateCert(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        invalidToken,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update with an empty token",
@@ -549,7 +549,7 @@ func TestUpdateCert(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        "",
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update a valid config",
@@ -641,7 +641,7 @@ func TestUpdateConnections(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        invalidToken,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update connections with an empty token",
@@ -649,7 +649,7 @@ func TestUpdateConnections(t *testing.T) {
 			id:          saved.MFThing,
 			auth:        "",
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update connections valid config",
@@ -783,14 +783,14 @@ func TestList(t *testing.T) {
 			desc:   "view list unauthorized",
 			auth:   invalidToken,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", path, 0, 10),
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    configPage{},
 		},
 		{
 			desc:   "view list with an empty token",
 			auth:   "",
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", path, 0, 10),
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    configPage{},
 		},
 		{
@@ -991,12 +991,12 @@ func TestRemove(t *testing.T) {
 			desc:   "remove unauthorized",
 			id:     saved.MFThing,
 			auth:   invalidToken,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		}, {
 			desc:   "remove with an empty token",
 			id:     saved.MFThing,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "remove non-existing config",
@@ -1107,7 +1107,7 @@ func TestBootstrap(t *testing.T) {
 			desc:        "bootstrap a Thing with an empty key",
 			externalID:  c.ExternalID,
 			externalKey: "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			res:         unauthRes,
 			secure:      false,
 		},
@@ -1188,7 +1188,7 @@ func TestChangeState(t *testing.T) {
 			auth:        invalidToken,
 			state:       active,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "change state with an empty token",
@@ -1196,7 +1196,7 @@ func TestChangeState(t *testing.T) {
 			auth:        "",
 			state:       active,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "change state with invalid content type",

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -24,7 +24,7 @@ type addReq struct {
 
 func (req addReq) validate() error {
 	if req.token == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.ExternalID == "" || req.ExternalKey == "" {
@@ -41,7 +41,7 @@ type entityReq struct {
 
 func (req entityReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -60,7 +60,7 @@ type updateReq struct {
 
 func (req updateReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -80,7 +80,7 @@ type updateCertReq struct {
 
 func (req updateCertReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.thingID == "" {
@@ -98,7 +98,7 @@ type updateConnReq struct {
 
 func (req updateConnReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -117,7 +117,7 @@ type listReq struct {
 
 func (req listReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.limit == 0 || req.limit > maxLimit {
@@ -134,7 +134,7 @@ type bootstrapReq struct {
 
 func (req bootstrapReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -152,7 +152,7 @@ type changeStateReq struct {
 
 func (req changeStateReq) validate() error {
 	if req.key == "" {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	if req.id == "" {

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -21,7 +21,7 @@ func TestAddReqValidation(t *testing.T) {
 			token:       "",
 			externalID:  "external-id",
 			externalKey: "external-key",
-			err:         bootstrap.ErrUnauthorizedAccess,
+			err:         bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:        "empty external ID",
@@ -62,7 +62,7 @@ func TestEntityReqValidation(t *testing.T) {
 			desc: "empty key",
 			key:  "",
 			id:   "id",
-			err:  bootstrap.ErrUnauthorizedAccess,
+			err:  bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc: "empty id",
@@ -93,7 +93,7 @@ func TestUpdateReqValidation(t *testing.T) {
 			desc: "empty key",
 			key:  "",
 			id:   "id",
-			err:  bootstrap.ErrUnauthorizedAccess,
+			err:  bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc: "empty id",
@@ -125,7 +125,7 @@ func TestUpdateCertReqValidation(t *testing.T) {
 			desc:    "empty key",
 			key:     "",
 			thingID: "thingID",
-			err:     bootstrap.ErrUnauthorizedAccess,
+			err:     bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:    "empty thing key",
@@ -157,7 +157,7 @@ func TestUpdateConnReqValidation(t *testing.T) {
 			desc: "empty key",
 			key:  "",
 			id:   "id",
-			err:  bootstrap.ErrUnauthorizedAccess,
+			err:  bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc: "empty id",
@@ -191,7 +191,7 @@ func TestListReqValidation(t *testing.T) {
 			key:    "",
 			offset: 0,
 			limit:  1,
-			err:    bootstrap.ErrUnauthorizedAccess,
+			err:    bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:   "too large limit",
@@ -232,7 +232,7 @@ func TestBootstrapReqValidation(t *testing.T) {
 			desc:      "empty external key",
 			externKey: "",
 			externID:  "id",
-			err:       bootstrap.ErrUnauthorizedAccess,
+			err:       bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:      "empty external id",
@@ -266,7 +266,7 @@ func TestChangeStateReqValidation(t *testing.T) {
 			key:   "",
 			id:    "id",
 			state: bootstrap.State(1),
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:  "empty id",

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -262,7 +262,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, bootstrap.ErrNotFound):
 			w.WriteHeader(http.StatusNotFound)
-		case errors.Contains(errorVal, bootstrap.ErrUnauthorizedAccess):
+		case errors.Contains(errorVal, bootstrap.ErrUnauthenticated):
+			w.WriteHeader(http.StatusUnauthorized)
+		case errors.Contains(err, bootstrap.ErrUnauthorized):
 			w.WriteHeader(http.StatusForbidden)
 		case errors.Contains(errorVal, bootstrap.ErrConflict):
 			w.WriteHeader(http.StatusConflict)

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -72,7 +72,7 @@ func (crm *configRepositoryMock) RetrieveByID(token, id string) (bootstrap.Confi
 		return bootstrap.Config{}, bootstrap.ErrNotFound
 	}
 	if c.Owner != token {
-		return bootstrap.Config{}, bootstrap.ErrUnauthorizedAccess
+		return bootstrap.Config{}, bootstrap.ErrUnauthenticated
 	}
 
 	return c, nil
@@ -226,7 +226,7 @@ func (crm *configRepositoryMock) ChangeState(token, id string, state bootstrap.S
 		return bootstrap.ErrNotFound
 	}
 	if config.Owner != token {
-		return bootstrap.ErrUnauthorizedAccess
+		return bootstrap.ErrUnauthenticated
 	}
 
 	config.State = state

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -40,7 +40,7 @@ func (svc *mainfluxThings) CreateThings(_ context.Context, owner string, ths ...
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil {
-		return []things.Thing{}, things.ErrUnauthorizedAccess
+		return []things.Thing{}, things.ErrUnauthenticated
 	}
 	for i := range ths {
 		svc.counter++
@@ -59,7 +59,7 @@ func (svc *mainfluxThings) ViewThing(_ context.Context, owner, id string) (thing
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil {
-		return things.Thing{}, things.ErrUnauthorizedAccess
+		return things.Thing{}, things.ErrUnauthenticated
 	}
 
 	if t, ok := svc.things[id]; ok && t.Owner == userID.Value {
@@ -76,11 +76,11 @@ func (svc *mainfluxThings) Connect(_ context.Context, owner string, chIDs, thIDs
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 	for _, chID := range chIDs {
 		if svc.channels[chID].Owner != userID.Value {
-			return things.ErrUnauthorizedAccess
+			return things.ErrUnauthenticated
 		}
 		for _, thID := range thIDs {
 			svc.connections[chID] = append(svc.connections[chID], thID)
@@ -96,7 +96,7 @@ func (svc *mainfluxThings) Disconnect(_ context.Context, owner, chanID, thingID 
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil || svc.channels[chanID].Owner != userID.Value {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	ids := svc.connections[chanID]
@@ -128,7 +128,7 @@ func (svc *mainfluxThings) RemoveThing(_ context.Context, owner, id string) erro
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if t, ok := svc.things[id]; !ok || t.Owner != userID.Value {
@@ -185,7 +185,7 @@ func (svc *mainfluxThings) CreateChannels(_ context.Context, owner string, chs .
 
 	userID, err := svc.auth.Identify(context.Background(), &mainflux.Token{Value: owner})
 	if err != nil {
-		return []things.Channel{}, things.ErrUnauthorizedAccess
+		return []things.Channel{}, things.ErrUnauthenticated
 	}
 	for i := range chs {
 		svc.counter++

--- a/bootstrap/mocks/users.go
+++ b/bootstrap/mocks/users.go
@@ -26,7 +26,7 @@ func (svc serviceMock) Identify(ctx context.Context, in *mainflux.Token, opts ..
 	if id, ok := svc.users[in.Value]; ok {
 		return &mainflux.UserID{Value: id}, nil
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }
 
 func (svc serviceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opts ...grpc.CallOption) (*mainflux.Token, error) {
@@ -36,5 +36,5 @@ func (svc serviceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opts ..
 			return &mainflux.Token{Value: id}, nil
 		}
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }

--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -370,7 +370,7 @@ func TestRemove(t *testing.T) {
 			desc:  "remove config with invalid credentials",
 			id:    saved.MFThing,
 			token: "",
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 			event: nil,
 		},
 	}
@@ -506,7 +506,7 @@ func TestChangeState(t *testing.T) {
 			id:    saved.MFThing,
 			token: "",
 			state: bootstrap.Inactive,
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 			event: nil,
 		},
 	}

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -22,9 +22,13 @@ var (
 	// ErrMalformedEntity indicates malformed entity specification.
 	ErrMalformedEntity = errors.New("malformed entity specification")
 
-	// ErrUnauthorizedAccess indicates missing or invalid credentials provided
+	// ErrUnauthenticated indicates missing or invalid credentials provided
 	// when accessing a protected resource.
-	ErrUnauthorizedAccess = errors.New("missing or invalid credentials provided")
+	ErrUnauthenticated = errors.New("missing or invalid credentials provided")
+
+	// ErrUnauthorized indicates unauthorized access
+	// when accessing a protected resource.
+	ErrUnauthorized = errors.New("unauthorized access")
 
 	// ErrConflict indicates that entity with the same ID or external ID already exists.
 	ErrConflict = errors.New("entity already exists")
@@ -385,7 +389,7 @@ func (bs bootstrapService) identify(token string) (string, error) {
 
 	res, err := bs.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return "", ErrUnauthorizedAccess
+		return "", ErrUnauthenticated
 	}
 
 	return res.GetValue(), nil

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -133,7 +133,7 @@ func TestAdd(t *testing.T) {
 			desc:   "add a config with wrong credentials",
 			config: config,
 			token:  invalidToken,
-			err:    bootstrap.ErrUnauthorizedAccess,
+			err:    bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:   "add a config with invalid list of channels",
@@ -180,7 +180,7 @@ func TestView(t *testing.T) {
 			desc:  "view a config with wrong credentials",
 			id:    config.MFThing,
 			token: invalidToken,
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 		},
 	}
 
@@ -232,7 +232,7 @@ func TestUpdate(t *testing.T) {
 			desc:   "update a config with wrong credentials",
 			config: saved,
 			token:  invalidToken,
-			err:    bootstrap.ErrUnauthorizedAccess,
+			err:    bootstrap.ErrUnauthenticated,
 		},
 	}
 
@@ -290,7 +290,7 @@ func TestUpdateCert(t *testing.T) {
 			clientKey:  "newKey",
 			caCert:     "newCert",
 			token:      invalidToken,
-			err:        bootstrap.ErrUnauthorizedAccess,
+			err:        bootstrap.ErrUnauthenticated,
 		},
 	}
 
@@ -364,7 +364,7 @@ func TestUpdateConnections(t *testing.T) {
 			token:       invalidToken,
 			id:          created.MFKey,
 			connections: []string{"2", "3"},
-			err:         bootstrap.ErrUnauthorizedAccess,
+			err:         bootstrap.ErrUnauthenticated,
 		},
 	}
 
@@ -442,7 +442,7 @@ func TestList(t *testing.T) {
 			token:  invalidToken,
 			offset: 0,
 			limit:  10,
-			err:    bootstrap.ErrUnauthorizedAccess,
+			err:    bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc: "list last page",
@@ -501,7 +501,7 @@ func TestRemove(t *testing.T) {
 			desc:  "view a config with wrong credentials",
 			id:    saved.MFThing,
 			token: invalidToken,
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:  "remove an existing config",
@@ -611,7 +611,7 @@ func TestChangeState(t *testing.T) {
 			state: bootstrap.Active,
 			id:    saved.MFThing,
 			token: invalidToken,
-			err:   bootstrap.ErrUnauthorizedAccess,
+			err:   bootstrap.ErrUnauthenticated,
 		},
 		{
 			desc:  "change state of non-existing config",

--- a/bootstrap/swagger.yml
+++ b/bootstrap/swagger.yml
@@ -33,7 +33,7 @@ paths:
               description: Created configuration's relative URL (i.e. /things/configs/{configId}).
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
         415:
           description: Missing or invalid content type.
@@ -62,8 +62,10 @@ paths:
             $ref: "#/definitions/ConfigList"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/bootstrap/{externalId}:
@@ -105,7 +107,7 @@ paths:
             $ref: "#/definitions/BootstrapRes"
         404:
           description: |
-            Failed to retrieve corresponding config. 
+            Failed to retrieve corresponding config.
         500:
           $ref: "#/responses/ServiceError"
   /things/configs/{configId}:
@@ -121,8 +123,10 @@ paths:
           description: Data retrieved.
           schema:
             $ref: "#/definitions/ConfigRes"
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Config does not exist.
         500:
@@ -149,8 +153,10 @@ paths:
           description: Config updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Config does not exist.
         415:
@@ -172,8 +178,10 @@ paths:
           description: Config removed.
         400:
           description: Failed due to malformed config ID.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/configs/certs/{configId}:
@@ -198,8 +206,10 @@ paths:
           description: Config updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Config does not exist.
         415:
@@ -228,8 +238,10 @@ paths:
           description: Config updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Config does not exist.
         415:
@@ -263,8 +275,10 @@ paths:
           description: Config removed.
         400:
           description: Failed due to malformed config's ID.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
 

--- a/http/api/endpoint_test.go
+++ b/http/api/endpoint_test.go
@@ -57,7 +57,7 @@ func TestPublish(t *testing.T) {
 	chanID := "1"
 	contentType := "application/senml+json"
 	token := "auth_token"
-	invalidToken := "invalid_token"
+	unauthorizedToken := "invalid_token"
 	msg := `[{"n":"current","t":-1,"v":1.6}]`
 	thingsClient := mocks.NewThingsClient(map[string]string{token: chanID})
 	svc := newService(thingsClient)
@@ -83,13 +83,13 @@ func TestPublish(t *testing.T) {
 			msg:         msg,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
-		"publish message with invalid authorization token": {
+		"publish message with unauthorized token": {
 			chanID:      chanID,
 			msg:         msg,
 			contentType: contentType,
-			auth:        invalidToken,
+			auth:        unauthorizedToken,
 			status:      http.StatusForbidden,
 		},
 		"publish message without content type": {

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -144,8 +144,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch err {
 	case errMalformedData, errMalformedSubtopic:
 		w.WriteHeader(http.StatusBadRequest)
-	case things.ErrUnauthorizedAccess:
-		w.WriteHeader(http.StatusForbidden)
+	case things.ErrUnauthenticated:
+		w.WriteHeader(http.StatusUnauthorized)
 	default:
 		if e, ok := status.FromError(err); ok {
 			switch e.Code() {

--- a/http/mocks/things.go
+++ b/http/mocks/things.go
@@ -39,12 +39,12 @@ func (tc thingsClient) CanAccessByKey(ctx context.Context, req *mainflux.AccessB
 	}
 
 	if key == "" {
-		return nil, things.ErrUnauthorizedAccess
+		return nil, things.ErrUnauthenticated
 	}
 
 	id, ok := tc.things[key]
 	if !ok {
-		return nil, status.Error(codes.PermissionDenied, "invalid credentials provided")
+		return nil, status.Error(codes.PermissionDenied, "unauthorized access")
 	}
 
 	return &mainflux.ThingID{Value: id}, nil

--- a/http/swagger.yaml
+++ b/http/swagger.yaml
@@ -43,8 +43,10 @@ paths:
           description: Message is accepted for processing.
         400:
           description: Message discarded due to its malformed content.
-        403:
+        401:
           description: Message discarded due to missing or invalid credentials.
+        403:
+          description: Message discarded due to unauthorized access.
         404:
           description: Message discarded due to invalid channel id.
         415:

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -22,15 +22,15 @@ var _ session.Handler = (*handler)(nil)
 const protocol = "mqtt"
 
 var (
-	channelRegExp         = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
-	errMalformedTopic     = errors.New("malformed topic")
-	errMalformedData      = errors.New("malformed request data")
-	errMalformedSubtopic  = errors.New("malformed subtopic")
-	errUnauthorizedAccess = errors.New("missing or invalid credentials provided")
-	errNilClient          = errors.New("using nil client")
-	errInvalidConnect     = errors.New("CONNECT request with invalid username or client ID")
-	errNilTopicPub        = errors.New("PUBLISH to nil topic")
-	errNilTopicSub        = errors.New("SUB to nil topic")
+	channelRegExp        = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
+	errMalformedTopic    = errors.New("malformed topic")
+	errMalformedData     = errors.New("malformed request data")
+	errMalformedSubtopic = errors.New("malformed subtopic")
+	errUnauthenticated   = errors.New("missing or invalid credentials provided")
+	errNilClient         = errors.New("using nil client")
+	errInvalidConnect    = errors.New("CONNECT request with invalid username or client ID")
+	errNilTopicPub       = errors.New("PUBLISH to nil topic")
+	errNilTopicSub       = errors.New("SUB to nil topic")
 )
 
 // Event implements events.Event interface
@@ -65,7 +65,7 @@ func (h *handler) AuthConnect(c *session.Client) error {
 	}
 
 	if thid != c.Username {
-		return errUnauthorizedAccess
+		return errUnauthenticated
 	}
 
 	if err := h.es.Connect(c.Username); err != nil {

--- a/pkg/sdk/go/certs.go
+++ b/pkg/sdk/go/certs.go
@@ -61,7 +61,7 @@ func (sdk mfSDK) RemoveCert(id, token string) error {
 	case http.StatusNoContent:
 		return nil
 	case http.StatusForbidden:
-		return ErrUnauthorized
+		return ErrUnauthenticated
 	default:
 		return ErrCertsRemove
 	}

--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -54,14 +54,14 @@ func TestCreateChannel(t *testing.T) {
 			desc:    "create new channel with empty token",
 			channel: channel,
 			token:   "",
-			err:     createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			empty:   true,
 		},
 		{
 			desc:    "create new channel with invalid token",
 			channel: channel,
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			empty:   true,
 		},
 		{
@@ -126,14 +126,14 @@ func TestCreateChannels(t *testing.T) {
 			desc:     "create new channels with empty token",
 			channels: channels,
 			token:    "",
-			err:      createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			res:      []sdk.Channel{},
 		},
 		{
 			desc:     "create new channels with invalid token",
 			channels: channels,
 			token:    wrongValue,
-			err:      createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			res:      []sdk.Channel{},
 		},
 	}
@@ -189,7 +189,7 @@ func TestChannel(t *testing.T) {
 			desc:     "get channel with invalid token",
 			chanID:   id,
 			token:    "",
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: sdk.Channel{},
 		},
 	}
@@ -244,7 +244,7 @@ func TestChannels(t *testing.T) {
 			token:    wrongValue,
 			offset:   0,
 			limit:    5,
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -252,7 +252,7 @@ func TestChannels(t *testing.T) {
 			token:    "",
 			offset:   0,
 			limit:    5,
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -366,7 +366,7 @@ func TestChannelsByThing(t *testing.T) {
 			offset:    0,
 			limit:     5,
 			connected: true,
-			err:       createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:       createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response:  nil,
 		},
 		{
@@ -376,7 +376,7 @@ func TestChannelsByThing(t *testing.T) {
 			offset:    0,
 			limit:     5,
 			connected: true,
-			err:       createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:       createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response:  nil,
 		},
 		{
@@ -483,13 +483,13 @@ func TestUpdateChannel(t *testing.T) {
 			desc:    "update channel with invalid token",
 			channel: sdk.Channel{ID: id, Name: "test2"},
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedUpdate, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedUpdate, http.StatusUnauthorized),
 		},
 		{
 			desc:    "update channel with empty token",
 			channel: sdk.Channel{ID: id, Name: "test2"},
 			token:   "",
-			err:     createError(sdk.ErrFailedUpdate, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedUpdate, http.StatusUnauthorized),
 		},
 	}
 
@@ -526,7 +526,7 @@ func TestDeleteChannel(t *testing.T) {
 			desc:   "delete channel with invalid token",
 			chanID: id,
 			token:  wrongValue,
-			err:    createError(sdk.ErrFailedRemoval, http.StatusForbidden),
+			err:    createError(sdk.ErrFailedRemoval, http.StatusUnauthorized),
 		},
 		{
 			desc:   "delete non-existing channel",
@@ -544,7 +544,7 @@ func TestDeleteChannel(t *testing.T) {
 			desc:   "delete channel with empty token",
 			chanID: id,
 			token:  "",
-			err:    createError(sdk.ErrFailedRemoval, http.StatusForbidden),
+			err:    createError(sdk.ErrFailedRemoval, http.StatusUnauthorized),
 		},
 		{
 			desc:   "delete existing channel",

--- a/pkg/sdk/go/message_test.go
+++ b/pkg/sdk/go/message_test.go
@@ -31,7 +31,7 @@ func newMessageServer(svc adapter.Service) *httptest.Server {
 func TestSendMessage(t *testing.T) {
 	chanID := "1"
 	atoken := "auth_token"
-	invalidToken := "invalid_token"
+	unauthorizedToken := "invalid_token"
 	msg := `[{"n":"current","t":-1,"v":1.6}]`
 	thingsClient := mocks.NewThingsClient(map[string]string{atoken: chanID})
 	pub := newMessageService(thingsClient)
@@ -64,12 +64,12 @@ func TestSendMessage(t *testing.T) {
 			chanID: chanID,
 			msg:    msg,
 			auth:   "",
-			err:    createError(sdk.ErrFailedPublish, http.StatusForbidden),
+			err:    createError(sdk.ErrFailedPublish, http.StatusUnauthorized),
 		},
-		"publish message with invalid authorization token": {
+		"publish message with unauthorized token": {
 			chanID: chanID,
 			msg:    msg,
-			auth:   invalidToken,
+			auth:   unauthorizedToken,
 			err:    createError(sdk.ErrFailedPublish, http.StatusForbidden),
 		},
 		"publish message with wrong content type": {

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -24,8 +24,8 @@ const (
 const minPassLen = 8
 
 var (
-	// ErrUnauthorized indicates that entity creation failed.
-	ErrUnauthorized = errors.New("unauthorized, missing credentials")
+	// ErrUnauthenticated indicates that entity creation failed.
+	ErrUnauthenticated = errors.New("unauthenticated, missing credentials")
 
 	// ErrFailedCreation indicates that entity creation failed.
 	ErrFailedCreation = errors.New("failed to create entity")

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -98,14 +98,14 @@ func TestCreateThing(t *testing.T) {
 			desc:     "create new thing with empty token",
 			thing:    thing,
 			token:    "",
-			err:      createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			location: "",
 		},
 		{
 			desc:     "create new thing with invalid token",
 			thing:    thing,
 			token:    wrongValue,
-			err:      createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			location: "",
 		},
 	}
@@ -163,14 +163,14 @@ func TestCreateThings(t *testing.T) {
 			desc:   "create new thing with empty token",
 			things: things,
 			token:  "",
-			err:    createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:    createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			res:    []sdk.Thing{},
 		},
 		{
 			desc:   "create new thing with invalid token",
 			things: things,
 			token:  wrongValue,
-			err:    createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:    createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 			res:    []sdk.Thing{},
 		},
 	}
@@ -228,7 +228,7 @@ func TestThing(t *testing.T) {
 			desc:     "get thing with invalid token",
 			thID:     id,
 			token:    wrongValue,
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: sdk.Thing{},
 		},
 	}
@@ -286,7 +286,7 @@ func TestThings(t *testing.T) {
 			token:    wrongValue,
 			offset:   0,
 			limit:    5,
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -294,7 +294,7 @@ func TestThings(t *testing.T) {
 			token:    "",
 			offset:   0,
 			limit:    5,
-			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:      createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -412,7 +412,7 @@ func TestThingsByChannel(t *testing.T) {
 			offset:    0,
 			limit:     5,
 			connected: true,
-			err:       createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:       createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response:  nil,
 		},
 		{
@@ -422,7 +422,7 @@ func TestThingsByChannel(t *testing.T) {
 			offset:    0,
 			limit:     5,
 			connected: true,
-			err:       createError(sdk.ErrFailedFetch, http.StatusForbidden),
+			err:       createError(sdk.ErrFailedFetch, http.StatusUnauthorized),
 			response:  nil,
 		},
 		{
@@ -545,7 +545,7 @@ func TestUpdateThing(t *testing.T) {
 				Metadata: metadata2,
 			},
 			token: wrongValue,
-			err:   createError(sdk.ErrFailedUpdate, http.StatusForbidden),
+			err:   createError(sdk.ErrFailedUpdate, http.StatusUnauthorized),
 		},
 		{
 			desc: "update channel with empty token",
@@ -555,7 +555,7 @@ func TestUpdateThing(t *testing.T) {
 				Metadata: metadata2,
 			},
 			token: "",
-			err:   createError(sdk.ErrFailedUpdate, http.StatusForbidden),
+			err:   createError(sdk.ErrFailedUpdate, http.StatusUnauthorized),
 		},
 	}
 
@@ -592,7 +592,7 @@ func TestDeleteThing(t *testing.T) {
 			desc:    "delete thing with invalid token",
 			thingID: id,
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedRemoval, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedRemoval, http.StatusUnauthorized),
 		},
 		{
 			desc:    "delete non-existing thing",
@@ -610,7 +610,7 @@ func TestDeleteThing(t *testing.T) {
 			desc:    "delete thing with empty token",
 			thingID: id,
 			token:   "",
-			err:     createError(sdk.ErrFailedRemoval, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedRemoval, http.StatusUnauthorized),
 		},
 		{
 			desc:    "delete existing thing",
@@ -708,14 +708,14 @@ func TestConnectThing(t *testing.T) {
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedConnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedConnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "connect existing thing to existing channel with empty token",
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   "",
-			err:     createError(sdk.ErrFailedConnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedConnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "connect thing from owner to channel of other user",
@@ -812,14 +812,14 @@ func TestConnect(t *testing.T) {
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedConnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedConnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "connect existing things to existing channels with empty token",
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   emptyValue,
-			err:     createError(sdk.ErrFailedConnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedConnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "connect things from owner to channels of other user",
@@ -923,14 +923,14 @@ func TestDisconnectThing(t *testing.T) {
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   wrongValue,
-			err:     createError(sdk.ErrFailedDisconnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedDisconnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "disconnect existing thing from existing channel with empty token",
 			thingID: thingID,
 			chanID:  chanID1,
 			token:   "",
-			err:     createError(sdk.ErrFailedDisconnect, http.StatusForbidden),
+			err:     createError(sdk.ErrFailedDisconnect, http.StatusUnauthorized),
 		},
 		{
 			desc:    "disconnect owner's thing from someone elses channel",

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -139,7 +139,7 @@ func TestCreateToken(t *testing.T) {
 			desc:  "create token for non existing user",
 			user:  sdk.User{Email: "user2@example.com", Password: "password"},
 			token: "",
-			err:   createError(sdk.ErrFailedCreation, http.StatusForbidden),
+			err:   createError(sdk.ErrFailedCreation, http.StatusUnauthorized),
 		},
 		{
 			desc:  "create user with empty email",

--- a/provision/api/requests.go
+++ b/provision/api/requests.go
@@ -9,7 +9,7 @@ type addThingReq struct {
 
 func (req addThingReq) validate() error {
 	if req.ExternalID == "" || req.ExternalKey == "" {
-		return errUnauthorized
+		return errUnauthenticated
 	}
 	return nil
 }

--- a/provision/api/requests_test.go
+++ b/provision/api/requests_test.go
@@ -21,7 +21,7 @@ func TestValidate(t *testing.T) {
 			err:         nil,
 		},
 		"external id for device empty": {
-			err: errUnauthorized,
+			err: errUnauthenticated,
 		},
 	}
 

--- a/provision/api/transport.go
+++ b/provision/api/transport.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	errUnsupportedContentType = errors.New("unsupported content type")
-	errUnauthorized           = errors.New("missing or invalid credentials provided")
+	errUnauthenticated        = errors.New("missing or invalid credentials provided")
 	errMalformedEntity        = errors.New("malformed entity")
 	errConflict               = errors.New("entity already exists")
 )

--- a/provision/service.go
+++ b/provision/service.go
@@ -226,7 +226,7 @@ func (ps *provisionService) Cert(token, thingID, daysValid string, keyBits int) 
 
 	th, err := ps.sdk.Thing(thingID, token)
 	if err != nil {
-		return "", "", errors.Wrap(SDK.ErrUnauthorized, err)
+		return "", "", errors.Wrap(SDK.ErrUnauthenticated, err)
 	}
 	cert, err := ps.sdk.IssueCert(th.ID, ps.conf.Certs.KeyBits, ps.conf.Certs.KeyType, ps.conf.Certs.HoursValid, token)
 	return cert.ClientCert, cert.ClientKey, err

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -154,7 +154,7 @@ func TestReadAll(t *testing.T) {
 		"read page with empty token": {
 			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
 			token:  "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		"read page with default offset": {
 			url:    fmt.Sprintf("%s/channels/%s/messages?limit=10", ts.URL, chanID),

--- a/readers/mocks/things.go
+++ b/readers/mocks/things.go
@@ -14,7 +14,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var errUnauthorized = status.Error(codes.PermissionDenied, "missing or invalid credentials provided")
+var (
+	errUnauthenticated = status.Error(codes.Unauthenticated, "missing credentials provided")
+	errUnauthorized    = status.Error(codes.PermissionDenied, "unauthorized access")
+)
 
 var _ mainflux.ThingsServiceClient = (*thingsServiceMock)(nil)
 
@@ -32,7 +35,7 @@ func (svc thingsServiceMock) CanAccessByKey(ctx context.Context, in *mainflux.Ac
 	}
 
 	if token == "" {
-		return nil, errUnauthorized
+		return nil, errUnauthenticated
 	}
 
 	return &mainflux.ThingID{Value: token}, nil

--- a/readers/swagger.yml
+++ b/readers/swagger.yml
@@ -30,8 +30,10 @@ paths:
             $ref: "#/definitions/MessagesPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
 

--- a/things/api/auth/grpc/endpoint_test.go
+++ b/things/api/auth/grpc/endpoint_test.go
@@ -161,7 +161,7 @@ func TestIdentify(t *testing.T) {
 		"identify non-existent thing": {
 			key:  wrong,
 			id:   wrongID,
-			code: codes.PermissionDenied,
+			code: codes.Unauthenticated,
 		},
 	}
 

--- a/things/api/auth/grpc/server.go
+++ b/things/api/auth/grpc/server.go
@@ -103,8 +103,10 @@ func encodeError(err error) error {
 		return nil
 	case things.ErrMalformedEntity:
 		return status.Error(codes.InvalidArgument, "received invalid can access request")
-	case things.ErrUnauthorizedAccess:
-		return status.Error(codes.PermissionDenied, "missing or invalid credentials provided")
+	case things.ErrUnauthenticated:
+		return status.Error(codes.Unauthenticated, "missing or invalid credentials provided")
+	case things.ErrUnauthorized:
+		return status.Error(codes.PermissionDenied, "unauthorized access")
 	default:
 		return status.Error(codes.Internal, "internal server error")
 	}

--- a/things/api/auth/http/endpoint_test.go
+++ b/things/api/auth/http/endpoint_test.go
@@ -110,7 +110,7 @@ func TestIdentify(t *testing.T) {
 		"identify non-existent thing": {
 			contentType: contentType,
 			req:         nonexistentData,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		"identify with missing content type": {
 			contentType: wrong,
@@ -120,7 +120,7 @@ func TestIdentify(t *testing.T) {
 		"identify with empty JSON request": {
 			contentType: contentType,
 			req:         "{}",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		"identify with invalid JSON request": {
 			contentType: contentType,
@@ -192,7 +192,7 @@ func TestCanAccessByKey(t *testing.T) {
 			contentType: contentType,
 			chanID:      sch.ID,
 			req:         "{}",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		"check access with invalid JSON request": {
 			contentType: contentType,
@@ -271,7 +271,7 @@ func TestCanAccessByID(t *testing.T) {
 			contentType: contentType,
 			chanID:      sch.ID,
 			req:         "{}",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		"check access with invalid JSON request": {
 			contentType: contentType,

--- a/things/api/auth/http/requests.go
+++ b/things/api/auth/http/requests.go
@@ -17,7 +17,7 @@ type identifyReq struct {
 
 func (req identifyReq) validate() error {
 	if req.Token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	return nil
@@ -29,8 +29,12 @@ type canAccessByKeyReq struct {
 }
 
 func (req canAccessByKeyReq) validate() error {
-	if req.Token == "" || req.chanID == "" {
-		return things.ErrUnauthorizedAccess
+	if req.Token == "" {
+		return things.ErrUnauthenticated
+	}
+
+	if req.chanID == "" {
+		return things.ErrUnauthorized
 	}
 
 	return nil
@@ -42,8 +46,12 @@ type canAccessByIDReq struct {
 }
 
 func (req canAccessByIDReq) validate() error {
-	if req.ThingID == "" || req.chanID == "" {
-		return things.ErrUnauthorizedAccess
+	if req.ThingID == "" {
+		return things.ErrUnauthenticated
+	}
+
+	if req.chanID == "" {
+		return things.ErrUnauthorized
 	}
 
 	return nil

--- a/things/api/auth/http/transport.go
+++ b/things/api/auth/http/transport.go
@@ -119,7 +119,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", contentType)
 
 	switch err {
-	case things.ErrUnauthorizedAccess:
+	case things.ErrUnauthenticated:
+		w.WriteHeader(http.StatusUnauthorized)
+	case things.ErrUnauthorized:
 		w.WriteHeader(http.StatusForbidden)
 	case errUnsupportedContentType:
 		w.WriteHeader(http.StatusUnsupportedMediaType)

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -45,7 +45,7 @@ var (
 	}
 	invalidName = strings.Repeat("m", maxNameSize+1)
 	notFoundRes = toJSON(errorRes{things.ErrNotFound.Error()})
-	unauthRes   = toJSON(errorRes{things.ErrUnauthorizedAccess.Error()})
+	unauthRes   = toJSON(errorRes{things.ErrUnauthenticated.Error()})
 )
 
 type testRequest struct {
@@ -142,7 +142,7 @@ func TestCreateThing(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -150,7 +150,7 @@ func TestCreateThing(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -274,7 +274,7 @@ func TestCreateThings(t *testing.T) {
 			data:        data,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			response:    "",
 		},
 		{
@@ -282,7 +282,7 @@ func TestCreateThings(t *testing.T) {
 			data:        data,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			response:    "",
 		},
 		{
@@ -372,7 +372,7 @@ func TestUpdateThing(t *testing.T) {
 			id:          sth.ID,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update thing with empty user token",
@@ -380,7 +380,7 @@ func TestUpdateThing(t *testing.T) {
 			id:          sth.ID,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update thing with invalid data format",
@@ -500,7 +500,7 @@ func TestUpdateKey(t *testing.T) {
 			id:          sth.ID,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update thing with empty user token",
@@ -508,7 +508,7 @@ func TestUpdateKey(t *testing.T) {
 			id:          sth.ID,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update thing with invalid data format",
@@ -593,14 +593,14 @@ func TestViewThing(t *testing.T) {
 			desc:   "view thing by passing invalid token",
 			id:     sth.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    unauthRes,
 		},
 		{
 			desc:   "view thing by passing empty token",
 			id:     sth.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    unauthRes,
 		},
 		{
@@ -666,14 +666,14 @@ func TestListThings(t *testing.T) {
 		{
 			desc:   "get a list of things with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", thingURL, 0, 1),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of things with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", thingURL, 0, 1),
 			res:    nil,
 		},
@@ -826,14 +826,14 @@ func TestListThingsByChannel(t *testing.T) {
 		{
 			desc:   "get a list of things by channel with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s/%s/things?offset=%d&limit=%d", thingURL, sch.ID, 0, 1),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of things by channel with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s/%s/things?offset=%d&limit=%d", thingURL, sch.ID, 0, 1),
 			res:    nil,
 		},
@@ -962,13 +962,13 @@ func TestRemoveThing(t *testing.T) {
 			desc:   "delete thing with invalid token",
 			id:     sth.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "delete thing with empty token",
 			id:     sth.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 	}
 
@@ -1017,7 +1017,7 @@ func TestCreateChannel(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -1025,7 +1025,7 @@ func TestCreateChannel(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -1133,7 +1133,7 @@ func TestCreateChannels(t *testing.T) {
 			data:        data,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			response:    "",
 		},
 		{
@@ -1141,7 +1141,7 @@ func TestCreateChannels(t *testing.T) {
 			data:        data,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			response:    "",
 		},
 		{
@@ -1240,7 +1240,7 @@ func TestUpdateChannel(t *testing.T) {
 			id:          sch.ID,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update channel with empty token",
@@ -1248,7 +1248,7 @@ func TestUpdateChannel(t *testing.T) {
 			id:          sch.ID,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update channel with invalid data format",
@@ -1350,14 +1350,14 @@ func TestViewChannel(t *testing.T) {
 			desc:   "view channel with invalid token",
 			id:     sch.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    unauthRes,
 		},
 		{
 			desc:   "view channel with empty token",
 			id:     sch.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    unauthRes,
 		},
 		{
@@ -1427,14 +1427,14 @@ func TestListChannels(t *testing.T) {
 		{
 			desc:   "get a list of channels with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", channelURL, 0, 1),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of channels with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s?offset=%d&limit=%d", channelURL, 0, 1),
 			res:    nil,
 		},
@@ -1583,14 +1583,14 @@ func TestListChannelsByThing(t *testing.T) {
 		{
 			desc:   "get a list of channels by thing with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s/%s/channels?offset=%d&limit=%d", channelURL, sth.ID, 0, 1),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of channels by thing with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf("%s/%s/channels?offset=%d&limit=%d", channelURL, sth.ID, 0, 1),
 			res:    nil,
 		},
@@ -1707,7 +1707,7 @@ func TestRemoveChannel(t *testing.T) {
 			desc:   "remove channel with invalid token",
 			id:     sch.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "remove existing channel",
@@ -1725,13 +1725,13 @@ func TestRemoveChannel(t *testing.T) {
 			desc:   "remove channel with invalid token",
 			id:     sch.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "remove channel with empty token",
 			id:     sch.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 	}
 
@@ -1812,14 +1812,14 @@ func TestConnect(t *testing.T) {
 			chanID:  ach.ID,
 			thingID: ath.ID,
 			auth:    wrongValue,
-			status:  http.StatusForbidden,
+			status:  http.StatusUnauthorized,
 		},
 		{
 			desc:    "connect existing thing to existing channel with empty token",
 			chanID:  ach.ID,
 			thingID: ath.ID,
 			auth:    "",
-			status:  http.StatusForbidden,
+			status:  http.StatusUnauthorized,
 		},
 		{
 			desc:    "connect thing from owner to channel of other user",
@@ -1941,7 +1941,7 @@ func TestCreateConnections(t *testing.T) {
 			thingIDs:    ths,
 			auth:        wrongValue,
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "connect existing things to existing channels with empty token",
@@ -1949,7 +1949,7 @@ func TestCreateConnections(t *testing.T) {
 			thingIDs:    ths,
 			auth:        "",
 			contentType: contentType,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "connect things from owner to channels of other user",
@@ -2087,14 +2087,14 @@ func TestDisconnnect(t *testing.T) {
 			chanID:  ach.ID,
 			thingID: ath.ID,
 			auth:    wrongValue,
-			status:  http.StatusForbidden,
+			status:  http.StatusUnauthorized,
 		},
 		{
 			desc:    "disconnect thing from channel with empty token",
 			chanID:  ach.ID,
 			thingID: ath.ID,
 			auth:    "",
-			status:  http.StatusForbidden,
+			status:  http.StatusUnauthorized,
 		},
 		{
 			desc:    "disconnect owner's thing from someone elses channel",

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -23,7 +23,7 @@ type createThingReq struct {
 
 func (req createThingReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if len(req.Name) > maxNameSize {
@@ -40,7 +40,7 @@ type createThingsReq struct {
 
 func (req createThingsReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if len(req.Things) <= 0 {
@@ -65,7 +65,7 @@ type updateThingReq struct {
 
 func (req updateThingReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -87,7 +87,7 @@ type updateKeyReq struct {
 
 func (req updateKeyReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.id == "" || req.Key == "" {
@@ -105,7 +105,7 @@ type createChannelReq struct {
 
 func (req createChannelReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if len(req.Name) > maxNameSize {
@@ -122,7 +122,7 @@ type createChannelsReq struct {
 
 func (req createChannelsReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if len(req.Channels) <= 0 {
@@ -147,7 +147,7 @@ type updateChannelReq struct {
 
 func (req updateChannelReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -168,7 +168,7 @@ type viewResourceReq struct {
 
 func (req viewResourceReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -188,7 +188,7 @@ type listResourcesReq struct {
 
 func (req *listResourcesReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.limit == 0 || req.limit > maxLimitSize {
@@ -212,7 +212,7 @@ type listByConnectionReq struct {
 
 func (req listByConnectionReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -234,7 +234,7 @@ type connectionReq struct {
 
 func (req connectionReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if req.chanID == "" || req.thingID == "" {
@@ -252,7 +252,7 @@ type createConnectionsReq struct {
 
 func (req createConnectionsReq) validate() error {
 	if req.token == "" {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthenticated
 	}
 
 	if len(req.ChannelIDs) == 0 || len(req.ThingIDs) == 0 {

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -395,7 +395,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		switch {
 		case errors.Contains(errorVal, things.ErrMalformedEntity):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, things.ErrUnauthorizedAccess):
+		case errors.Contains(errorVal, things.ErrUnauthenticated):
+			w.WriteHeader(http.StatusUnauthorized)
+		case errors.Contains(errorVal, things.ErrUnauthorized):
 			w.WriteHeader(http.StatusForbidden)
 		case errors.Contains(errorVal, things.ErrNotFound):
 			w.WriteHeader(http.StatusNotFound)

--- a/things/mocks/auth.go
+++ b/things/mocks/auth.go
@@ -26,7 +26,7 @@ func (svc authServiceMock) Identify(ctx context.Context, in *mainflux.Token, opt
 	if id, ok := svc.users[in.Value]; ok {
 		return &mainflux.UserID{Value: id}, nil
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }
 
 func (svc authServiceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opts ...grpc.CallOption) (*mainflux.Token, error) {
@@ -36,5 +36,5 @@ func (svc authServiceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opt
 			return &mainflux.Token{Value: id}, nil
 		}
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -382,7 +382,7 @@ func (cr channelRepository) hasThing(ctx context.Context, chanID, thingID string
 	}
 
 	if !exists {
-		return things.ErrUnauthorizedAccess
+		return things.ErrUnauthorized
 	}
 
 	return nil

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -83,7 +83,7 @@ func TestCreateThings(t *testing.T) {
 			desc:  "create things with invalid credentials",
 			ths:   []things.Thing{{Name: "a", Metadata: map[string]interface{}{"test": "test"}}},
 			key:   "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 			event: nil,
 		},
 	}
@@ -253,7 +253,7 @@ func TestRemoveThing(t *testing.T) {
 			desc:  "delete thing with invalid credentials",
 			id:    strconv.FormatUint(math.MaxUint64, 10),
 			key:   "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 			event: nil,
 		},
 	}
@@ -310,7 +310,7 @@ func TestCreateChannels(t *testing.T) {
 			desc:  "create channels with invalid credentials",
 			chs:   []things.Channel{{Name: "a", Metadata: map[string]interface{}{"test": "test"}}},
 			key:   "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 			event: nil,
 		},
 	}
@@ -489,7 +489,7 @@ func TestRemoveChannel(t *testing.T) {
 			desc:  "create non-existent channel",
 			id:    strconv.FormatUint(math.MaxUint64, 10),
 			key:   "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 			event: nil,
 		},
 	}

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -67,7 +67,7 @@ func TestCreateThings(t *testing.T) {
 				things.Thing{Name: "e"},
 			},
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 	}
 
@@ -99,7 +99,7 @@ func TestUpdateThing(t *testing.T) {
 			desc:  "update thing with wrong credentials",
 			thing: sth,
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		{
 			desc:  "update non-existing thing",
@@ -141,7 +141,7 @@ func TestUpdateKey(t *testing.T) {
 			token: wrongValue,
 			id:    sth.ID,
 			key:   key,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		{
 			desc:  "update key of non-existing thing",
@@ -176,7 +176,7 @@ func TestViewThing(t *testing.T) {
 		"view thing with wrong credentials": {
 			id:    sth.ID,
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		"view non-existing thing": {
 			id:    wrongID,
@@ -252,7 +252,7 @@ func TestListThings(t *testing.T) {
 			offset: 0,
 			limit:  0,
 			size:   0,
-			err:    things.ErrUnauthorizedAccess,
+			err:    things.ErrUnauthenticated,
 		},
 		"list with metadata": {
 			token:    token,
@@ -359,7 +359,7 @@ func TestListThingsByChannel(t *testing.T) {
 			limit:     0,
 			connected: true,
 			size:      0,
-			err:       things.ErrUnauthorizedAccess,
+			err:       things.ErrUnauthenticated,
 		},
 		"list things by non-existent channel with wrong credentials": {
 			token:     token,
@@ -404,7 +404,7 @@ func TestRemoveThing(t *testing.T) {
 			desc:  "remove thing with wrong credentials",
 			id:    sth.ID,
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		{
 			desc:  "remove existing thing",
@@ -458,7 +458,7 @@ func TestCreateChannels(t *testing.T) {
 				things.Channel{Name: "e"},
 			},
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 	}
 
@@ -490,7 +490,7 @@ func TestUpdateChannel(t *testing.T) {
 			desc:    "update channel with wrong credentials",
 			channel: sch,
 			token:   wrongValue,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthenticated,
 		},
 		{
 			desc:    "update non-existing channel",
@@ -525,7 +525,7 @@ func TestViewChannel(t *testing.T) {
 		"view channel with wrong credentials": {
 			id:    sch.ID,
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		"view non-existing channel": {
 			id:    wrongID,
@@ -603,7 +603,7 @@ func TestListChannels(t *testing.T) {
 			offset: 0,
 			limit:  0,
 			size:   0,
-			err:    things.ErrUnauthorizedAccess,
+			err:    things.ErrUnauthenticated,
 		},
 		"list with existing name": {
 			token:  token,
@@ -726,7 +726,7 @@ func TestListChannelsByThing(t *testing.T) {
 			limit:     0,
 			connected: true,
 			size:      0,
-			err:       things.ErrUnauthorizedAccess,
+			err:       things.ErrUnauthenticated,
 		},
 		"list channels by non-existent thing": {
 			token:     token,
@@ -771,7 +771,7 @@ func TestRemoveChannel(t *testing.T) {
 			desc:  "remove channel with wrong credentials",
 			id:    sch.ID,
 			token: wrongValue,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 		{
 			desc:  "remove existing channel",
@@ -826,7 +826,7 @@ func TestConnect(t *testing.T) {
 			token:   wrongValue,
 			chanID:  sch.ID,
 			thingID: sth.ID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthenticated,
 		},
 		{
 			desc:    "connect thing to non-existing channel",
@@ -885,7 +885,7 @@ func TestDisconnect(t *testing.T) {
 			token:   wrongValue,
 			chanID:  sch.ID,
 			thingID: sth.ID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthenticated,
 		},
 		{
 			desc:    "disconnect from non-existing channel",
@@ -932,12 +932,12 @@ func TestCanAccessByKey(t *testing.T) {
 		"not-connected cannot access": {
 			token:   wrongValue,
 			channel: sch.ID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthorized,
 		},
 		"access to non-existing channel": {
 			token:   sth.Key,
 			channel: wrongID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthorized,
 		},
 	}
 
@@ -969,12 +969,12 @@ func TestCanAccessByID(t *testing.T) {
 		"not-connected cannot access": {
 			thingID: wrongValue,
 			channel: sch.ID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthorized,
 		},
 		"access to non-existing channel": {
 			thingID: sth.ID,
 			channel: wrongID,
-			err:     things.ErrUnauthorizedAccess,
+			err:     things.ErrUnauthorized,
 		},
 	}
 
@@ -1003,7 +1003,7 @@ func TestIdentify(t *testing.T) {
 		"identify non-existing thing": {
 			token: wrongValue,
 			id:    wrongID,
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthenticated,
 		},
 	}
 

--- a/things/swagger.yaml
+++ b/things/swagger.yaml
@@ -33,8 +33,10 @@ paths:
               description: Created thing's relative URL (i.e. /things/{thingId}).
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:
@@ -61,8 +63,10 @@ paths:
             $ref: "#/definitions/ThingsPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/bulk:
@@ -86,8 +90,10 @@ paths:
           description: Things registered.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:
@@ -112,8 +118,10 @@ paths:
             $ref: "#/definitions/ThingsPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/{thingId}:
@@ -129,8 +137,10 @@ paths:
           description: Data retrieved.
           schema:
             $ref: "#/definitions/ThingRes"
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Thing does not exist.
         500:
@@ -157,8 +167,10 @@ paths:
           description: Thing updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Thing does not exist.
         415:
@@ -180,8 +192,10 @@ paths:
           description: Thing removed.
         400:
           description: Failed due to malformed thing's ID.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/{thingId}/key:
@@ -205,8 +219,10 @@ paths:
           description: Thing key updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Thing does not exist.
         409:
@@ -240,8 +256,10 @@ paths:
               description: Created channel's relative URL (i.e. /channels/{chanId}).
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:
@@ -267,8 +285,10 @@ paths:
             $ref: "#/definitions/ChannelsPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /channels/bulk:
@@ -292,8 +312,10 @@ paths:
           description: Channels registered.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:
@@ -311,8 +333,10 @@ paths:
           description: Data retrieved.
           schema:
             $ref: "#/definitions/ChannelRes"
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Channel does not exist.
         500:
@@ -339,8 +363,10 @@ paths:
           description: Channel updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Channel does not exist.
         415:
@@ -362,8 +388,10 @@ paths:
           description: Channel removed.
         400:
           description: Failed due to malformed channel's ID.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /things/{thingId}/channels:
@@ -386,8 +414,10 @@ paths:
             $ref: "#/definitions/ChannelsPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /channels/{chanId}/things/{thingId}:
@@ -405,8 +435,10 @@ paths:
       responses:
         200:
           description: Thing connected.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Channel or thing does not exist.
         500:
@@ -425,8 +457,10 @@ paths:
       responses:
         204:
           description: Thing disconnected.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Channel or thing does not exist.
         500:
@@ -508,8 +542,10 @@ paths:
           description: Thing ID returned.
           schema:
             $ref: "#/definitions/Identity"
+        401:
+          description: Missing or invalid access token provided.
         403:
-          description: Thing with specified key doesn't exist.
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:

--- a/things/users/users.go
+++ b/things/users/users.go
@@ -35,7 +35,7 @@ func (repo singleUserRepo) Issue(ctx context.Context, req *mainflux.IssueReq, op
 	defer cancel()
 
 	if repo.token != req.GetIssuer() {
-		return nil, things.ErrUnauthorizedAccess
+		return nil, things.ErrUnauthorized
 	}
 
 	return &mainflux.Token{Value: repo.token}, nil
@@ -46,7 +46,7 @@ func (repo singleUserRepo) Identify(ctx context.Context, token *mainflux.Token, 
 	defer cancel()
 
 	if repo.token != token.GetValue() {
-		return nil, things.ErrUnauthorizedAccess
+		return nil, things.ErrUnauthorized
 	}
 
 	return &mainflux.UserID{Value: repo.email}, nil

--- a/things/users/users_test.go
+++ b/things/users/users_test.go
@@ -30,7 +30,7 @@ func TestIdentify(t *testing.T) {
 		"identify non-existing user": {
 			token: "non-existing",
 			id:    "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthorized,
 		},
 		"identify existing user": {
 			token: token,
@@ -57,7 +57,7 @@ func TestIssue(t *testing.T) {
 		"issue key unauthorized": {
 			token: "non-existing",
 			id:    "",
-			err:   things.ErrUnauthorizedAccess,
+			err:   things.ErrUnauthorized,
 		},
 		"issue key": {
 			token: token,

--- a/twins/api/http/endpoint_states_test.go
+++ b/twins/api/http/endpoint_states_test.go
@@ -93,14 +93,14 @@ func TestListStates(t *testing.T) {
 		{
 			desc:   "get a list of states with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf(queryFmt, baseURL, 0, 5),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of states with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf(queryFmt, baseURL, 0, 5),
 			res:    nil,
 		},

--- a/twins/api/http/endpoint_twins_test.go
+++ b/twins/api/http/endpoint_twins_test.go
@@ -138,7 +138,7 @@ func TestAddTwin(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -146,7 +146,7 @@ func TestAddTwin(t *testing.T) {
 			req:         data,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 			location:    "",
 		},
 		{
@@ -258,7 +258,7 @@ func TestUpdateTwin(t *testing.T) {
 			id:          stw.ID,
 			contentType: contentType,
 			auth:        wrongValue,
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update twin with empty user token",
@@ -266,7 +266,7 @@ func TestUpdateTwin(t *testing.T) {
 			id:          stw.ID,
 			contentType: contentType,
 			auth:        "",
-			status:      http.StatusForbidden,
+			status:      http.StatusUnauthorized,
 		},
 		{
 			desc:        "update twin with invalid data format",
@@ -359,7 +359,7 @@ func TestViewTwin(t *testing.T) {
 			desc:   "view twin by passing invalid token",
 			id:     stw.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    twinRes{},
 		},
 		{
@@ -373,7 +373,7 @@ func TestViewTwin(t *testing.T) {
 			desc:   "view twin by passing empty token",
 			id:     stw.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			res:    twinRes{},
 		},
 	}
@@ -438,14 +438,14 @@ func TestListTwins(t *testing.T) {
 		{
 			desc:   "get a list of twins with invalid token",
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf(queryFmt, baseURL, 0, 1),
 			res:    nil,
 		},
 		{
 			desc:   "get a list of twins with empty token",
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 			url:    fmt.Sprintf(queryFmt, baseURL, 0, 1),
 			res:    nil,
 		},
@@ -608,13 +608,13 @@ func TestRemoveTwin(t *testing.T) {
 			desc:   "delete twin with invalid token",
 			id:     stw.ID,
 			auth:   wrongValue,
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 		{
 			desc:   "delete twin with empty token",
 			id:     stw.ID,
 			auth:   "",
-			status: http.StatusForbidden,
+			status: http.StatusUnauthorized,
 		},
 	}
 

--- a/twins/api/http/requests.go
+++ b/twins/api/http/requests.go
@@ -25,7 +25,7 @@ type addTwinReq struct {
 
 func (req addTwinReq) validate() error {
 	if req.token == "" {
-		return twins.ErrUnauthorizedAccess
+		return twins.ErrUnauthenticated
 	}
 
 	if len(req.Name) > maxNameSize {
@@ -45,7 +45,7 @@ type updateTwinReq struct {
 
 func (req updateTwinReq) validate() error {
 	if req.token == "" {
-		return twins.ErrUnauthorizedAccess
+		return twins.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -66,7 +66,7 @@ type viewTwinReq struct {
 
 func (req viewTwinReq) validate() error {
 	if req.token == "" {
-		return twins.ErrUnauthorizedAccess
+		return twins.ErrUnauthenticated
 	}
 
 	if req.id == "" {
@@ -86,7 +86,7 @@ type listReq struct {
 
 func (req *listReq) validate() error {
 	if req.token == "" {
-		return twins.ErrUnauthorizedAccess
+		return twins.ErrUnauthenticated
 	}
 
 	if req.limit == 0 || req.limit > maxLimitSize {
@@ -109,7 +109,7 @@ type listStatesReq struct {
 
 func (req *listStatesReq) validate() error {
 	if req.token == "" {
-		return twins.ErrUnauthorizedAccess
+		return twins.ErrUnauthenticated
 	}
 
 	if req.id == "" {

--- a/twins/api/http/transport.go
+++ b/twins/api/http/transport.go
@@ -209,7 +209,9 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	switch err {
 	case twins.ErrMalformedEntity:
 		w.WriteHeader(http.StatusBadRequest)
-	case twins.ErrUnauthorizedAccess:
+	case twins.ErrUnauthenticated:
+		w.WriteHeader(http.StatusUnauthorized)
+	case twins.ErrUnauthorized:
 		w.WriteHeader(http.StatusForbidden)
 	case twins.ErrNotFound:
 		w.WriteHeader(http.StatusNotFound)

--- a/twins/mocks/authn.go
+++ b/twins/mocks/authn.go
@@ -26,7 +26,7 @@ func (svc authNServiceClient) Identify(ctx context.Context, in *mainflux.Token, 
 	if id, ok := svc.users[in.Value]; ok {
 		return &mainflux.UserID{Value: id}, nil
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }
 
 func (svc *authNServiceClient) Issue(ctx context.Context, in *mainflux.IssueReq, opts ...grpc.CallOption) (*mainflux.Token, error) {

--- a/twins/service.go
+++ b/twins/service.go
@@ -25,9 +25,13 @@ var (
 	// invalid username or password).
 	ErrMalformedEntity = errors.New("malformed entity specification")
 
-	// ErrUnauthorizedAccess indicates missing or invalid credentials provided
+	// ErrUnauthenticated indicates missing or invalid credentials provided
 	// when accessing a protected resource.
-	ErrUnauthorizedAccess = errors.New("missing or invalid credentials provided")
+	ErrUnauthenticated = errors.New("missing or invalid credentials provided")
+
+	// ErrUnauthorized indicates unauthorized access
+	// when accessing a protected resource.
+	ErrUnauthorized = errors.New("unauthorized access")
 
 	// ErrNotFound indicates a non-existent entity request.
 	ErrNotFound = errors.New("non-existent entity")
@@ -122,7 +126,7 @@ func (ts *twinsService) AddTwin(ctx context.Context, token string, twin Twin, de
 
 	res, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return Twin{}, ErrUnauthorizedAccess
+		return Twin{}, ErrUnauthenticated
 	}
 
 	twin.ID, err = ts.uuidProvider.ID()
@@ -165,7 +169,7 @@ func (ts *twinsService) UpdateTwin(ctx context.Context, token string, twin Twin,
 
 	_, err = ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return ErrUnauthorizedAccess
+		return ErrUnauthenticated
 	}
 
 	tw, err := ts.twins.RetrieveByID(ctx, twin.ID)
@@ -215,7 +219,7 @@ func (ts *twinsService) ViewTwin(ctx context.Context, token, twinID string) (tw 
 
 	_, err = ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return Twin{}, ErrUnauthorizedAccess
+		return Twin{}, ErrUnauthenticated
 	}
 
 	twin, err := ts.twins.RetrieveByID(ctx, twinID)
@@ -234,7 +238,7 @@ func (ts *twinsService) RemoveTwin(ctx context.Context, token, twinID string) (e
 
 	_, err = ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return ErrUnauthorizedAccess
+		return ErrUnauthenticated
 	}
 
 	if err := ts.twins.Remove(ctx, twinID); err != nil {
@@ -247,7 +251,7 @@ func (ts *twinsService) RemoveTwin(ctx context.Context, token, twinID string) (e
 func (ts *twinsService) ListTwins(ctx context.Context, token string, offset uint64, limit uint64, name string, metadata Metadata) (Page, error) {
 	res, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return Page{}, ErrUnauthorizedAccess
+		return Page{}, ErrUnauthenticated
 	}
 
 	return ts.twins.RetrieveAll(ctx, res.GetValue(), offset, limit, name, metadata)
@@ -256,7 +260,7 @@ func (ts *twinsService) ListTwins(ctx context.Context, token string, offset uint
 func (ts *twinsService) ListStates(ctx context.Context, token string, offset uint64, limit uint64, twinID string) (StatesPage, error) {
 	_, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
-		return StatesPage{}, ErrUnauthorizedAccess
+		return StatesPage{}, ErrUnauthenticated
 	}
 
 	return ts.states.RetrieveAll(ctx, offset, limit, twinID)

--- a/twins/service_test.go
+++ b/twins/service_test.go
@@ -51,7 +51,7 @@ func TestAddTwin(t *testing.T) {
 			desc:  "add twin with wrong credentials",
 			twin:  twin,
 			token: wrongToken,
-			err:   twins.ErrUnauthorizedAccess,
+			err:   twins.ErrUnauthenticated,
 		},
 	}
 
@@ -89,7 +89,7 @@ func TestUpdateTwin(t *testing.T) {
 			desc:  "update twin with wrong credentials",
 			twin:  saved,
 			token: wrongToken,
-			err:   twins.ErrUnauthorizedAccess,
+			err:   twins.ErrUnauthenticated,
 		},
 		{
 			desc:  "update non-existing twin",
@@ -125,7 +125,7 @@ func TestViewTwin(t *testing.T) {
 		"view twin with wrong credentials": {
 			id:    saved.ID,
 			token: wrongToken,
-			err:   twins.ErrUnauthorizedAccess,
+			err:   twins.ErrUnauthenticated,
 		},
 		"view non-existing twin": {
 			id:    wrongID,
@@ -186,7 +186,7 @@ func TestListTwins(t *testing.T) {
 			token:  wrongToken,
 			limit:  0,
 			offset: n,
-			err:    twins.ErrUnauthorizedAccess,
+			err:    twins.ErrUnauthenticated,
 		},
 	}
 
@@ -215,7 +215,7 @@ func TestRemoveTwin(t *testing.T) {
 			desc:  "remove twin with wrong credentials",
 			id:    saved.ID,
 			token: wrongToken,
-			err:   twins.ErrUnauthorizedAccess,
+			err:   twins.ErrUnauthenticated,
 		},
 		{
 			desc:  "remove existing twin",
@@ -390,7 +390,7 @@ func TestListStates(t *testing.T) {
 			offset: 0,
 			limit:  10,
 			size:   0,
-			err:    twins.ErrUnauthorizedAccess,
+			err:    twins.ErrUnauthenticated,
 		},
 		{
 			desc:   "get a list with id of non-existent twin",

--- a/twins/swagger.yaml
+++ b/twins/swagger.yaml
@@ -33,8 +33,10 @@ paths:
               description: Created twin's relative URL (i.e. /twins/{twinID}).
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         415:
           description: Missing or invalid content type.
         500:
@@ -59,12 +61,14 @@ paths:
           schema:
             $ref: '#/definitions/TwinsPage'
         400:
-          description: Failed due to malformed query parameters.            
-        403:
+          description: Failed due to malformed query parameters.
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: '#/responses/ServiceError'
-  
+
   /twins/{twinID}:
     get:
       summary: Retrieves twin info
@@ -79,9 +83,11 @@ paths:
           schema:
             $ref: '#/definitions/TwinRes'
         400:
-          description: Failed due to malformed twin's ID.            
-        403:
+          description: Failed due to malformed twin's ID.
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Twin does not exist.
         500:
@@ -107,8 +113,10 @@ paths:
           description: Twin updated.
         400:
           description: Failed due to malformed twin's ID or malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
           description: Twin does not exist.
         415:
@@ -128,13 +136,15 @@ paths:
           description: Twin removed.
         400:
           description: Failed due to malformed twin's ID.
-        403:
+        401:
           description: Missing or invalid access token provided
+        403:
+          description: Unauthorized access.
         404:
-          description: Twin does not exist.          
+          description: Twin does not exist.
         500:
           $ref: '#/responses/ServiceError'
-  
+
   /states/{twinID}:
     get:
       summary: Retrieves states of twin with id twinID
@@ -156,12 +166,14 @@ paths:
             $ref: '#/definitions/StatesPage'
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         404:
-          description: Twin does not exist.          
+          description: Twin does not exist.
         500:
-          $ref: '#/responses/ServiceError'  
+          $ref: '#/responses/ServiceError'
 
 responses:
   ServiceError:
@@ -196,10 +208,10 @@ parameters:
     description: Twin name
     in: query
     type: string
-    required: false    
+    required: false
   Metadata:
     name: metadata
-    description: | 
+    description: |
       Metadata filter. Filtering is performed matching the parameter with
       metadata on top level. Parameter is json.
     in: query
@@ -329,7 +341,7 @@ definitions:
         minItems: 0
         uniqueItems: true
         items:
-          $ref: '#/definitions/StateRes' 
+          $ref: '#/definitions/StateRes'
       total:
         type: integer
         description: Total number of items.

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -27,7 +27,7 @@ type viewUserReq struct {
 
 func (req viewUserReq) validate() error {
 	if req.token == "" {
-		return users.ErrUnauthorizedAccess
+		return users.ErrUnauthenticated
 	}
 	return nil
 }
@@ -39,7 +39,7 @@ type updateUserReq struct {
 
 func (req updateUserReq) validate() error {
 	if req.token == "" {
-		return users.ErrUnauthorizedAccess
+		return users.ErrUnauthenticated
 	}
 	return nil
 }
@@ -83,13 +83,13 @@ type passwChangeReq struct {
 
 func (req passwChangeReq) validate() error {
 	if req.Token == "" {
-		return users.ErrUnauthorizedAccess
+		return users.ErrUnauthenticated
 	}
 	if len(req.Password) < minPassLen {
 		return users.ErrMalformedEntity
 	}
 	if req.OldPassword == "" {
-		return users.ErrUnauthorizedAccess
+		return users.ErrUnauthenticated
 	}
 	return nil
 }

--- a/users/api/transport.go
+++ b/users/api/transport.go
@@ -209,8 +209,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		switch {
 		case errors.Contains(errorVal, users.ErrMalformedEntity):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, users.ErrUnauthorizedAccess):
-			w.WriteHeader(http.StatusForbidden)
+		case errors.Contains(errorVal, users.ErrUnauthenticated):
+			w.WriteHeader(http.StatusUnauthorized)
 		case errors.Contains(errorVal, users.ErrConflict):
 			w.WriteHeader(http.StatusConflict)
 		case errors.Contains(errorVal, ErrUnsupportedContentType):

--- a/users/mocks/authn.go
+++ b/users/mocks/authn.go
@@ -26,7 +26,7 @@ func (svc authNServiceMock) Identify(ctx context.Context, in *mainflux.Token, op
 	if id, ok := svc.users[in.Value]; ok {
 		return &mainflux.UserID{Value: id}, nil
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }
 
 func (svc authNServiceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opts ...grpc.CallOption) (*mainflux.Token, error) {
@@ -36,5 +36,5 @@ func (svc authNServiceMock) Issue(ctx context.Context, in *mainflux.IssueReq, op
 			return &mainflux.Token{Value: id}, nil
 		}
 	}
-	return nil, users.ErrUnauthorizedAccess
+	return nil, users.ErrUnauthenticated
 }

--- a/users/mocks/hasher.go
+++ b/users/mocks/hasher.go
@@ -26,7 +26,7 @@ func (hm *hasherMock) Hash(pwd string) (string, error) {
 
 func (hm *hasherMock) Compare(plain, hashed string) error {
 	if plain != hashed {
-		return users.ErrUnauthorizedAccess
+		return users.ErrUnauthenticated
 	}
 
 	return nil

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -91,18 +91,18 @@ func TestLogin(t *testing.T) {
 				Email:    wrong,
 				Password: user.Password,
 			},
-			err: users.ErrUnauthorizedAccess,
+			err: users.ErrUnauthenticated,
 		},
 		"login with wrong password": {
 			user: users.User{
 				Email:    user.Email,
 				Password: wrong,
 			},
-			err: users.ErrUnauthorizedAccess,
+			err: users.ErrUnauthenticated,
 		},
 		"login failed auth": {
 			user: noAuthUser,
-			err:  users.ErrUnauthorizedAccess,
+			err:  users.ErrUnauthenticated,
 		},
 	}
 
@@ -135,7 +135,7 @@ func TestViewUser(t *testing.T) {
 		"invalid token's user info": {
 			user:  users.User{},
 			token: "",
-			err:   users.ErrUnauthorizedAccess,
+			err:   users.ErrUnauthenticated,
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestUpdateUser(t *testing.T) {
 		"update user with invalid token": {
 			user:  user,
 			token: "non-existent",
-			err:   users.ErrUnauthorizedAccess,
+			err:   users.ErrUnauthenticated,
 		},
 	}
 
@@ -206,8 +206,8 @@ func TestChangePassword(t *testing.T) {
 		err         error
 	}{
 		"valid user change password ":                    {token, "newpassword", user.Password, nil},
-		"valid user change password with wrong password": {token, "newpassword", "wrongpassword", users.ErrUnauthorizedAccess},
-		"valid user change password invalid token":       {"", "newpassword", user.Password, users.ErrUnauthorizedAccess},
+		"valid user change password with wrong password": {token, "newpassword", "wrongpassword", users.ErrUnauthenticated},
+		"valid user change password invalid token":       {"", "newpassword", user.Password, users.ErrUnauthenticated},
 	}
 
 	for desc, tc := range cases {
@@ -229,7 +229,7 @@ func TestResetPassword(t *testing.T) {
 		err      error
 	}{
 		"valid user reset password ":   {resetToken.GetValue(), user.Email, nil},
-		"invalid user reset password ": {"", "newpassword", users.ErrUnauthorizedAccess},
+		"invalid user reset password ": {"", "newpassword", users.ErrUnauthenticated},
 	}
 
 	for desc, tc := range cases {

--- a/users/swagger.yaml
+++ b/users/swagger.yaml
@@ -51,8 +51,10 @@ paths:
             $ref: "#/definitions/UsersPage"
         400:
           description: Failed due to malformed query parameters.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /users:
@@ -76,8 +78,10 @@ paths:
           description: User updated.
         400:
           description: Failed due to malformed JSON.
-        403:
+        401:
           description: Missing or invalid access token provided.
+        403:
+          description: Unauthorized access.
         500:
           $ref: "#/responses/ServiceError"
   /tokens:
@@ -104,7 +108,7 @@ paths:
             Failed due to malformed JSON.
           schema:
             $ref: "#/definitions/Error"
-        403:
+        401:
           description: |
             Failed due to using invalid credentials.
           schema:


### PR DESCRIPTION
Use `401 Unauthorized` instead of `403 Forbidden` for errors related to 
authentication. 

According to [https://tools.ietf.org/html/rfc6750#section-3](https://tools.ietf.org/html/rfc6750#section-3)
