### PR TITLE
NOISSUE - Add subtopic wildcard for twin attribute's definition

### DIFF
--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -42,66 +42,63 @@ import (
 const (
 	queue = "twins"
 
-	defLogLevel         = "error"
-	defHTTPPort         = "8180"
-	defJaegerURL        = ""
-	defServerCert       = ""
-	defServerKey        = ""
-	defDB               = "mainflux-twins"
-	defDBHost           = "localhost"
-	defDBPort           = "27017"
-	defCacheURL         = "localhost:6379"
-	defCachePass        = ""
-	defCacheDB          = "0"
-	defSingleUserEmail  = ""
-	defSingleUserToken  = ""
-	defClientTLS        = "false"
-	defCACerts          = ""
-	defChannelID        = ""
-	defSubtopicWildcard = "#"
-	defNatsURL          = "nats://localhost:4222"
-	defAuthnURL         = "localhost:8181"
-	defAuthnTimeout     = "1s"
+	defLogLevel        = "error"
+	defHTTPPort        = "8180"
+	defJaegerURL       = ""
+	defServerCert      = ""
+	defServerKey       = ""
+	defDB              = "mainflux-twins"
+	defDBHost          = "localhost"
+	defDBPort          = "27017"
+	defCacheURL        = "localhost:6379"
+	defCachePass       = ""
+	defCacheDB         = "0"
+	defSingleUserEmail = ""
+	defSingleUserToken = ""
+	defClientTLS       = "false"
+	defCACerts         = ""
+	defChannelID       = ""
+	defNatsURL         = "nats://localhost:4222"
+	defAuthnURL        = "localhost:8181"
+	defAuthnTimeout    = "1s"
 
-	envLogLevel         = "MF_TWINS_LOG_LEVEL"
-	envHTTPPort         = "MF_TWINS_HTTP_PORT"
-	envJaegerURL        = "MF_JAEGER_URL"
-	envServerCert       = "MF_TWINS_SERVER_CERT"
-	envServerKey        = "MF_TWINS_SERVER_KEY"
-	envDB               = "MF_TWINS_DB"
-	envDBHost           = "MF_TWINS_DB_HOST"
-	envDBPort           = "MF_TWINS_DB_PORT"
-	envCacheURL         = "MF_TWINS_CACHE_URL"
-	envCachePass        = "MF_TWINS_CACHE_PASS"
-	envCacheDB          = "MF_TWINS_CACHE_DB"
-	envSingleUserEmail  = "MF_TWINS_SINGLE_USER_EMAIL"
-	envSingleUserToken  = "MF_TWINS_SINGLE_USER_TOKEN"
-	envClientTLS        = "MF_TWINS_CLIENT_TLS"
-	envCACerts          = "MF_TWINS_CA_CERTS"
-	envChannelID        = "MF_TWINS_CHANNEL_ID"
-	envSubtopicWildcard = "MF_TWINS_SUBTOPIC_WILDCARD"
-	envNatsURL          = "MF_NATS_URL"
-	envAuthnURL         = "MF_AUTHN_GRPC_URL"
-	envAuthnTimeout     = "MF_AUTHN_GRPC_TIMEOUT"
+	envLogLevel        = "MF_TWINS_LOG_LEVEL"
+	envHTTPPort        = "MF_TWINS_HTTP_PORT"
+	envJaegerURL       = "MF_JAEGER_URL"
+	envServerCert      = "MF_TWINS_SERVER_CERT"
+	envServerKey       = "MF_TWINS_SERVER_KEY"
+	envDB              = "MF_TWINS_DB"
+	envDBHost          = "MF_TWINS_DB_HOST"
+	envDBPort          = "MF_TWINS_DB_PORT"
+	envCacheURL        = "MF_TWINS_CACHE_URL"
+	envCachePass       = "MF_TWINS_CACHE_PASS"
+	envCacheDB         = "MF_TWINS_CACHE_DB"
+	envSingleUserEmail = "MF_TWINS_SINGLE_USER_EMAIL"
+	envSingleUserToken = "MF_TWINS_SINGLE_USER_TOKEN"
+	envClientTLS       = "MF_TWINS_CLIENT_TLS"
+	envCACerts         = "MF_TWINS_CA_CERTS"
+	envChannelID       = "MF_TWINS_CHANNEL_ID"
+	envNatsURL         = "MF_NATS_URL"
+	envAuthnURL        = "MF_AUTHN_GRPC_URL"
+	envAuthnTimeout    = "MF_AUTHN_GRPC_TIMEOUT"
 )
 
 type config struct {
-	logLevel         string
-	httpPort         string
-	jaegerURL        string
-	serverCert       string
-	serverKey        string
-	dbCfg            twmongodb.Config
-	cacheURL         string
-	cachePass        string
-	cacheDB          string
-	singleUserEmail  string
-	singleUserToken  string
-	clientTLS        bool
-	caCerts          string
-	channelID        string
-	subtopicWildcard string
-	natsURL          string
+	logLevel        string
+	httpPort        string
+	jaegerURL       string
+	serverCert      string
+	serverKey       string
+	dbCfg           twmongodb.Config
+	cacheURL        string
+	cachePass       string
+	cacheDB         string
+	singleUserEmail string
+	singleUserToken string
+	clientTLS       bool
+	caCerts         string
+	channelID       string
+	natsURL         string
 
 	authnURL     string
 	authnTimeout time.Duration
@@ -138,7 +135,7 @@ func main() {
 	}
 	defer pubSub.Close()
 
-	svc := newService(pubSub, cfg.channelID, cfg.subtopicWildcard, auth, dbTracer, db, cacheTracer, cacheClient, logger)
+	svc := newService(pubSub, cfg.channelID, auth, dbTracer, db, cacheTracer, cacheClient, logger)
 
 	tracer, closer := initJaeger("twins", cfg.jaegerURL, logger)
 	defer closer.Close()
@@ -173,24 +170,23 @@ func loadConfig() config {
 	}
 
 	return config{
-		logLevel:         mainflux.Env(envLogLevel, defLogLevel),
-		httpPort:         mainflux.Env(envHTTPPort, defHTTPPort),
-		serverCert:       mainflux.Env(envServerCert, defServerCert),
-		serverKey:        mainflux.Env(envServerKey, defServerKey),
-		jaegerURL:        mainflux.Env(envJaegerURL, defJaegerURL),
-		dbCfg:            dbCfg,
-		cacheURL:         mainflux.Env(envCacheURL, defCacheURL),
-		cachePass:        mainflux.Env(envCachePass, defCachePass),
-		cacheDB:          mainflux.Env(envCacheDB, defCacheDB),
-		singleUserEmail:  mainflux.Env(envSingleUserEmail, defSingleUserEmail),
-		singleUserToken:  mainflux.Env(envSingleUserToken, defSingleUserToken),
-		clientTLS:        tls,
-		caCerts:          mainflux.Env(envCACerts, defCACerts),
-		channelID:        mainflux.Env(envChannelID, defChannelID),
-		subtopicWildcard: mainflux.Env(envSubtopicWildcard, defSubtopicWildcard),
-		natsURL:          mainflux.Env(envNatsURL, defNatsURL),
-		authnURL:         mainflux.Env(envAuthnURL, defAuthnURL),
-		authnTimeout:     authnTimeout,
+		logLevel:        mainflux.Env(envLogLevel, defLogLevel),
+		httpPort:        mainflux.Env(envHTTPPort, defHTTPPort),
+		serverCert:      mainflux.Env(envServerCert, defServerCert),
+		serverKey:       mainflux.Env(envServerKey, defServerKey),
+		jaegerURL:       mainflux.Env(envJaegerURL, defJaegerURL),
+		dbCfg:           dbCfg,
+		cacheURL:        mainflux.Env(envCacheURL, defCacheURL),
+		cachePass:       mainflux.Env(envCachePass, defCachePass),
+		cacheDB:         mainflux.Env(envCacheDB, defCacheDB),
+		singleUserEmail: mainflux.Env(envSingleUserEmail, defSingleUserEmail),
+		singleUserToken: mainflux.Env(envSingleUserToken, defSingleUserToken),
+		clientTLS:       tls,
+		caCerts:         mainflux.Env(envCACerts, defCACerts),
+		channelID:       mainflux.Env(envChannelID, defChannelID),
+		natsURL:         mainflux.Env(envNatsURL, defNatsURL),
+		authnURL:        mainflux.Env(envAuthnURL, defAuthnURL),
+		authnTimeout:    authnTimeout,
 	}
 }
 
@@ -266,8 +262,8 @@ func connectToRedis(cacheURL, cachePass, cacheDB string, logger logger.Logger) *
 	})
 }
 
-func newService(ps messaging.PubSub, chanID string, subtopicWildcard string, users mainflux.AuthNServiceClient, dbTracer opentracing.Tracer, db *mongo.Database, cacheTracer opentracing.Tracer, cacheClient *redis.Client, logger logger.Logger) twins.Service {
-	twinRepo := twmongodb.NewTwinRepository(db, subtopicWildcard)
+func newService(ps messaging.PubSub, chanID string, users mainflux.AuthNServiceClient, dbTracer opentracing.Tracer, db *mongo.Database, cacheTracer opentracing.Tracer, cacheClient *redis.Client, logger logger.Logger) twins.Service {
+	twinRepo := twmongodb.NewTwinRepository(db)
 	twinRepo = tracing.TwinRepositoryMiddleware(dbTracer, twinRepo)
 
 	stateRepo := twmongodb.NewStateRepository(db)
@@ -277,7 +273,7 @@ func newService(ps messaging.PubSub, chanID string, subtopicWildcard string, use
 	twinCache := rediscache.NewTwinCache(cacheClient)
 	twinCache = tracing.TwinCacheMiddleware(cacheTracer, twinCache)
 
-	svc := twins.New(ps, users, twinRepo, twinCache, stateRepo, up, chanID, subtopicWildcard, logger)
+	svc := twins.New(ps, users, twinRepo, twinCache, stateRepo, up, chanID, logger)
 	svc = api.LoggingMiddleware(svc, logger)
 	svc = api.MetricsMiddleware(
 		svc,

--- a/twins/README.md
+++ b/twins/README.md
@@ -27,7 +27,6 @@ default values.
 | MF_TWINS_CLIENT_TLS        | Flag that indicates if TLS should be turned on                       | false                 |
 | MF_TWINS_CA_CERTS          | Path to trusted CAs in PEM format                                    |                       |
 | MF_TWINS_CHANNEL_ID        | NATS notifications channel id                                        |                       |
-| MF_TWINS_SUBTOPIC_WILDCARD | Subtopic wildcard for attribute's definition                         | #                     |
 | MF_NATS_URL                | Mainflux NATS broker URL                                             | nats://localhost:4222 |
 | MF_AUTHN_GRPC_URL          | AuthN service gRPC URL                                               | localhost:8181        |
 | MF_AUTHN_GRPC_TIMEOUT      | AuthN service gRPC request timeout in seconds                        | 1s                    |
@@ -64,7 +63,6 @@ services:
       MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on]
       MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format]
       MF_TWINS_CHANNEL_ID: [NATS notifications channel id]
-      MF_TWINS_SUBTOPIC_WILDCARD: [Subtopic wildcard for attribute's definition]
       MF_NATS_URL: [Mainflux NATS broker URL]
       MF_AUTHN_GRPC_URL: [AuthN service gRPC URL]
       MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds]
@@ -101,7 +99,6 @@ MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode] \
 MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on] \
 MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format] \
 MF_TWINS_CHANNEL_ID: [NATS notifications channel id] \
-MF_TWINS_SUBTOPIC_WILDCARD: [Subtopic wildcard for attribute's definition] \
 MF_NATS_URL: [Mainflux NATS broker URL] \
 MF_AUTHN_GRPC_URL: [AuthN service gRPC URL] \
 MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds] \

--- a/twins/README.md
+++ b/twins/README.md
@@ -26,7 +26,7 @@ default values.
 | MF_TWINS_SINGLE_USER_TOKEN | User token for single user mode that should be passed in auth header |                       |
 | MF_TWINS_CLIENT_TLS        | Flag that indicates if TLS should be turned on                       | false                 |
 | MF_TWINS_CA_CERTS          | Path to trusted CAs in PEM format                                    |                       |
-| MF_TWINS_CHANNEL_ID        | NATS notifications channel id                                        |                       |
+| MF_TWINS_CHANNEL_ID        | NATS notifications channel ID                                        |                       |
 | MF_NATS_URL                | Mainflux NATS broker URL                                             | nats://localhost:4222 |
 | MF_AUTHN_GRPC_URL          | AuthN service gRPC URL                                               | localhost:8181        |
 | MF_AUTHN_GRPC_TIMEOUT      | AuthN service gRPC request timeout in seconds                        | 1s                    |
@@ -62,7 +62,7 @@ services:
       MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode]
       MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on]
       MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format]
-      MF_TWINS_CHANNEL_ID: [NATS notifications channel id]
+      MF_TWINS_CHANNEL_ID: [NATS notifications channel ID]
       MF_NATS_URL: [Mainflux NATS broker URL]
       MF_AUTHN_GRPC_URL: [AuthN service gRPC URL]
       MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds]
@@ -98,7 +98,7 @@ MF_TWINS_SINGLE_USER_EMAIL: [User email for single user mode] \
 MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode] \
 MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on] \
 MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format] \
-MF_TWINS_CHANNEL_ID: [NATS notifications channel id] \
+MF_TWINS_CHANNEL_ID: [NATS notifications channel ID] \
 MF_NATS_URL: [Mainflux NATS broker URL] \
 MF_AUTHN_GRPC_URL: [AuthN service gRPC URL] \
 MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds] \
@@ -115,7 +115,7 @@ stands for the crud operation done on twin - create, update, delete or
 retrieve - or state - save state. In order to use twin service notifications,
 one must inform it - via environment variables - about the Mainflux channel used
 for notification publishing. You must use an already existing channel, since you
-cannot know in advance or set the channel id (Mainflux does it automatically).
+cannot know in advance or set the channel ID (Mainflux does it automatically).
 
 To set the environment variable, please go to `.env` file and set the following
 variable:

--- a/twins/README.md
+++ b/twins/README.md
@@ -26,11 +26,11 @@ default values.
 | MF_TWINS_SINGLE_USER_TOKEN | User token for single user mode that should be passed in auth header |                       |
 | MF_TWINS_CLIENT_TLS        | Flag that indicates if TLS should be turned on                       | false                 |
 | MF_TWINS_CA_CERTS          | Path to trusted CAs in PEM format                                    |                       |
-| MF_TWINS_MQTT_URL          | Mqtt broker URL for twin CRUD and states update notifications        | tcp://localhost:1883  |
-| MF_TWINS_CHANNEL_ID        | Mqtt notifications topic                                             |                       |
+| MF_TWINS_CHANNEL_ID        | NATS notifications channel id                                        |                       |
+| MF_TWINS_SUBTOPIC_WILDCARD | Subtopic wildcard for attribute's definition                         | #                     |
 | MF_NATS_URL                | Mainflux NATS broker URL                                             | nats://localhost:4222 |
 | MF_AUTHN_GRPC_URL          | AuthN service gRPC URL                                               | localhost:8181        |
-| MF_AUTHN_GRPC_TIMEOUT      | AuthN service gRPC request timeout in seconds                        | 1s                     |
+| MF_AUTHN_GRPC_TIMEOUT      | AuthN service gRPC request timeout in seconds                        | 1s                    |
 | MF_TWINS_CACHE_URL         | Cache database URL                                                   | localhost:6379        |
 | MF_TWINS_CACHE_PASS        | Cache database password                                              |                       |
 | MF_TWINS_CACHE_DB          | Cache instance name                                                  | 0                     |
@@ -63,8 +63,8 @@ services:
       MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode]
       MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on]
       MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format]
-      MF_TWINS_MQTT_URL: [Mqtt broker URL for twin CRUD and states]
-      MF_TWINS_CHANNEL_ID: [Mqtt notifications topic]
+      MF_TWINS_CHANNEL_ID: [NATS notifications channel id]
+      MF_TWINS_SUBTOPIC_WILDCARD: [Subtopic wildcard for attribute's definition]
       MF_NATS_URL: [Mainflux NATS broker URL]
       MF_AUTHN_GRPC_URL: [AuthN service gRPC URL]
       MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds]
@@ -100,8 +100,8 @@ MF_TWINS_SINGLE_USER_EMAIL: [User email for single user mode] \
 MF_TWINS_SINGLE_USER_TOKEN: [User token for single user mode] \
 MF_TWINS_CLIENT_TLS: [Flag that indicates if TLS should be turned on] \
 MF_TWINS_CA_CERTS: [Path to trusted CAs in PEM format] \
-MF_TWINS_MQTT_URL: [Mqtt broker URL for twin CRUD and states] \
-MF_TWINS_CHANNEL_ID: [Mqtt notifications topic] \
+MF_TWINS_CHANNEL_ID: [NATS notifications channel id] \
+MF_TWINS_SUBTOPIC_WILDCARD: [Subtopic wildcard for attribute's definition] \
 MF_NATS_URL: [Mainflux NATS broker URL] \
 MF_AUTHN_GRPC_URL: [AuthN service gRPC URL] \
 MF_AUTHN_GRPC_TIMEOUT: [AuthN service gRPC request timeout in seconds] \

--- a/twins/mocks/service.go
+++ b/twins/mocks/service.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/mainflux/mainflux/pkg/messaging"
@@ -11,6 +12,8 @@ import (
 )
 
 const publisher = "twins"
+
+var id = 0
 
 // NewService use mock dependencies to create real twins service
 func NewService(tokens map[string]string) twins.Service {
@@ -36,6 +39,15 @@ func CreateDefinition(channels []string, subtopics []string) twins.Definition {
 		def.Attributes = append(def.Attributes, attr)
 	}
 	return def
+}
+
+// CreateTwin creates twin
+func CreateTwin(channels []string, subtopics []string) twins.Twin {
+	id++
+	return twins.Twin{
+		ID:          strconv.Itoa(id),
+		Definitions: []twins.Definition{CreateDefinition(channels, subtopics)},
+	}
 }
 
 // CreateSenML creates SenML record array

--- a/twins/mocks/service.go
+++ b/twins/mocks/service.go
@@ -21,7 +21,7 @@ func NewService(tokens map[string]string) twins.Service {
 	uuidProvider := uuid.NewMock()
 	subs := map[string]string{"chanID": "chanID"}
 	broker := NewBroker(subs)
-	return twins.New(broker, auth, twinsRepo, twinCache, statesRepo, uuidProvider, "chanID", "#", nil)
+	return twins.New(broker, auth, twinsRepo, twinCache, statesRepo, uuidProvider, "chanID", nil)
 }
 
 // CreateDefinition creates twin definition

--- a/twins/mocks/service.go
+++ b/twins/mocks/service.go
@@ -21,7 +21,7 @@ func NewService(tokens map[string]string) twins.Service {
 	uuidProvider := uuid.NewMock()
 	subs := map[string]string{"chanID": "chanID"}
 	broker := NewBroker(subs)
-	return twins.New(broker, auth, twinsRepo, twinCache, statesRepo, uuidProvider, "chanID", nil)
+	return twins.New(broker, auth, twinsRepo, twinCache, statesRepo, uuidProvider, "chanID", "#", nil)
 }
 
 // CreateDefinition creates twin definition

--- a/twins/mocks/states.go
+++ b/twins/mocks/states.go
@@ -55,12 +55,11 @@ func (srm *stateRepositoryMock) RetrieveAll(ctx context.Context, offset uint64, 
 	srm.mu.Lock()
 	defer srm.mu.Unlock()
 
-	items := make([]twins.State, 0)
-
 	if limit <= 0 {
 		return twins.StatesPage{}, nil
 	}
 
+	var items []twins.State
 	for k, v := range srm.states {
 		if (uint64)(len(items)) >= limit {
 			break
@@ -78,17 +77,26 @@ func (srm *stateRepositoryMock) RetrieveAll(ctx context.Context, offset uint64, 
 		return items[i].ID < items[j].ID
 	})
 
-	total := uint64(len(srm.states))
 	page := twins.StatesPage{
 		States: items,
 		PageMetadata: twins.PageMetadata{
-			Total:  total,
+			Total:  srm.total(twinID),
 			Offset: offset,
 			Limit:  limit,
 		},
 	}
 
 	return page, nil
+}
+
+func (srm *stateRepositoryMock) total(twinID string) uint64 {
+	var total uint64
+	for k := range srm.states {
+		if strings.HasPrefix(k, twinID) {
+			total++
+		}
+	}
+	return total
 }
 
 // RetrieveLast returns the last state related to twin spec by id

--- a/twins/mocks/twins.go
+++ b/twins/mocks/twins.go
@@ -81,11 +81,7 @@ func (trm *twinRepositoryMock) RetrieveByAttribute(ctx context.Context, channel,
 			}
 		}
 	}
-
-	if len(ids) > 0 {
-		return ids, nil
-	}
-	return ids, twins.ErrNotFound
+	return ids, nil
 }
 
 func (trm *twinRepositoryMock) RetrieveAll(_ context.Context, owner string, offset uint64, limit uint64, name string, metadata twins.Metadata) (twins.Page, error) {

--- a/twins/mocks/twins.go
+++ b/twins/mocks/twins.go
@@ -75,7 +75,7 @@ func (trm *twinRepositoryMock) RetrieveByAttribute(ctx context.Context, channel,
 	for _, twin := range trm.twins {
 		def := twin.Definitions[len(twin.Definitions)-1]
 		for _, attr := range def.Attributes {
-			if attr.Channel == channel && attr.Subtopic == subtopic {
+			if attr.Channel == channel && (attr.Subtopic == "#" || attr.Subtopic == subtopic) {
 				ids = append(ids, twin.ID)
 				break
 			}
@@ -215,12 +215,10 @@ func (tcm *twinCacheMock) IDs(_ context.Context, channel, subtopic string) ([]st
 
 	var ids []string
 
-	idsMap, ok := tcm.attrIds[channel+subtopic]
-	if !ok {
-		return ids, nil
+	for k := range tcm.attrIds[channel+subtopic] {
+		ids = append(ids, k)
 	}
-
-	for k := range idsMap {
+	for k := range tcm.attrIds[channel+"#"] {
 		ids = append(ids, k)
 	}
 

--- a/twins/mocks/twins.go
+++ b/twins/mocks/twins.go
@@ -75,7 +75,7 @@ func (trm *twinRepositoryMock) RetrieveByAttribute(ctx context.Context, channel,
 	for _, twin := range trm.twins {
 		def := twin.Definitions[len(twin.Definitions)-1]
 		for _, attr := range def.Attributes {
-			if attr.Channel == channel && (attr.Subtopic == "#" || attr.Subtopic == subtopic) {
+			if attr.Channel == channel && (attr.Subtopic == twins.SubtopicWildcard || attr.Subtopic == subtopic) {
 				ids = append(ids, twin.ID)
 				break
 			}
@@ -218,7 +218,7 @@ func (tcm *twinCacheMock) IDs(_ context.Context, channel, subtopic string) ([]st
 	for k := range tcm.attrIds[channel+subtopic] {
 		ids = append(ids, k)
 	}
-	for k := range tcm.attrIds[channel+"#"] {
+	for k := range tcm.attrIds[channel+twins.SubtopicWildcard] {
 		ids = append(ids, k)
 	}
 

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -18,15 +18,17 @@ const (
 )
 
 type twinRepository struct {
-	db *mongo.Database
+	db               *mongo.Database
+	subtopicWildcard string
 }
 
 var _ twins.TwinRepository = (*twinRepository)(nil)
 
 // NewTwinRepository instantiates a MongoDB implementation of twin repository.
-func NewTwinRepository(db *mongo.Database) twins.TwinRepository {
+func NewTwinRepository(db *mongo.Database, sw string) twins.TwinRepository {
 	return &twinRepository{
-		db: db,
+		db:               db,
+		subtopicWildcard: sw,
 	}
 }
 

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -25,10 +25,9 @@ type twinRepository struct {
 var _ twins.TwinRepository = (*twinRepository)(nil)
 
 // NewTwinRepository instantiates a MongoDB implementation of twin repository.
-func NewTwinRepository(db *mongo.Database, sw string) twins.TwinRepository {
+func NewTwinRepository(db *mongo.Database) twins.TwinRepository {
 	return &twinRepository{
-		db:               db,
-		subtopicWildcard: sw,
+		db: db,
 	}
 }
 
@@ -97,7 +96,7 @@ func (tr *twinRepository) RetrieveByAttribute(ctx context.Context, channel, subt
 			"definition.channel": channel,
 			"$or": []interface{}{
 				bson.M{"definition.subtopic": subtopic},
-				bson.M{"definition.subtopic": "#"},
+				bson.M{"definition.subtopic": twins.SubtopicWildcard},
 			},
 		},
 	}

--- a/twins/mongodb/twins.go
+++ b/twins/mongodb/twins.go
@@ -92,8 +92,11 @@ func (tr *twinRepository) RetrieveByAttribute(ctx context.Context, channel, subt
 	}
 	match := bson.M{
 		"$match": bson.M{
-			"definition.channel":  channel,
-			"definition.subtopic": subtopic,
+			"definition.channel": channel,
+			"$or": []interface{}{
+				bson.M{"definition.subtopic": subtopic},
+				bson.M{"definition.subtopic": "#"},
+			},
 		},
 	}
 	prj2 := bson.M{

--- a/twins/mongodb/twins_test.go
+++ b/twins/mongodb/twins_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	log "github.com/mainflux/mainflux/logger"
+	uuidProvider "github.com/mainflux/mainflux/pkg/uuid"
 	"github.com/mainflux/mainflux/twins"
 	"github.com/mainflux/mainflux/twins/mongodb"
-	uuidProvider "github.com/mainflux/mainflux/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -28,6 +28,7 @@ const (
 	collection  = "twins"
 	email       = "mfx_twin@example.com"
 	validName   = "mfx_twin"
+	wildcard    = "#"
 )
 
 var (
@@ -44,7 +45,7 @@ func TestTwinsSave(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
 
 	db := client.Database(testDB)
-	repo := mongodb.NewTwinRepository(db)
+	repo := mongodb.NewTwinRepository(db, wildcard)
 
 	twid, err := uuid.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -89,7 +90,7 @@ func TestTwinsUpdate(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
 
 	db := client.Database(testDB)
-	repo := mongodb.NewTwinRepository(db)
+	repo := mongodb.NewTwinRepository(db, wildcard)
 
 	twid, err := uuid.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -146,7 +147,7 @@ func TestTwinsRetrieveByID(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
 
 	db := client.Database(testDB)
-	repo := mongodb.NewTwinRepository(db)
+	repo := mongodb.NewTwinRepository(db, wildcard)
 
 	twid, err := uuid.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -201,7 +202,7 @@ func TestTwinsRetrieveAll(t *testing.T) {
 	db := client.Database(testDB)
 	db.Collection(collection).DeleteMany(context.Background(), bson.D{})
 
-	twinRepo := mongodb.NewTwinRepository(db)
+	twinRepo := mongodb.NewTwinRepository(db, wildcard)
 
 	n := uint64(10)
 	for i := uint64(0); i < n; i++ {
@@ -296,7 +297,7 @@ func TestTwinsRemove(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Creating new MongoDB client expected to succeed: %s.\n", err))
 
 	db := client.Database(testDB)
-	repo := mongodb.NewTwinRepository(db)
+	repo := mongodb.NewTwinRepository(db, wildcard)
 
 	twid, err := uuid.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))

--- a/twins/mongodb/twins_test.go
+++ b/twins/mongodb/twins_test.go
@@ -29,6 +29,7 @@ const (
 	collection  = "twins"
 	email       = "mfx_twin@example.com"
 	validName   = "mfx_twin"
+	subtopic    = "engine"
 )
 
 var (
@@ -193,26 +194,18 @@ func TestTwinsRetrieveByAttribute(t *testing.T) {
 	db := client.Database(testDB)
 	repo := mongodb.NewTwinRepository(db)
 
-	tws := make(map[string]twins.Twin, 3)
 	chID, err := uuid.ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	empty, wildcard, nonEmpty := "empty", "wildcard", "nonEmpty"
-	tws[empty] = twins.Twin{
-		ID:          empty,
-		Definitions: []twins.Definition{mocks.CreateDefinition([]string{chID}, []string{""})},
-	}
-	tws[wildcard] = twins.Twin{
-		ID:          wildcard,
-		Definitions: []twins.Definition{mocks.CreateDefinition([]string{chID}, []string{twins.SubtopicWildcard})},
-	}
-	tws[nonEmpty] = twins.Twin{
-		ID:          nonEmpty,
-		Definitions: []twins.Definition{mocks.CreateDefinition([]string{chID}, []string{nonEmpty})},
-	}
-	for _, tw := range tws {
-		_, err = repo.Save(context.Background(), tw)
-		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	}
+
+	empty := mocks.CreateTwin([]string{chID}, []string{""})
+	_, err = repo.Save(context.Background(), empty)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	wildcard := mocks.CreateTwin([]string{chID}, []string{twins.SubtopicWildcard})
+	_, err = repo.Save(context.Background(), wildcard)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	nonEmpty := mocks.CreateTwin([]string{chID}, []string{subtopic})
+	_, err = repo.Save(context.Background(), nonEmpty)
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	cases := []struct {
 		desc     string
@@ -222,17 +215,17 @@ func TestTwinsRetrieveByAttribute(t *testing.T) {
 		{
 			desc:     "retrieve empty subtopic",
 			subtopic: "",
-			ids:      []string{wildcard, empty},
+			ids:      []string{wildcard.ID, empty.ID},
 		},
 		{
 			desc:     "retrieve wildcard subtopic",
 			subtopic: twins.SubtopicWildcard,
-			ids:      []string{wildcard},
+			ids:      []string{wildcard.ID},
 		},
 		{
 			desc:     "retrieve non-empty subtopic",
-			subtopic: nonEmpty,
-			ids:      []string{wildcard, nonEmpty},
+			subtopic: subtopic,
+			ids:      []string{wildcard.ID, nonEmpty.ID},
 		},
 	}
 

--- a/twins/redis/twins.go
+++ b/twins/redis/twins.go
@@ -74,6 +74,11 @@ func (tc *twinCache) IDs(_ context.Context, channel, subtopic string) ([]string,
 	if err != nil {
 		return nil, errors.Wrap(ErrRedisTwinIDs, err)
 	}
+	idsWildcard, err := tc.client.SMembers(attrKey(channel, "#")).Result()
+	if err != nil {
+		return nil, errors.Wrap(ErrRedisTwinIDs, err)
+	}
+	ids = append(ids, idsWildcard...)
 	return ids, nil
 }
 

--- a/twins/redis/twins.go
+++ b/twins/redis/twins.go
@@ -74,7 +74,7 @@ func (tc *twinCache) IDs(_ context.Context, channel, subtopic string) ([]string,
 	if err != nil {
 		return nil, errors.Wrap(ErrRedisTwinIDs, err)
 	}
-	idsWildcard, err := tc.client.SMembers(attrKey(channel, "#")).Result()
+	idsWildcard, err := tc.client.SMembers(attrKey(channel, twins.SubtopicWildcard)).Result()
 	if err != nil {
 		return nil, errors.Wrap(ErrRedisTwinIDs, err)
 	}

--- a/twins/service.go
+++ b/twins/service.go
@@ -362,7 +362,7 @@ func prepareState(st *State, tw *Twin, rec senml.Record, msg *messaging.Message)
 		if !attr.PersistState {
 			continue
 		}
-		if attr.Channel == msg.Channel && attr.Subtopic == msg.Subtopic {
+		if attr.Channel == msg.Channel && (attr.Subtopic == "#" || attr.Subtopic == msg.Subtopic) {
 			action = update
 			delta := math.Abs(float64(st.Created.UnixNano()) - recNano)
 			if recNano == 0 || delta > float64(def.Delta) {

--- a/twins/service.go
+++ b/twins/service.go
@@ -70,8 +70,9 @@ const (
 	noop = iota
 	update
 	save
-	millisec = 1e6
-	nanosec  = 1e9
+	millisec         = 1e6
+	nanosec          = 1e9
+	SubtopicWildcard = ">"
 )
 
 var crudOp = map[string]string{
@@ -88,31 +89,29 @@ var crudOp = map[string]string{
 }
 
 type twinsService struct {
-	publisher        messaging.Publisher
-	auth             mainflux.AuthNServiceClient
-	twins            TwinRepository
-	states           StateRepository
-	uuidProvider     mainflux.UUIDProvider
-	channelID        string
-	subtopicWildcard string
-	twinCache        TwinCache
-	logger           logger.Logger
+	publisher    messaging.Publisher
+	auth         mainflux.AuthNServiceClient
+	twins        TwinRepository
+	states       StateRepository
+	uuidProvider mainflux.UUIDProvider
+	channelID    string
+	twinCache    TwinCache
+	logger       logger.Logger
 }
 
 var _ Service = (*twinsService)(nil)
 
 // New instantiates the twins service implementation.
-func New(publisher messaging.Publisher, auth mainflux.AuthNServiceClient, twins TwinRepository, tcache TwinCache, sr StateRepository, idp mainflux.UUIDProvider, chann string, sw string, logger logger.Logger) Service {
+func New(publisher messaging.Publisher, auth mainflux.AuthNServiceClient, twins TwinRepository, tcache TwinCache, sr StateRepository, idp mainflux.UUIDProvider, chann string, logger logger.Logger) Service {
 	return &twinsService{
-		publisher:        publisher,
-		auth:             auth,
-		twins:            twins,
-		twinCache:        tcache,
-		states:           sr,
-		uuidProvider:     idp,
-		subtopicWildcard: sw,
-		channelID:        chann,
-		logger:           logger,
+		publisher:    publisher,
+		auth:         auth,
+		twins:        twins,
+		twinCache:    tcache,
+		states:       sr,
+		uuidProvider: idp,
+		channelID:    chann,
+		logger:       logger,
 	}
 }
 
@@ -364,7 +363,7 @@ func (ts *twinsService) prepareState(st *State, tw *Twin, rec senml.Record, msg 
 		if !attr.PersistState {
 			continue
 		}
-		if attr.Channel == msg.Channel && (attr.Subtopic == ts.subtopicWildcard || attr.Subtopic == msg.Subtopic) {
+		if attr.Channel == msg.Channel && (attr.Subtopic == SubtopicWildcard || attr.Subtopic == msg.Subtopic) {
 			action = update
 			delta := math.Abs(float64(st.Created.UnixNano()) - recNano)
 			if recNano == 0 || delta > float64(def.Delta) {

--- a/twins/service.go
+++ b/twins/service.go
@@ -88,29 +88,31 @@ var crudOp = map[string]string{
 }
 
 type twinsService struct {
-	publisher    messaging.Publisher
-	auth         mainflux.AuthNServiceClient
-	twins        TwinRepository
-	states       StateRepository
-	uuidProvider mainflux.UUIDProvider
-	channelID    string
-	twinCache    TwinCache
-	logger       logger.Logger
+	publisher        messaging.Publisher
+	auth             mainflux.AuthNServiceClient
+	twins            TwinRepository
+	states           StateRepository
+	uuidProvider     mainflux.UUIDProvider
+	channelID        string
+	subtopicWildcard string
+	twinCache        TwinCache
+	logger           logger.Logger
 }
 
 var _ Service = (*twinsService)(nil)
 
 // New instantiates the twins service implementation.
-func New(publisher messaging.Publisher, auth mainflux.AuthNServiceClient, twins TwinRepository, tcache TwinCache, sr StateRepository, idp mainflux.UUIDProvider, chann string, logger logger.Logger) Service {
+func New(publisher messaging.Publisher, auth mainflux.AuthNServiceClient, twins TwinRepository, tcache TwinCache, sr StateRepository, idp mainflux.UUIDProvider, chann string, sw string, logger logger.Logger) Service {
 	return &twinsService{
-		publisher:    publisher,
-		auth:         auth,
-		twins:        twins,
-		twinCache:    tcache,
-		states:       sr,
-		uuidProvider: idp,
-		channelID:    chann,
-		logger:       logger,
+		publisher:        publisher,
+		auth:             auth,
+		twins:            twins,
+		twinCache:        tcache,
+		states:           sr,
+		uuidProvider:     idp,
+		subtopicWildcard: sw,
+		channelID:        chann,
+		logger:           logger,
 	}
 }
 
@@ -314,7 +316,7 @@ func (ts *twinsService) saveState(msg *messaging.Message, twinID string) error {
 	}
 
 	for _, rec := range recs {
-		action := prepareState(&st, &tw, rec, msg)
+		action := ts.prepareState(&st, &tw, rec, msg)
 		switch action {
 		case noop:
 			return nil
@@ -335,7 +337,7 @@ func (ts *twinsService) saveState(msg *messaging.Message, twinID string) error {
 	return nil
 }
 
-func prepareState(st *State, tw *Twin, rec senml.Record, msg *messaging.Message) int {
+func (ts *twinsService) prepareState(st *State, tw *Twin, rec senml.Record, msg *messaging.Message) int {
 	def := tw.Definitions[len(tw.Definitions)-1]
 	st.TwinID = tw.ID
 	st.Definition = def.ID
@@ -362,7 +364,7 @@ func prepareState(st *State, tw *Twin, rec senml.Record, msg *messaging.Message)
 		if !attr.PersistState {
 			continue
 		}
-		if attr.Channel == msg.Channel && (attr.Subtopic == "#" || attr.Subtopic == msg.Subtopic) {
+		if attr.Channel == msg.Channel && (attr.Subtopic == ts.subtopicWildcard || attr.Subtopic == msg.Subtopic) {
 			action = update
 			delta := math.Abs(float64(st.Created.UnixNano()) - recNano)
 			if recNano == 0 || delta > float64(def.Delta) {

--- a/twins/service_test.go
+++ b/twins/service_test.go
@@ -253,6 +253,10 @@ func TestSaveStates(t *testing.T) {
 	tw, err := svc.AddTwin(context.Background(), token, twin, def)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
+	defWildcard := mocks.CreateDefinition(channels[0:2], []string{twins.SubtopicWildcard, twins.SubtopicWildcard})
+	twWildcard, err := svc.AddTwin(context.Background(), token, twin, defWildcard)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+
 	var recs = make([]senml.Record, numRecs)
 	mocks.CreateSenML(numRecs, recs)
 
@@ -300,10 +304,14 @@ func TestSaveStates(t *testing.T) {
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		err = svc.SaveStates(message)
-		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 		ttlAdded += tc.size
 		page, err := svc.ListStates(context.TODO(), token, 0, 10, tw.ID)
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+		assert.Equal(t, ttlAdded, page.Total, fmt.Sprintf("%s: expected %d total got %d total\n", tc.desc, ttlAdded, page.Total))
+
+		page, err = svc.ListStates(context.TODO(), token, 0, 10, twWildcard.ID)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		assert.Equal(t, ttlAdded, page.Total, fmt.Sprintf("%s: expected %d total got %d total\n", tc.desc, ttlAdded, page.Total))
 	}


### PR DESCRIPTION
### What does this do?
Twin stores semantic definition of a data system. Such definition consists of attributes which are uniquely defined by the combination of channel and subtopic. Currently, we can only define attribute to match the combination of an empty or non-empty subtopic and channel. However, we don't have means to define attribute to match all the combinations of a certain channel and subtopics, i.e. we don't have means to store to states all message of a channel irrespective of the subtopic used to send messages. Adition of a wildcard subtopic enables attribute to pick up all messages sent via it's channel.

### List any changes that modify/break current functionality
N/A

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
Yes