### PR TITLE
NOISSUE - Remove thing related code from twins service

### DIFF
--- a/twins/README.md
+++ b/twins/README.md
@@ -1,10 +1,10 @@
 # Twins
 
 Service twins is used for CRUD and update of digital twins. Twin is a semantic
-representation of a real world entity, be it device, application or something
-else. It holds the sequence of attribute based definitions of a real world thing
-and refers to the time series of definition based states that hold the
-historical data about the represented real world thing.
+representation of a real world data system consisting of data producers and
+consumers. It stores the sequence of attribute based definitions of a system and
+refers to a time series of definition based states that store the system
+historical data.
 
 ## Configuration
 
@@ -27,8 +27,6 @@ default values.
 | MF_TWINS_CLIENT_TLS        | Flag that indicates if TLS should be turned on                       | false                 |
 | MF_TWINS_CA_CERTS          | Path to trusted CAs in PEM format                                    |                       |
 | MF_TWINS_MQTT_URL          | Mqtt broker URL for twin CRUD and states update notifications        | tcp://localhost:1883  |
-| MF_TWINS_THING_ID          | ID of thing representing twins service & mqtt user                   |                       |
-| MF_TWINS_THING_KEY         | Key of thing representing twins service & mqtt pass                  |                       |
 | MF_TWINS_CHANNEL_ID        | Mqtt notifications topic                                             |                       |
 | MF_NATS_URL                | Mainflux NATS broker URL                                             | nats://localhost:4222 |
 | MF_AUTHN_GRPC_URL          | AuthN service gRPC URL                                               | localhost:8181        |
@@ -37,8 +35,8 @@ default values.
 ## Deployment
 
 The service itself is distributed as Docker container. The following snippet
-provides a compose file template that can be used to deploy the service container
-locally:
+provides a compose file template that can be used to deploy the service
+container locally:
 
 ```yaml
 version: "3"
@@ -62,15 +60,14 @@ services:
       MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on]
       MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format]
       MF_TWINS_MQTT_URL: [Mqtt broker URL for twin CRUD and states]
-      MF_TWINS_THING_ID: [ID of thing representing twins service]
-      MF_TWINS_THING_KEY: [Key of thing representing twins service]
       MF_TWINS_CHANNEL_ID: [Mqtt notifications topic]
       MF_NATS_URL: [Mainflux NATS broker URL]
       MF_AUTHN_GRPC_URL: [AuthN service gRPC URL]
       MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds]
 ```
 
-To start the service outside of the container, execute the following shell script:
+To start the service outside of the container, execute the following shell
+script:
 
 ```bash
 # download the latest version of the service
@@ -97,8 +94,6 @@ MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode] \
 MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on] \
 MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format] \
 MF_TWINS_MQTT_URL: [Mqtt broker URL for twin CRUD and states] \
-MF_TWINS_THING_ID: [ID of thing representing twins service] \
-MF_TWINS_THING_KEY: [Key of thing representing twins service] \
 MF_TWINS_CHANNEL_ID: [Mqtt notifications topic] \
 MF_NATS_URL: [Mainflux NATS broker URL] \
 MF_AUTHN_GRPC_URL: [AuthN service gRPC URL] \
@@ -110,25 +105,23 @@ $GOBIN/mainflux-twins
 
 ### Starting twins service
 
-The twins service publishes notifications on an mqtt topic of the format
-`channels/<MF_TWINS_CHANNEL_ID>/messages/<twinID>/<crudOp>`, where `crudOp`
+The twins service publishes notifications on a NATS subject of the format
+`channels.<MF_TWINS_CHANNEL_ID>.messages.<twinID>.<crudOp>`, where `crudOp`
 stands for the crud operation done on twin - create, update, delete or
-retrieve - or state - save state. In order to use twin service, one must
-inform it - via environment variables - about the Mainflux thing and
-channel used for mqtt notification publishing. You can use an already existing
-thing and channel - thing has to be connected to channel - or create new ones.
+retrieve - or state - save state. In order to use twin service notifications,
+one must inform it - via environment variables - about the Mainflux channel used
+for notification publishing. You must use an already existing channel, since you
+cannot know in advance or set the channel id (Mainflux does it automatically).
 
-To set the environment variables, please go to `.env` file and set the following
-variables:
+To set the environment variable, please go to `.env` file and set the following
+variable:
 
 ```
-MF_TWINS_THING_ID=
-MF_TWINS_THING_KEY=
 MF_TWINS_CHANNEL_ID=
 ```
 
-with the corresponding values of the desired thing and channel. If you are
-running mainflux natively, than do the same thing in the corresponding console
+with the corresponding values of the desired channel. If you are running
+mainflux natively, than do the same thing in the corresponding console
 environment.
 
 For more information about service capabilities and its usage, please check out

--- a/twins/api/http/endpoint.go
+++ b/twins/api/http/endpoint.go
@@ -46,7 +46,6 @@ func updateTwinEndpoint(svc twins.Service) endpoint.Endpoint {
 		twin := twins.Twin{
 			ID:       req.id,
 			Name:     req.Name,
-			ThingID:  req.ThingID,
 			Metadata: req.Metadata,
 		}
 
@@ -76,42 +75,12 @@ func viewTwinEndpoint(svc twins.Service) endpoint.Endpoint {
 			Owner:       twin.Owner,
 			ID:          twin.ID,
 			Name:        twin.Name,
-			ThingID:     twin.ThingID,
 			Created:     twin.Created,
 			Updated:     twin.Updated,
 			Revision:    twin.Revision,
 			Definitions: twin.Definitions,
 			Metadata:    twin.Metadata,
 		}
-		return res, nil
-	}
-}
-
-func viewTwinByThingEndpoint(svc twins.Service) endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(viewTwinReq)
-
-		if err := req.validate(); err != nil {
-			return nil, err
-		}
-
-		twin, err := svc.ViewTwinByThing(ctx, req.token, req.id)
-		if err != nil {
-			return nil, err
-		}
-
-		res := viewTwinRes{
-			Owner:       twin.Owner,
-			ID:          twin.ID,
-			Name:        twin.Name,
-			ThingID:     twin.ThingID,
-			Created:     twin.Created,
-			Updated:     twin.Updated,
-			Revision:    twin.Revision,
-			Definitions: twin.Definitions,
-			Metadata:    twin.Metadata,
-		}
-
 		return res, nil
 	}
 }
@@ -142,7 +111,6 @@ func listTwinsEndpoint(svc twins.Service) endpoint.Endpoint {
 				Owner:       twin.Owner,
 				ID:          twin.ID,
 				Name:        twin.Name,
-				ThingID:     twin.ThingID,
 				Created:     twin.Created,
 				Updated:     twin.Updated,
 				Revision:    twin.Revision,

--- a/twins/api/http/endpoint_test.go
+++ b/twins/api/http/endpoint_test.go
@@ -31,7 +31,6 @@ const (
 	email       = "user@example.com"
 	token       = "token"
 	wrongValue  = "wrong_value"
-	thingID     = "5b68df78-86f7-48a6-ac4f-bb24dd75c39e"
 	wrongID     = 0
 	maxNameSize = 1024
 	topic       = "topic"
@@ -87,8 +86,7 @@ func TestAddTwin(t *testing.T) {
 	ts := newServer(svc)
 	defer ts.Close()
 
-	// tw := twins.Twin{ThingID: thingID}
-	tw := twinReq{ThingID: thingID}
+	tw := twinReq{}
 	data := toJSON(tw)
 
 	tw.Name = invalidName
@@ -191,7 +189,7 @@ func TestUpdateTwin(t *testing.T) {
 	ts := newServer(svc)
 	defer ts.Close()
 
-	twin := twins.Twin{ThingID: thingID}
+	twin := twins.Twin{}
 	def := twins.Definition{}
 	stw, _ := svc.AddTwin(context.Background(), token, twin, def)
 
@@ -304,7 +302,7 @@ func TestViewTwin(t *testing.T) {
 	defer ts.Close()
 
 	def := twins.Definition{}
-	twin := twins.Twin{ThingID: thingID}
+	twin := twins.Twin{}
 	stw, err := svc.AddTwin(context.Background(), token, twin, def)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
@@ -312,7 +310,6 @@ func TestViewTwin(t *testing.T) {
 		Owner:       stw.Owner,
 		Name:        stw.Name,
 		ID:          stw.ID,
-		ThingID:     stw.ThingID,
 		Revision:    stw.Revision,
 		Created:     stw.Created,
 		Updated:     stw.Updated,
@@ -387,7 +384,7 @@ func TestRemoveTwin(t *testing.T) {
 	defer ts.Close()
 
 	def := twins.Definition{}
-	twin := twins.Twin{ThingID: thingID}
+	twin := twins.Twin{}
 	stw, _ := svc.AddTwin(context.Background(), token, twin, def)
 
 	cases := []struct {
@@ -444,7 +441,6 @@ func TestRemoveTwin(t *testing.T) {
 type twinReq struct {
 	token      string
 	Name       string                 `json:"name,omitempty"`
-	ThingID    string                 `json:"thing_id"`
 	Definition twins.Definition       `json:"definition,omitempty"`
 	Metadata   map[string]interface{} `json:"metadata,omitempty"`
 }
@@ -453,7 +449,6 @@ type twinRes struct {
 	Owner       string                 `json:"owner"`
 	Name        string                 `json:"name,omitempty"`
 	ID          string                 `json:"id"`
-	ThingID     string                 `json:"thing_id"`
 	Revision    int                    `json:"revision"`
 	Created     time.Time              `json:"created"`
 	Updated     time.Time              `json:"updated"`

--- a/twins/api/http/requests.go
+++ b/twins/api/http/requests.go
@@ -37,7 +37,6 @@ type updateTwinReq struct {
 	token      string
 	id         string
 	Name       string                 `json:"name,omitempty"`
-	ThingID    string                 `json:"thing_id,omitempty"`
 	Definition twins.Definition       `json:"definition,omitempty"`
 	Metadata   map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/twins/api/http/responses.go
+++ b/twins/api/http/responses.go
@@ -51,7 +51,6 @@ func (res twinRes) Empty() bool {
 type viewTwinRes struct {
 	Owner       string                 `json:"owner,omitempty"`
 	ID          string                 `json:"id"`
-	ThingID     string                 `json:"thing_id"`
 	Name        string                 `json:"name,omitempty"`
 	Revision    int                    `json:"revision"`
 	Created     time.Time              `json:"created"`

--- a/twins/api/http/transport.go
+++ b/twins/api/http/transport.go
@@ -81,13 +81,6 @@ func MakeHandler(tracer opentracing.Tracer, svc twins.Service) http.Handler {
 		opts...,
 	))
 
-	r.Get("/things/:id", kithttp.NewServer(
-		kitot.TraceServer(tracer, "view_twin_by_thing")(viewTwinByThingEndpoint(svc)),
-		decodeViewTwinByThing,
-		encodeResponse,
-		opts...,
-	))
-
 	r.Get("/states/:id", kithttp.NewServer(
 		kitot.TraceServer(tracer, "list_states")(listStatesEndpoint(svc)),
 		decodeListStates,
@@ -187,15 +180,6 @@ func decodeListStates(_ context.Context, r *http.Request) (interface{}, error) {
 		limit:  l,
 		offset: o,
 		id:     bone.GetValue(r, "id"),
-	}
-
-	return req, nil
-}
-
-func decodeViewTwinByThing(_ context.Context, r *http.Request) (interface{}, error) {
-	req := viewTwinReq{
-		token: r.Header.Get("Authorization"),
-		id:    bone.GetValue(r, "id"),
 	}
 
 	return req, nil

--- a/twins/api/logging.go
+++ b/twins/api/logging.go
@@ -105,19 +105,6 @@ func (lm *loggingMiddleware) ListStates(ctx context.Context, token string, offse
 	return lm.svc.ListStates(ctx, token, offset, limit, id)
 }
 
-func (lm *loggingMiddleware) ViewTwinByThing(ctx context.Context, token, thingid string) (tw twins.Twin, err error) {
-	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method view_twin_by_thing for token %s and thing %s took %s to complete", token, thingid, time.Since(begin))
-		if err != nil {
-			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
-			return
-		}
-		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
-	}(time.Now())
-
-	return lm.svc.ViewTwinByThing(ctx, token, thingid)
-}
-
 func (lm *loggingMiddleware) RemoveTwin(ctx context.Context, token, id string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method remove_twin for token %s and twin %s took %s to complete", token, id, time.Since(begin))

--- a/twins/api/metrics.go
+++ b/twins/api/metrics.go
@@ -86,15 +86,6 @@ func (ms *metricsMiddleware) ListStates(ctx context.Context, token string, offse
 	return ms.svc.ListStates(ctx, token, offset, limit, id)
 }
 
-func (ms *metricsMiddleware) ViewTwinByThing(ctx context.Context, token, thingid string) (twins.Twin, error) {
-	defer func(begin time.Time) {
-		ms.counter.With("method", "view_twin_by_thing").Add(1)
-		ms.latency.With("method", "view_twin_by_thing").Observe(time.Since(begin).Seconds())
-	}(time.Now())
-
-	return ms.svc.ViewTwinByThing(ctx, token, thingid)
-}
-
 func (ms *metricsMiddleware) RemoveTwin(ctx context.Context, token, id string) (err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "remove_twin").Add(1)

--- a/twins/doc.go
+++ b/twins/doc.go
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package twins contains the domain concept definitions needed to support
-// Mainflux twins service functionality. Twin is a semantic representation
-// of a real world entity, be it device, application or something else.
-// It holds the sequence of attribute based definitions of a real world
-// thing and refers to the time series of definition based states that
-// hold the historical data about the represented real world thing.
+// Mainflux twins service functionality. Twin is a semantic representation of a
+// real world data system consisting of data producers and consumers. It stores
+// the sequence of attribute based definitions of a data system and refers to a
+// time series of definition based states that store the system historical data.
 package twins

--- a/twins/mocks/twins.go
+++ b/twins/mocks/twins.go
@@ -86,20 +86,6 @@ func (trm *twinRepositoryMock) RetrieveByAttribute(ctx context.Context, channel,
 	return ids, nil
 }
 
-func (trm *twinRepositoryMock) RetrieveByThing(_ context.Context, thingid string) (twins.Twin, error) {
-	trm.mu.Lock()
-	defer trm.mu.Unlock()
-
-	for _, twin := range trm.twins {
-		if twin.ThingID == thingid {
-			return twin, nil
-		}
-	}
-
-	return twins.Twin{}, twins.ErrNotFound
-
-}
-
 func (trm *twinRepositoryMock) RetrieveAll(_ context.Context, owner string, offset uint64, limit uint64, name string, metadata twins.Metadata) (twins.Page, error) {
 	trm.mu.Lock()
 	defer trm.mu.Unlock()

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -77,17 +77,6 @@ func (tr *twinRepository) RetrieveByID(_ context.Context, id string) (twins.Twin
 	return tw, nil
 }
 
-func (tr *twinRepository) RetrieveByThing(ctx context.Context, thingid string) (twins.Twin, error) {
-	coll := tr.db.Collection(twinsCollection)
-	tw := twins.Twin{}
-	filter := bson.D{{"thingid", thingid}}
-	if err := coll.FindOne(context.Background(), filter).Decode(&tw); err != nil {
-		return tw, twins.ErrNotFound
-	}
-
-	return tw, nil
-}
-
 func (tr *twinRepository) RetrieveByAttribute(ctx context.Context, channel, subtopic string) ([]string, error) {
 	coll := tr.db.Collection(twinsCollection)
 
@@ -157,39 +146,6 @@ func (tr *twinRepository) RetrieveAll(ctx context.Context, owner string, offset 
 	if len(metadata) > 0 {
 		filter = append(filter, bson.E{"metadata", metadata})
 	}
-	cur, err := coll.Find(ctx, filter, findOptions)
-	if err != nil {
-		return twins.Page{}, err
-	}
-
-	results, err := decodeTwins(ctx, cur)
-	if err != nil {
-		return twins.Page{}, err
-	}
-
-	total, err := coll.CountDocuments(ctx, filter)
-	if err != nil {
-		return twins.Page{}, err
-	}
-
-	return twins.Page{
-		Twins: results,
-		PageMetadata: twins.PageMetadata{
-			Total:  uint64(total),
-			Offset: offset,
-			Limit:  limit,
-		},
-	}, nil
-}
-
-func (tr *twinRepository) RetrieveAllByThing(ctx context.Context, thingid string, offset uint64, limit uint64) (twins.Page, error) {
-	coll := tr.db.Collection(twinsCollection)
-
-	findOptions := options.Find()
-	findOptions.SetSkip(int64(offset))
-	findOptions.SetLimit(int64(limit))
-
-	filter := bson.D{{"thingid", thingid}}
 	cur, err := coll.Find(ctx, filter, findOptions)
 	if err != nil {
 		return twins.Page{}, err

--- a/twins/mongodb/twins_test.go
+++ b/twins/mongodb/twins_test.go
@@ -185,54 +185,6 @@ func TestTwinsRetrieveByID(t *testing.T) {
 	}
 }
 
-func TestTwinsRetrieveByThing(t *testing.T) {
-	client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(addr))
-	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
-
-	db := client.Database(testDB)
-	repo := mongodb.NewTwinRepository(db)
-
-	twid, err := idp.ID()
-	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
-	thingid, err := idp.ID()
-	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
-	nonexistentThingID, err := idp.ID()
-	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-
-	twin := twins.Twin{
-		ID:      twid,
-		ThingID: thingid,
-	}
-
-	if _, err := repo.Save(context.Background(), twin); err != nil {
-		testLog.Error(err.Error())
-	}
-
-	cases := []struct {
-		desc    string
-		thingid string
-		err     error
-	}{
-		{
-			desc:    "retrieve an existing twin",
-			thingid: thingid,
-			err:     nil,
-		},
-		{
-			desc:    "retrieve a non-existing twin",
-			thingid: nonexistentThingID,
-			err:     twins.ErrNotFound,
-		},
-	}
-
-	for _, tc := range cases {
-		_, err := repo.RetrieveByThing(context.Background(), tc.thingid)
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
-	}
-}
-
 func TestTwinsRetrieveAll(t *testing.T) {
 	email := "twin-multi-retrieval@example.com"
 	name := "mainflux"

--- a/twins/service.go
+++ b/twins/service.go
@@ -52,11 +52,6 @@ type Service interface {
 	// ID belonging to the user identified by the provided key.
 	ViewTwin(ctx context.Context, token, id string) (tw Twin, err error)
 
-	// ViewTwinByThing retrieves data about subset of twins that represent
-	// specified thing belong to the user identified by
-	// the provided key.
-	ViewTwinByThing(ctx context.Context, token, thingid string) (Twin, error)
-
 	// RemoveTwin removes the twin identified with the provided ID, that
 	// belongs to the user identified by the provided key.
 	RemoveTwin(ctx context.Context, token, id string) (err error)
@@ -183,11 +178,6 @@ func (ts *twinsService) UpdateTwin(ctx context.Context, token string, twin Twin,
 		tw.Name = twin.Name
 	}
 
-	if twin.ThingID != "" {
-		revision = true
-		tw.ThingID = twin.ThingID
-	}
-
 	if len(def.Attributes) > 0 {
 		revision = true
 		def.Created = time.Now()
@@ -234,15 +224,6 @@ func (ts *twinsService) ViewTwin(ctx context.Context, token, id string) (tw Twin
 	b, err = json.Marshal(twin)
 
 	return twin, nil
-}
-
-func (ts *twinsService) ViewTwinByThing(ctx context.Context, token, thingid string) (Twin, error) {
-	_, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
-	if err != nil {
-		return Twin{}, ErrUnauthorizedAccess
-	}
-
-	return ts.twins.RetrieveByThing(ctx, thingid)
 }
 
 func (ts *twinsService) RemoveTwin(ctx context.Context, token, id string) (err error) {

--- a/twins/twins.go
+++ b/twins/twins.go
@@ -27,13 +27,12 @@ type Definition struct {
 	Delta      int64       `json:"delta"`
 }
 
-// Twin represents a Mainflux thing digital twin. Each twin is owned by one thing, and
-// is assigned with the unique identifier.
+// Twin is a Mainflux data system representation. Each twin is owned
+// by a single user, and is assigned with the unique identifier.
 type Twin struct {
 	Owner       string
 	ID          string
 	Name        string
-	ThingID     string
 	Created     time.Time
 	Updated     time.Time
 	Revision    int
@@ -72,11 +71,8 @@ type TwinRepository interface {
 	// the attribute with given channel and subtopic
 	RetrieveByAttribute(ctx context.Context, channel, subtopic string) ([]string, error)
 
-	// RetrieveAll retrieves the subset of things owned by the specified user.
+	// RetrieveAll retrieves the subset of twins owned by the specified user.
 	RetrieveAll(context.Context, string, uint64, uint64, string, Metadata) (Page, error)
-
-	// RetrieveByThing retrieves twin that represents specified thing
-	RetrieveByThing(context.Context, string) (Twin, error)
 
 	// Remove removes the twin having the provided identifier.
 	Remove(ctx context.Context, id string) error


### PR DESCRIPTION
Formerly, twin service was dependent on Mainflux thing. Every twin was connected to one and only one thing. Now twin is decoupled from thing and is thing agnostic, since its definition relies only on channels and subtopics.

Also, since notifications were published via mqtt, we needed a MF thing in order to publish them. Now they are published directly on NATS, so there is no need to specify thing via env var.

The code related to thing in the upper two senses is now removed.