### PR TITLE
NOISUE - Fix cache error when key is not in Redis

### DIFF
--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -398,6 +398,10 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 		case errors.Contains(errorVal, errInvalidQueryParams):
 			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, things.ErrRemoveThing):
+			w.WriteHeader(http.StatusInternalServerError)
+		case errors.Contains(errorVal, things.ErrRemoveChannel):
+			w.WriteHeader(http.StatusInternalServerError)
 		case errors.Contains(errorVal, io.ErrUnexpectedEOF):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, io.EOF):

--- a/things/redis/channels.go
+++ b/things/redis/channels.go
@@ -14,14 +14,16 @@ import (
 
 const chanPrefix = "channel"
 
-// ErrRedisConnectChannel indicates error while adding connection in redis cache
-var ErrRedisConnectChannel = errors.New("add connection to redis cache error")
+var (
+	// ErrRedisConnectChannel indicates error while adding connection in redis cache
+	ErrRedisConnectChannel = errors.New("failed to add connection to redis cache")
 
-// ErrRedisDisconnectChannel indicates error while removing connection from redis cache
-var ErrRedisDisconnectChannel = errors.New("remove connection from redis cache error")
+	// ErrRedisDisconnectChannel indicates error while removing connection from redis cache
+	ErrRedisDisconnectChannel = errors.New("failed to remove connection from redis cache")
 
-// ErrRedisRemoveChannel indicates error while removing channel from redis cache
-var ErrRedisRemoveChannel = errors.New("remove channel from redis cache error")
+	// ErrRedisRemoveChannel indicates error while removing channel from redis cache
+	ErrRedisRemoveChannel = errors.New("failed to remove channel from redis cache")
+)
 
 var _ things.ChannelCache = (*channelCache)(nil)
 

--- a/things/redis/things.go
+++ b/things/redis/things.go
@@ -19,13 +19,13 @@ const (
 
 var (
 	// ErrRedisThingSave indicates error while saving Thing in redis cache
-	ErrRedisThingSave = errors.New("saving thing in redis cache error")
+	ErrRedisThingSave = errors.New("failed to save thing in redis cache")
 
 	// ErrRedisThingID indicates error while geting Thing ID from redis cache
-	ErrRedisThingID = errors.New("get thing id from redis cache error")
+	ErrRedisThingID = errors.New("failed to get thing id from redis cache")
 
 	// ErrRedisThingRemove indicates error while removing Thing from redis cache
-	ErrRedisThingRemove = errors.New("remove thing from redis cache error")
+	ErrRedisThingRemove = errors.New("failed to remove thing from redis cache")
 )
 
 var _ things.ThingCache = (*thingCache)(nil)

--- a/things/redis/things.go
+++ b/things/redis/things.go
@@ -17,14 +17,16 @@ const (
 	idPrefix  = "thing"
 )
 
-// ErrRedisThingSave indicates error while saving Thing in redis cache
-var ErrRedisThingSave = errors.New("saving thing in redis cache error")
+var (
+	// ErrRedisThingSave indicates error while saving Thing in redis cache
+	ErrRedisThingSave = errors.New("saving thing in redis cache error")
 
-// ErrRedisThingID indicates error while geting Thing ID from redis cache
-var ErrRedisThingID = errors.New("get thing id from redis cache error")
+	// ErrRedisThingID indicates error while geting Thing ID from redis cache
+	ErrRedisThingID = errors.New("get thing id from redis cache error")
 
-// ErrRedisThingRemove indicates error while removing Thing from redis cache
-var ErrRedisThingRemove = errors.New("remove thing from redis cache error")
+	// ErrRedisThingRemove indicates error while removing Thing from redis cache
+	ErrRedisThingRemove = errors.New("remove thing from redis cache error")
+)
 
 var _ things.ThingCache = (*thingCache)(nil)
 
@@ -65,6 +67,10 @@ func (tc *thingCache) ID(_ context.Context, thingKey string) (string, error) {
 func (tc *thingCache) Remove(_ context.Context, thingID string) error {
 	tid := fmt.Sprintf("%s:%s", idPrefix, thingID)
 	key, err := tc.client.Get(tid).Result()
+	// Redis returns Nil Reply when key does not exist.
+	if err == redis.Nil {
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(ErrRedisThingRemove, err)
 	}

--- a/things/redis/things_test.go
+++ b/things/redis/things_test.go
@@ -10,8 +10,8 @@ import (
 
 	r "github.com/go-redis/redis"
 	"github.com/mainflux/mainflux/pkg/errors"
-	"github.com/mainflux/mainflux/things/redis"
 	"github.com/mainflux/mainflux/pkg/uuid"
+	"github.com/mainflux/mainflux/things/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,7 +108,7 @@ func TestThingRemove(t *testing.T) {
 		{
 			desc: "Remove non-existing thing from cache",
 			ID:   id2,
-			err:  r.Nil,
+			err:  nil,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes an error Things service throws in case that key is not present in Redis. In that case, Redis returns an error, which is actually nil but is not nil type.

### Which issue(s) does this PR fix/relate to?
There is no such issue.

### List any changes that modify/break current functionality
There are no changes that modify current functionality.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No.