### PR TITLE
NOISSUE - Use `pgcrypto` instead `uuid-ossp` for UUIDs generation 

### DIFF
--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -63,9 +63,9 @@ func migrateDB(db *sqlx.DB) error {
 			{
 				Id: "users_3",
 				Up: []string{
-					`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+					`CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 					ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS
-					id UUID DEFAULT uuid_generate_v4()`,
+					id UUID NOT NULL DEFAULT gen_random_uuid()`,
 				},
 			},
 		},


### PR DESCRIPTION
According to 
https://www.postgresql.org/docs/current/uuid-ossp.html

```
Note
If you only need randomly-generated (version 4) UUIDs, consider using the gen_random_uuid() function from the pgcrypto module instead.
```