### PR TITLE
MF-1344 - Fix links to API documentations

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -113,6 +113,6 @@ If `MF_EMAIL_TEMPLATE` doesn't point to any file service will function but passw
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](openapi.yaml).
+the [API documentation](openapi.yml).
 
 [doc]: http://mainflux.readthedocs.io

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -157,6 +157,6 @@ Setting `MF_BOOTSTRAP_CA_CERTS` expects a file in PEM format of trusted CAs. Thi
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yml).
+the [API documentation](openapi.yml).
 
 [doc]: http://mainflux.readthedocs.io

--- a/http/README.md
+++ b/http/README.md
@@ -72,4 +72,4 @@ Setting `MF_HTTP_ADAPTER_CA_CERTS` expects a file in PEM format of trusted CAs. 
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yaml).
+the [API documentation](openapi.yml).

--- a/readers/cassandra/README.md
+++ b/readers/cassandra/README.md
@@ -102,4 +102,4 @@ docker-compose -f docker/addons/casandra-reader/docker-compose.yml up -d
 
 Service exposes [HTTP API][doc]  for fetching messages.
 
-[doc]: ../swagger.yml
+[doc]: ../openapi.yml

--- a/readers/influxdb/README.md
+++ b/readers/influxdb/README.md
@@ -98,4 +98,4 @@ docker-compose -f docker/addons/influxdb-reader/docker-compose.yml up -d
 
 Service exposes [HTTP API][doc] for fetching messages.
 
-[doc]: ../swagger.yml
+[doc]: ../openapi.yml

--- a/readers/mongodb/README.md
+++ b/readers/mongodb/README.md
@@ -94,4 +94,4 @@ docker-compose -f docker/addons/mongodb-reader/docker-compose.yml up -d
 
 Service exposes [HTTP API][doc] for fetching messages.
 
-[doc]: ../swagger.yml
+[doc]: ../openapi.yml

--- a/things/README.md
+++ b/things/README.md
@@ -143,6 +143,6 @@ Setting `MF_THINGS_CA_CERTS` expects a file in PEM format of trusted CAs. This w
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yaml).
+the [API documentation](openapi.yml).
 
 [doc]: http://mainflux.readthedocs.io

--- a/twins/README.md
+++ b/twins/README.md
@@ -129,6 +129,6 @@ mainflux natively, than do the same thing in the corresponding console
 environment.
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yaml).
+the [API documentation](openapi.yml).
 
 [doc]: http://mainflux.readthedocs.io

--- a/users/README.md
+++ b/users/README.md
@@ -107,6 +107,6 @@ If `MF_EMAIL_TEMPLATE` doesn't point to any file service will function but passw
 ## Usage
 
 For more information about service capabilities and its usage, please check out
-the [API documentation](swagger.yaml).
+the [API documentation](openapi.yml).
 
 [doc]: http://mainflux.readthedocs.io


### PR DESCRIPTION
### What does this do?
Fix links to API documentations in `README.md` files of services (auth, bootstrap, http, cassandra-reader, influxdb-reader, mongodb-reader, things, twins, users).

### Which issue(s) does this PR fix/relate to?
Resolves #1344
