### PR TITLE
MF-1163 - Fix influxdb-reader to use nanoseconds precision

### DIFF
--- a/readers/influxdb/messages.go
+++ b/readers/influxdb/messages.go
@@ -196,12 +196,12 @@ func parseMessage(names []string, fields []interface{}) senml.Message {
 			}
 		case float64:
 			if name == "time" {
-				t, err := time.Parse(time.RFC3339, fields[i].(string))
+				t, err := time.Parse(time.RFC3339Nano, fields[i].(string))
 				if err != nil {
 					continue
 				}
 
-				v := float64(t.Unix())
+				v := float64(t.UnixNano()) / float64(1e9)
 				msgField.SetFloat(v)
 				continue
 			}

--- a/readers/influxdb/messages_test.go
+++ b/readers/influxdb/messages_test.go
@@ -59,7 +59,7 @@ func TestReadAll(t *testing.T) {
 
 	messages := []senml.Message{}
 	subtopicMsgs := []senml.Message{}
-	now := time.Now().Unix()
+	now := time.Now().UnixNano()
 	for i := 0; i < msgsNum; i++ {
 		// Mix possible values as well as value sum.
 		count := i % valueFields
@@ -78,7 +78,7 @@ func TestReadAll(t *testing.T) {
 			msg.Sum = &sum
 		}
 
-		msg.Time = float64(now - int64(i))
+		msg.Time = float64(now)/float64(1e9) - float64(i)
 		messages = append(messages, msg)
 		if count == 0 {
 			subtopicMsgs = append(subtopicMsgs, msg)

--- a/writers/influxdb/messages_test.go
+++ b/writers/influxdb/messages_test.go
@@ -88,7 +88,7 @@ func TestSave(t *testing.T) {
 		_, err := queryDB(dropMsgs)
 		require.Nil(t, err, fmt.Sprintf("Cleaning data from InfluxDB expected to succeed: %s.\n", err))
 
-		now := time.Now().Unix()
+		now := time.Now().UnixNano()
 		msg := senml.Message{
 			Channel:    "45",
 			Publisher:  "2580",
@@ -116,7 +116,7 @@ func TestSave(t *testing.T) {
 				msg.Sum = &sum
 			}
 
-			msg.Time = float64(now + int64(i))
+			msg.Time = float64(now)/float64(1e9) + float64(i)
 			msgs = append(msgs, msg)
 		}
 


### PR DESCRIPTION
Signed-off-by: Manuel Imperiale <manuel.imperiale@gmail.com>

Resolves #1163 