### PR TITLE
NOISSUE - Set VerneMQ default log level

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -209,7 +209,7 @@ services:
     restart: on-failure
     environment:
       DOCKER_VERNEMQ_ALLOW_ANONYMOUS: "on"
-      DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL: debug
+      DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL: info
     networks:
       - mainflux-base-net
     volumes:


### PR DESCRIPTION
Signed-off-by: Nikola Marcetic n.marcetic86@gmail.com

### What does this do?
It sets VerneMQ to [default log level](https://docs.vernemq.com/configuration/logging#console-logging) `info` . The current log level `debug` (which is really unusable, except for VerneMQ developers) causes huge log outputs to stdout and blocks other Mainflux logs. It's really hard to debug anything.
### Which issue(s) does this PR fix/relate to?
NA
### List any changes that modify/break current functionality
NA
### Have you included tests for your changes?
NA
### Did you document any new/modified functionality?
NA
### Notes
NA