### PR TITLE
NOISSUE - Introduce additional group retrieve methods

### DIFF
--- a/users/api/endpoint.go
+++ b/users/api/endpoint.go
@@ -271,7 +271,14 @@ func listGroupsEndpoint(svc users.Service) endpoint.Endpoint {
 		if err := req.validate(); err != nil {
 			return groupPageRes{}, err
 		}
-		gp, err := svc.Groups(ctx, req.token, req.groupID, req.offset, req.limit, req.metadata)
+		if req.groupID == "" {
+			gp, err := svc.Groups(ctx, req.token, req.offset, req.limit, req.metadata)
+			if err != nil {
+				return groupPageRes{}, err
+			}
+			return buildGroupsResponse(gp), nil
+		}
+		gp, err := svc.GroupsChildren(ctx, req.token, req.groupID, req.offset, req.limit, req.metadata)
 		if err != nil {
 			return groupPageRes{}, err
 		}

--- a/users/api/logging.go
+++ b/users/api/logging.go
@@ -129,7 +129,7 @@ func (lm *loggingMiddleware) SendPasswordReset(ctx context.Context, host, email,
 	return lm.svc.SendPasswordReset(ctx, host, email, token)
 }
 
-func (lm *loggingMiddleware) CreateGroup(ctx context.Context, token string, group users.Group) (u users.Group, err error) {
+func (lm *loggingMiddleware) CreateGroup(ctx context.Context, token string, group users.Group) (gp users.Group, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_group with name %s took %s to complete", group.Name, time.Since(begin))
 		if err != nil {
@@ -142,9 +142,9 @@ func (lm *loggingMiddleware) CreateGroup(ctx context.Context, token string, grou
 	return lm.svc.CreateGroup(ctx, token, group)
 }
 
-func (lm *loggingMiddleware) Groups(ctx context.Context, token, id string, offset, limit uint64, meta users.Metadata) (e users.GroupPage, err error) {
+func (lm *loggingMiddleware) Groups(ctx context.Context, token string, offset, limit uint64, meta users.Metadata) (gp users.GroupPage, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method groups for parent %s took %s to complete", id, time.Since(begin))
+		message := fmt.Sprintf("Method groups for token %s took %s to complete", token, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
@@ -152,10 +152,36 @@ func (lm *loggingMiddleware) Groups(ctx context.Context, token, id string, offse
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.Groups(ctx, token, id, offset, limit, meta)
+	return lm.svc.Groups(ctx, token, offset, limit, meta)
 }
 
-func (lm *loggingMiddleware) Members(ctx context.Context, token, id string, offset, limit uint64, meta users.Metadata) (e users.UserPage, err error) {
+func (lm *loggingMiddleware) GroupsChildren(ctx context.Context, token, groupID string, offset, limit uint64, meta users.Metadata) (gp users.GroupPage, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method groups_children for parent %s took %s to complete", groupID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.GroupsChildren(ctx, token, groupID, offset, limit, meta)
+}
+
+func (lm *loggingMiddleware) GroupsAncestors(ctx context.Context, token, groupID string, offset, limit uint64, meta users.Metadata) (gp users.GroupPage, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method groups_ancestors for group %s took %s to complete", groupID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.GroupsAncestors(ctx, token, groupID, offset, limit, meta)
+}
+
+func (lm *loggingMiddleware) Members(ctx context.Context, token, id string, offset, limit uint64, meta users.Metadata) (gp users.UserPage, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method members for parent %s took %s to complete", id, time.Since(begin))
 		if err != nil {

--- a/users/api/metrics.go
+++ b/users/api/metrics.go
@@ -110,13 +110,31 @@ func (ms *metricsMiddleware) CreateGroup(ctx context.Context, token string, grou
 	return ms.svc.CreateGroup(ctx, token, group)
 }
 
-func (ms *metricsMiddleware) Groups(ctx context.Context, token, id string, offset, limit uint64, meta users.Metadata) (users.GroupPage, error) {
+func (ms *metricsMiddleware) Groups(ctx context.Context, token string, offset, limit uint64, meta users.Metadata) (users.GroupPage, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "groups").Add(1)
 		ms.latency.With("method", "groups").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.Groups(ctx, token, id, offset, limit, meta)
+	return ms.svc.Groups(ctx, token, offset, limit, meta)
+}
+
+func (ms *metricsMiddleware) GroupsChildren(ctx context.Context, token, groupID string, offset, limit uint64, meta users.Metadata) (users.GroupPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "groups_children").Add(1)
+		ms.latency.With("method", "groups_children").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.GroupsChildren(ctx, token, groupID, offset, limit, meta)
+}
+
+func (ms *metricsMiddleware) GroupsAncestors(ctx context.Context, token, groupID string, offset, limit uint64, meta users.Metadata) (users.GroupPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "groups_ancestors").Add(1)
+		ms.latency.With("method", "groups_ancestors").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.GroupsAncestors(ctx, token, groupID, offset, limit, meta)
 }
 
 func (ms *metricsMiddleware) Members(ctx context.Context, token, id string, offset, limit uint64, meta users.Metadata) (users.UserPage, error) {

--- a/users/groups.go
+++ b/users/groups.go
@@ -31,11 +31,17 @@ type GroupRepository interface {
 	// RetrieveByID retrieves group by its unique identifier.
 	RetrieveByID(ctx context.Context, id string) (Group, error)
 
-	// RetrieveByName retrieves group by name
+	// RetrieveByName retrieves group by name.
 	RetrieveByName(ctx context.Context, name string) (Group, error)
 
-	// RetrieveAllWithAncestors retrieves all groups if groupID == "",  if groupID is specified returns children groups
-	RetrieveAllWithAncestors(ctx context.Context, groupID string, offset, limit uint64, gm Metadata) (GroupPage, error)
+	// RetrieveAll retrieves all groups.
+	RetrieveAll(ctx context.Context, offset, limit uint64, gm Metadata) (GroupPage, error)
+
+	// RetrieveAllAncestors retrieves all groups that are ancestors to the group with given groupID.
+	RetrieveAllAncestors(ctx context.Context, groupID string, offset, limit uint64, gm Metadata) (GroupPage, error)
+
+	// RetrieveAllChildren retrieves all children from group with given groupID.
+	RetrieveAllChildren(ctx context.Context, groupID string, offset, limit uint64, gm Metadata) (GroupPage, error)
 
 	// Memberships retrieves all groups that user belongs to
 	Memberships(ctx context.Context, userID string, offset, limit uint64, gm Metadata) (GroupPage, error)

--- a/users/mocks/groups.go
+++ b/users/mocks/groups.go
@@ -187,7 +187,47 @@ func (grm *groupRepositoryMock) Memberships(ctx context.Context, userID string, 
 	}, nil
 }
 
-func (grm *groupRepositoryMock) RetrieveAllWithAncestors(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+func (grm *groupRepositoryMock) RetrieveAllAncestors(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+	grm.mu.Lock()
+	defer grm.mu.Unlock()
+	var items []users.Group
+
+	// TO-DO this needs to be fixed.
+	for _, g := range grm.groups {
+		items = append(items, g)
+	}
+	return users.GroupPage{
+		Groups: items,
+		PageMetadata: users.PageMetadata{
+			Limit:  limit,
+			Offset: offset,
+			Total:  uint64(len(items)),
+		},
+	}, nil
+}
+
+func (grm *groupRepositoryMock) RetrieveAllChildren(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+	grm.mu.Lock()
+	defer grm.mu.Unlock()
+	var items []users.Group
+
+	groups := grm.childrenByGroups[groupID]
+
+	for _, g := range groups {
+		items = append(items, g)
+	}
+
+	return users.GroupPage{
+		Groups: items,
+		PageMetadata: users.PageMetadata{
+			Limit:  limit,
+			Offset: offset,
+			Total:  uint64(len(items)),
+		},
+	}, nil
+}
+
+func (grm *groupRepositoryMock) RetrieveAll(ctx context.Context, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
 	grm.mu.Lock()
 	defer grm.mu.Unlock()
 	var items []users.Group

--- a/users/postgres/groups_test.go
+++ b/users/postgres/groups_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/mainflux/mainflux/pkg/uuid"
 	uuidProvider "github.com/mainflux/mainflux/pkg/uuid"
@@ -17,22 +18,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	metadata  = users.Metadata{"field": "value"}
+	wrongMeta = users.Metadata{"wrong": "wrong"}
+	user      = users.User{
+		Email:    "example@mainflux.com",
+		Password: password,
+	}
+	nonExistingUser = users.User{
+		Email:    "non_existing@mainflux.com",
+		Password: password,
+	}
+)
+
 const (
-	groupName = "Mainflux"
-	password  = "12345678"
+	groupName              = "Mainflux"
+	password               = "12345678"
+	metaNum                = 5
+	numOfGroups            = 10
+	numOfAncestorsInSubset = 5
 )
 
 func TestGroupSave(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.NewGroupRepo(dbMiddleware)
 	userRepo := postgres.NewUserRepo(dbMiddleware)
 	uid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("user id unexpected error: %s", err))
-	user := users.User{
-		ID:       uid,
-		Email:    "TestGroupSave@mainflux.com",
-		Password: password,
-	}
+	user.ID = uid
+
 	_, err = userRepo.Save(context.Background(), user)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
 
@@ -78,16 +94,15 @@ func TestGroupSave(t *testing.T) {
 }
 
 func TestGroupRetrieveByID(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.NewGroupRepo(dbMiddleware)
 	userRepo := postgres.NewUserRepo(dbMiddleware)
 	uid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	user := users.User{
-		ID:       uid,
-		Email:    "TestGroupRetrieveByID@mainflux.com",
-		Password: password,
-	}
+	user.ID = uid
+
 	_, err = userRepo.Save(context.Background(), user)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
 
@@ -143,16 +158,15 @@ func TestGroupRetrieveByID(t *testing.T) {
 }
 
 func TestGroupDelete(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.NewGroupRepo(dbMiddleware)
 	userRepo := postgres.NewUserRepo(dbMiddleware)
 	uid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	user := users.User{
-		ID:       uid,
-		Email:    "TestGroupDelete@mainflux.com",
-		Password: password,
-	}
+	user.ID = uid
+
 	_, err = userRepo.Save(context.Background(), user)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
 
@@ -208,16 +222,14 @@ func TestGroupDelete(t *testing.T) {
 }
 
 func TestAssignUser(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.NewGroupRepo(dbMiddleware)
 	userRepo := postgres.NewUserRepo(dbMiddleware)
 	uid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	user := users.User{
-		ID:       uid,
-		Email:    "TestAssignUser@mainflux.com",
-		Password: password,
-	}
+	user.ID = uid
 
 	_, err = userRepo.Save(context.Background(), user)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
@@ -283,17 +295,15 @@ func TestAssignUser(t *testing.T) {
 }
 
 func TestUnassignUser(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.NewGroupRepo(dbMiddleware)
 	userRepo := postgres.NewUserRepo(dbMiddleware)
 
 	uid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	user := users.User{
-		ID:       uid,
-		Email:    "UnassignUser1@mainflux.com",
-		Password: password,
-	}
+	user.ID = uid
 
 	_, err = userRepo.Save(context.Background(), user)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
@@ -303,30 +313,26 @@ func TestUnassignUser(t *testing.T) {
 
 	uid, err = uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	user = users.User{
-		ID:       uid,
-		Email:    "UnassignUser2@mainflux.com",
-		Password: password,
-	}
+	nonExistingUser.ID = uid
 
-	_, err = userRepo.Save(context.Background(), user)
+	_, err = userRepo.Save(context.Background(), nonExistingUser)
 	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
 
-	user2, err := userRepo.RetrieveByEmail(context.Background(), user.Email)
+	nonExistingUser, err := userRepo.RetrieveByEmail(context.Background(), nonExistingUser.Email)
 	require.Nil(t, err, fmt.Sprintf("retrieve got unexpected error: %s", err))
 
 	gid, err := uuid.New().ID()
 	require.Nil(t, err, fmt.Sprintf("group id unexpected error: %s", err))
-	group1 := users.Group{
+	group := users.Group{
 		ID:      gid,
-		Name:    groupName + "UnassignUser1",
+		Name:    groupName,
 		OwnerID: user.ID,
 	}
 
-	g1, err := repo.Save(context.Background(), group1)
+	g1, err := repo.Save(context.Background(), group)
 	require.Nil(t, err, fmt.Sprintf("group save got unexpected error: %s", err))
 
-	err = repo.Assign(context.Background(), user1.ID, group1.ID)
+	err = repo.Assign(context.Background(), user1.ID, group.ID)
 	require.Nil(t, err, fmt.Sprintf("failed to assign user: %s", err))
 
 	cases := []struct {
@@ -337,7 +343,7 @@ func TestUnassignUser(t *testing.T) {
 	}{
 		{desc: "remove user from a group", group: g1, user: user1, err: nil},
 		{desc: "remove already removed user from a group", group: g1, user: user1, err: nil},
-		{desc: "remove non existing user from a group", group: g1, user: user2, err: nil},
+		{desc: "remove non existing user from a group", group: g1, user: nonExistingUser, err: nil},
 	}
 
 	for _, tc := range cases {
@@ -345,4 +351,301 @@ func TestUnassignUser(t *testing.T) {
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
 
+}
+
+func TestRetrieveAll(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.NewGroupRepo(dbMiddleware)
+	userRepo := postgres.NewUserRepo(dbMiddleware)
+	uid, err := uuid.New().ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	user.ID = uid
+
+	_, err = userRepo.Save(context.Background(), user)
+	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
+
+	user, err = userRepo.RetrieveByEmail(context.Background(), user.Email)
+	require.Nil(t, err, fmt.Sprintf("retrieve got unexpected error: %s", err))
+
+	n := uint64(numOfGroups)
+	for i := uint64(0); i < n; i++ {
+		gid, err := uuid.New().ID()
+		require.Nil(t, err, fmt.Sprintf("group id unexpected error: %s", err))
+		group := users.Group{
+			ID:      gid,
+			Name:    fmt.Sprintf("group%d", i),
+			OwnerID: user.ID,
+		}
+
+		// Create Groups with metadata.
+		if i < metaNum {
+			group.Metadata = metadata
+		}
+
+		_, err = repo.Save(context.Background(), group)
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
+	}
+
+	cases := map[string]struct {
+		owner    string
+		offset   uint64
+		limit    uint64
+		name     string
+		size     uint64
+		total    uint64
+		metadata map[string]interface{}
+	}{
+		"retrieve all groups": {
+			offset: 0,
+			limit:  n,
+			size:   n,
+			total:  n,
+		},
+		"retrieve subset of groups": {
+			offset: n / 2,
+			limit:  n,
+			size:   n / 2,
+			total:  n,
+		},
+		"retrieve groups with existing metadata": {
+			offset:   0,
+			limit:    n,
+			size:     metaNum,
+			total:    metaNum,
+			metadata: metadata,
+		},
+		"retrieve groups with non-existing metadata": {
+			offset:   0,
+			limit:    n,
+			size:     0,
+			total:    0,
+			metadata: wrongMeta,
+		},
+	}
+	for desc, tc := range cases {
+		page, err := repo.RetrieveAll(context.Background(), tc.offset, tc.limit, tc.metadata)
+		size := uint64(len(page.Groups))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
+		assert.Equal(t, tc.total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.total, page.Total))
+		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %d\n", desc, err))
+	}
+
+}
+
+func TestRetrieveAllAncestors(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.NewGroupRepo(dbMiddleware)
+	userRepo := postgres.NewUserRepo(dbMiddleware)
+	uid, err := uuid.New().ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	user.ID = uid
+
+	_, err = userRepo.Save(context.Background(), user)
+	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
+
+	user, err = userRepo.RetrieveByEmail(context.Background(), user.Email)
+	require.Nil(t, err, fmt.Sprintf("retrieve got unexpected error: %s", err))
+
+	var parentID = ""
+	var lastChildParentID = ""
+	var subsetAncestorID = ""
+	n := uint64(numOfGroups)
+	for i := uint64(1); i <= n; i++ {
+		gid, err := uuid.New().ID()
+		require.Nil(t, err, fmt.Sprintf("group id unexpected error: %s", err))
+		group := users.Group{
+			ID:       gid,
+			Name:     fmt.Sprintf("group%d", i),
+			OwnerID:  user.ID,
+			ParentID: parentID,
+		}
+
+		// Create Groups with metadata.
+		if i <= metaNum {
+			group.Metadata = metadata
+		}
+
+		g, err := repo.Save(context.Background(), group)
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
+		if i == numOfGroups {
+			lastChildParentID = g.ParentID
+		}
+		if i == numOfAncestorsInSubset {
+			subsetAncestorID = g.ID
+		}
+		parentID = g.ID
+	}
+	cases := map[string]struct {
+		parentID string
+		offset   uint64
+		limit    uint64
+		name     string
+		size     uint64
+		total    uint64
+		metadata map[string]interface{}
+	}{
+		"retrieve all groups": {
+			parentID: lastChildParentID,
+			offset:   0,
+			limit:    n,
+			size:     n,
+			total:    n,
+		},
+		"retrieve subset of groups": {
+			parentID: lastChildParentID,
+			offset:   n / 2,
+			limit:    n,
+			size:     n / 2,
+			total:    n,
+		},
+		"retrieve groups with existing metadata": {
+			parentID: lastChildParentID,
+			offset:   0,
+			limit:    n,
+			size:     metaNum,
+			total:    metaNum,
+			metadata: metadata,
+		},
+		"retrieve groups with non-existing metadata": {
+			parentID: lastChildParentID,
+			offset:   0,
+			limit:    n,
+			size:     0,
+			total:    0,
+			metadata: wrongMeta,
+		},
+		"retrieve subset of groups by different parent": {
+			parentID: subsetAncestorID,
+			offset:   0,
+			limit:    n,
+			size:     numOfAncestorsInSubset + 1,
+			total:    numOfAncestorsInSubset + 1,
+			metadata: nil,
+		},
+	}
+	for desc, tc := range cases {
+		page, err := repo.RetrieveAllAncestors(context.Background(), tc.parentID, tc.offset, tc.limit, tc.metadata)
+		size := uint64(len(page.Groups))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
+		assert.Equal(t, tc.total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.total, page.Total))
+		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %d\n", desc, err))
+	}
+
+}
+
+func TestRetrieveAllChildren(t *testing.T) {
+	err := cleanDB(db)
+	require.Nil(t, err, fmt.Sprintf("error cleaning db: %s", err))
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.NewGroupRepo(dbMiddleware)
+	userRepo := postgres.NewUserRepo(dbMiddleware)
+	uid, err := uuid.New().ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	user.ID = uid
+
+	_, err = userRepo.Save(context.Background(), user)
+	require.Nil(t, err, fmt.Sprintf("save got unexpected error: %s", err))
+
+	user, err = userRepo.RetrieveByEmail(context.Background(), user.Email)
+	require.Nil(t, err, fmt.Sprintf("retrieve got unexpected error: %s", err))
+
+	var parentID = ""
+	var rootParentID = ""
+	var subsetAncestorID = ""
+	n := uint64(numOfGroups)
+	for i := uint64(1); i <= n; i++ {
+		gid, err := uuid.New().ID()
+		require.Nil(t, err, fmt.Sprintf("group id unexpected error: %s", err))
+		group := users.Group{
+			ID:       gid,
+			Name:     fmt.Sprintf("group%d", i),
+			OwnerID:  user.ID,
+			ParentID: parentID,
+		}
+
+		// Create Groups with metadata.
+		if i <= metaNum {
+			group.Metadata = metadata
+		}
+
+		g, err := repo.Save(context.Background(), group)
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
+		if i == 1 {
+			rootParentID = g.ID
+		}
+		if i == numOfAncestorsInSubset {
+			subsetAncestorID = g.ID
+		}
+		parentID = g.ID
+	}
+	cases := map[string]struct {
+		parentID string
+		offset   uint64
+		limit    uint64
+		name     string
+		size     uint64
+		total    uint64
+		metadata map[string]interface{}
+	}{
+		"retrieve all groups": {
+			parentID: rootParentID,
+			offset:   0,
+			limit:    n,
+			size:     n,
+			total:    n,
+		},
+		"retrieve subset of groups": {
+			parentID: rootParentID,
+			offset:   n / 2,
+			limit:    n,
+			size:     n / 2,
+			total:    n,
+		},
+		"retrieve groups with existing metadata": {
+			parentID: rootParentID,
+			offset:   0,
+			limit:    n,
+			size:     metaNum,
+			total:    metaNum,
+			metadata: metadata,
+		},
+		"retrieve groups with non-existing metadata": {
+			parentID: rootParentID,
+			offset:   0,
+			limit:    n,
+			size:     0,
+			total:    0,
+			metadata: wrongMeta,
+		},
+		"retrieve subset of groups by different parent": {
+			parentID: subsetAncestorID,
+			offset:   0,
+			limit:    n,
+			size:     numOfAncestorsInSubset + 1,
+			total:    numOfAncestorsInSubset + 1,
+			metadata: nil,
+		},
+	}
+	for desc, tc := range cases {
+		page, err := repo.RetrieveAllChildren(context.Background(), tc.parentID, tc.offset, tc.limit, tc.metadata)
+		size := uint64(len(page.Groups))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
+		assert.Equal(t, tc.total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.total, page.Total))
+		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %d\n", desc, err))
+	}
+
+}
+
+func cleanDB(db *sqlx.DB) error {
+	if _, err := db.Exec("delete from groups"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("delete from users"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/users/tracing/groups.go
+++ b/users/tracing/groups.go
@@ -13,15 +13,17 @@ import (
 )
 
 const (
-	assignUser        = "assign_user"
-	saveGroup         = "save_group"
-	deleteGroup       = "delete_group"
-	updateGroup       = "update_group"
-	retrieveGroupByID = "retrieve_group_by_id"
-	retrieveAll       = "retrieve_all_groups"
-	retrieveByName    = "retrieve_by_name"
-	memberships       = "memberships"
-	unassignUser      = "unassign_user"
+	assignUser           = "assign_user"
+	saveGroup            = "save_group"
+	deleteGroup          = "delete_group"
+	updateGroup          = "update_group"
+	retrieveGroupByID    = "retrieve_group_by_id"
+	retrieveAll          = "retrieve_all_groups"
+	retrieveAllChildren  = "retrieve_all_children"
+	retrieveAllAncestors = "retrieve_all_ancestors"
+	retrieveByName       = "retrieve_by_name"
+	memberships          = "memberships"
+	unassignUser         = "unassign_user"
 )
 
 var _ users.GroupRepository = (*groupRepositoryMiddleware)(nil)
@@ -77,12 +79,28 @@ func (grm groupRepositoryMiddleware) RetrieveByName(ctx context.Context, name st
 	return grm.repo.RetrieveByName(ctx, name)
 }
 
-func (grm groupRepositoryMiddleware) RetrieveAllWithAncestors(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+func (grm groupRepositoryMiddleware) RetrieveAll(ctx context.Context, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
 	span := createSpan(ctx, grm.tracer, retrieveAll)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return grm.repo.RetrieveAllWithAncestors(ctx, groupID, offset, limit, gm)
+	return grm.repo.RetrieveAll(ctx, offset, limit, gm)
+}
+
+func (grm groupRepositoryMiddleware) RetrieveAllChildren(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+	span := createSpan(ctx, grm.tracer, retrieveAllChildren)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return grm.repo.RetrieveAllChildren(ctx, groupID, offset, limit, gm)
+}
+
+func (grm groupRepositoryMiddleware) RetrieveAllAncestors(ctx context.Context, groupID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {
+	span := createSpan(ctx, grm.tracer, retrieveAllAncestors)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return grm.repo.RetrieveAllAncestors(ctx, groupID, offset, limit, gm)
 }
 
 func (grm groupRepositoryMiddleware) Memberships(ctx context.Context, userID string, offset, limit uint64, gm users.Metadata) (users.GroupPage, error) {


### PR DESCRIPTION
Signed-off-by: Mirko Teodorovic <mirko.teodorovic@gmail.com>

This refactors group retrieve methods, separates `retrieve all`, `retrieve all children` and `retrieve all ancestors` in different methods
