### PR TITLE
MF-1198 - Add errors package tests

### DIFF
--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -5,6 +5,7 @@ package errors_test
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -34,7 +35,7 @@ func (ce *customError) Error() string {
 	return ce.msg
 }
 
-func TestWrap(t *testing.T) {
+func TestError(t *testing.T) {
 	cases := []struct {
 		desc string
 		err  error
@@ -63,7 +64,8 @@ func TestWrap(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		assert.Equal(t, tc.msg, tc.err.Error(), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, tc.err.Error()))
+		errMsg := tc.err.Error()
+		assert.Equal(t, tc.msg, errMsg, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.msg, errMsg))
 	}
 }
 
@@ -96,10 +98,39 @@ func TestContains(t *testing.T) {
 	}
 	for _, tc := range cases {
 		contains := errors.Contains(tc.container, tc.contained)
-		cntStr := strconv.FormatBool(contains)
-		assert.Equal(t, true, contains, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, "true", cntStr))
+		assert.Equal(t, true, contains, fmt.Sprintf("%s: expected %v to contain %v\n", tc.desc, tc.container, tc.contained))
 	}
 
+}
+
+func TestWrap(t *testing.T) {
+	cases := []struct {
+		desc  string
+		level int
+	}{
+		{
+			desc:  "level 1 wrap",
+			level: 1,
+		},
+		{
+			desc:  "level 5 wrap",
+			level: 5,
+		},
+		{
+			desc:  "level 10 wrap",
+			level: 10,
+		},
+	}
+
+	for _, tc := range cases {
+		err := wrap(tc.level)
+		msg := message(tc.level)
+		errMsg := err.Error()
+		assert.Equal(t, msg, errMsg, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, msg, errMsg))
+		contained := errors.New(strconv.Itoa(rand.Intn(tc.level)))
+		contains := errors.Contains(err, contained)
+		assert.Equal(t, true, contains, fmt.Sprintf("%s: expected %v to contain %v\n", tc.desc, err, contained))
+	}
 }
 
 func wrap(n int) error {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package errors_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/mainflux/mainflux/pkg/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	msg1 = "message 1"
+	msg2 = "message 2"
+	msg3 = "message 3"
+)
+
+var (
+	err1 = errors.New(msg1)
+	err2 = errors.New(msg2)
+	err3 = errors.New(msg3)
+)
+
+type customError struct {
+	msg string
+}
+
+func (ce *customError) Error() string {
+	return ce.msg
+}
+
+func TestWrap(t *testing.T) {
+	level := 10
+	err, msg := wrap(level)
+
+	cases := []struct {
+		desc string
+		err  error
+		msg  string
+	}{
+		{
+			desc: "level 0 wrapped error",
+			err:  err1,
+			msg:  msg1,
+		},
+		{
+			desc: "level 1 wrapped error",
+			err:  errors.Wrap(err1, err2),
+			msg:  fmt.Sprintf("%s : %s", msg1, msg2),
+		},
+		{
+			desc: "level 2 wrapped error",
+			err:  errors.Wrap(err1, errors.Wrap(err2, err3)),
+			msg:  fmt.Sprintf("%s : %s : %s", msg1, msg2, msg3),
+		},
+		{
+			desc: fmt.Sprintf("level %d wrapped error", level),
+			err:  err,
+			msg:  msg,
+		},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.msg, tc.err.Error(), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, tc.err.Error()))
+	}
+}
+
+func TestContains(t *testing.T) {
+	level := 10
+	err, _ := wrap(level)
+
+	cases := []struct {
+		desc      string
+		container error
+		contained error
+	}{
+		{
+			desc:      "res of errors.Wrap(err1, err2) contains err1",
+			container: errors.Wrap(err1, err2),
+			contained: err1,
+		},
+		{
+			desc:      "res of errors.Wrap(err1, err2) contains err2",
+			container: errors.Wrap(err1, err2),
+			contained: err2,
+		},
+		{
+			desc:      fmt.Sprintf("level %d wrapped error contains", level),
+			container: err,
+			contained: errors.New(""),
+		},
+	}
+	for _, tc := range cases {
+		contains := errors.Contains(tc.container, tc.contained)
+		cntStr := strconv.FormatBool(contains)
+		assert.Equal(t, true, contains, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, "true", cntStr))
+	}
+
+}
+
+func wrap(level int) (error, string) {
+	msg := "0"
+	err := error(&customError{msg: msg})
+	for i := 1; i < level; i++ {
+		err = errors.Wrap(errors.New(err.Error()), errors.New(strconv.Itoa(i)))
+		msg += fmt.Sprintf(" : %s", strconv.Itoa(i))
+	}
+	// msg == "0 : 1 : 2 : 3 : 4 : 5 : 6 : 7 : 8 : 9 : ... : level - 1"
+	return err, msg
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -14,18 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	msg1  = "message 1"
-	msg2  = "message 2"
-	msg3  = "message 3"
-	level = 10
-)
-
-var (
-	err1 = errors.New(msg1)
-	err2 = errors.New(msg2)
-	err3 = errors.New(msg3)
-)
+const level = 10
 
 type customError struct {
 	msg string
@@ -43,18 +32,18 @@ func TestError(t *testing.T) {
 	}{
 		{
 			desc: "level 0 wrapped error",
-			err:  err1,
-			msg:  msg1,
+			err:  errors.New("0"),
+			msg:  "0",
 		},
 		{
 			desc: "level 1 wrapped error",
-			err:  errors.Wrap(err1, err2),
-			msg:  fmt.Sprintf("%s : %s", msg1, msg2),
+			err:  wrap(1),
+			msg:  message(1),
 		},
 		{
 			desc: "level 2 wrapped error",
-			err:  errors.Wrap(err1, errors.Wrap(err2, err3)),
-			msg:  fmt.Sprintf("%s : %s : %s", msg1, msg2, msg3),
+			err:  wrap(2),
+			msg:  message(2),
 		},
 		{
 			desc: fmt.Sprintf("level %d wrapped error", level),
@@ -70,25 +59,29 @@ func TestError(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
+	err0 := errors.New("0")
+	err1 := errors.New("1")
+	err2 := errors.New("2")
+
 	cases := []struct {
 		desc      string
 		container error
 		contained error
 	}{
 		{
-			desc:      "res of errors.Wrap(err1, err2) contains err1",
-			container: errors.Wrap(err1, err2),
+			desc:      "res of errors.Wrap(err1, err0) contains err0",
+			container: errors.Wrap(err1, err0),
+			contained: err0,
+		},
+		{
+			desc:      "res of errors.Wrap(err1, err0) contains err1",
+			container: errors.Wrap(err1, err0),
 			contained: err1,
 		},
 		{
-			desc:      "res of errors.Wrap(err1, err2) contains err2",
-			container: errors.Wrap(err1, err2),
-			contained: err2,
-		},
-		{
-			desc:      "res of errors.Wrap(err1, errors.Wrap(err2, err3)) contains err2",
-			container: errors.Wrap(err1, errors.Wrap(err2, err3)),
-			contained: err2,
+			desc:      "res of errors.Wrap(err2, errors.Wrap(err1, err0)) contains err1",
+			container: errors.Wrap(err2, errors.Wrap(err1, err0)),
+			contained: err1,
 		},
 		{
 			desc:      fmt.Sprintf("level %d wrapped error contains", level),
@@ -134,7 +127,7 @@ func TestWrap(t *testing.T) {
 }
 
 func wrap(n int) error {
-	if n < 1 {
+	if n == 0 {
 		return errors.New(strconv.Itoa(n))
 	}
 	return errors.Wrap(errors.New(strconv.Itoa(n)), wrap(n-1))


### PR DESCRIPTION
Add unit tests to `errors` package from `pkg/`.

Resolves #1198 