### PR TITLE
influxdb读写服务 #1  提交合并influxdb读写服务

### DIFF
--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -36,19 +36,14 @@ func lastMeasurementEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 	return func(_ context.Context, request interface{}) (interface{}, error) {
 		req := request.(lastMeasurementReq)
 
-		/*if err := req.validate(); err != nil {
-			return nil, err
-		}*/
 		//调用服务
 		page, err := svc.GetLastMeasurement(req.chanIDs, req.query)
 		if err != nil {
 			return nil, err
 		}
 
-		return pageRes{
+		return res{
 			Total:    page.Total,
-			Offset:   page.Offset,
-			Limit:    page.Limit,
 			Messages: page.Messages,
 		}, nil
 	}
@@ -64,10 +59,8 @@ func pumpRunningSecondsEndpoint(svc readers.MessageRepository) endpoint.Endpoint
 			return nil, err
 		}
 
-		return pageRes{
+		return res{
 			Total:    page.Total,
-			Offset:   page.Offset,
-			Limit:    page.Limit,
 			Messages: page.Messages,
 		}, nil
 	}

--- a/readers/api/endpoint.go
+++ b/readers/api/endpoint.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"context"
-
 	"github.com/go-kit/kit/endpoint"
 	"github.com/mainflux/mainflux/readers"
 )
@@ -19,6 +18,67 @@ func listMessagesEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
 		}
 
 		page, err := svc.ReadAll(req.chanID, req.offset, req.limit, req.query)
+		if err != nil {
+			return nil, err
+		}
+
+		return pageRes{
+			Total:    page.Total,
+			Offset:   page.Offset,
+			Limit:    page.Limit,
+			Messages: page.Messages,
+		}, nil
+	}
+}
+
+//返回处理lastMeasurement请求的handler
+func lastMeasurementEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req := request.(lastMeasurementReq)
+
+		/*if err := req.validate(); err != nil {
+			return nil, err
+		}*/
+		//调用服务
+		page, err := svc.GetLastMeasurement(req.chanIDs, req.query)
+		if err != nil {
+			return nil, err
+		}
+
+		return pageRes{
+			Total:    page.Total,
+			Offset:   page.Offset,
+			Limit:    page.Limit,
+			Messages: page.Messages,
+		}, nil
+	}
+}
+
+//返回处理pumpRunningSeconds请求的handler
+func pumpRunningSecondsEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req := request.(pumpRunningReq)
+		//调用服务
+		page, err := svc.PumpRunningSeconds(req.chanIDs, req.query)
+		if err != nil {
+			return nil, err
+		}
+
+		return pageRes{
+			Total:    page.Total,
+			Offset:   page.Offset,
+			Limit:    page.Limit,
+			Messages: page.Messages,
+		}, nil
+	}
+}
+
+//返回处理getMessageByPublisher请求的handler
+func getMessageByPublisherEndpoint(svc readers.MessageRepository) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req := request.(getMessageReq)
+		//调用服务
+		page, err := svc.GetMessageByPublisher(req.chanID, req.offset, req.limit, req.aggregationType, req.interval, req.query)
 		if err != nil {
 			return nil, err
 		}

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -205,7 +205,18 @@ func TestReadAll(t *testing.T) {
 			url:    tc.url,
 			token:  tc.token,
 		}
+		//todo
+		fmt.Println("request---------")
+		fmt.Println("url : " + tc.url)
+		fmt.Println("token : " + tc.token)
+		fmt.Println("status : ", tc.status)
+		//
 		res, err := req.make()
+		//todo
+		fmt.Println("rep---------")
+		fmt.Println("StatusCode : ", res.StatusCode)
+		fmt.Println("Status : ", res.Status)
+		//
 		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
 		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
 	}

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -297,7 +297,7 @@ func TestGetMessageByPublisher(t *testing.T) {
 		msg := do.Header.Get("messages")
 		fmt.Println("msg = " + msg)
 		//fmt.Println(do.)
-		temp := make([]byte, 300)
+		temp := make([]byte, 10240)
 		//temp := []byte{}//这种声明定义  切片的大小为0 不能用于read读取数据
 		do.Body.Read(temp)
 

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -137,14 +137,13 @@ func TestGetLastMeasurement(t *testing.T) {
 		res.URL.RawQuery = q.Encode() //重新赋值给URL的RawQuery字段
 		//res.Header.Add("content-type","application/x-www-form-urlencoded")
 		if err != nil {
-			//return nil, err
+
 		}
 		if req.token != "" {
 			res.Header.Set("Authorization", req.token)
 		}
 		do, err := req.client.Do(res)
 
-		//todo
 		log.Println("rep:")
 		log.Println("Status : ", do.Status)
 		msg := do.Header.Get("messages")
@@ -406,66 +405,3 @@ func TestReadAll(t *testing.T) {
 		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
 	}
 }
-
-//
-//func TestReadAll(t *testing.T) {
-//	svc := newService()
-//	tc := mocks.NewThingsService()
-//	ts := newServer(svc, tc)
-//	defer ts.Close()
-//
-//	cases := map[string]struct {
-//		url    string
-//		token  string
-//		status int
-//	}{
-//		"read page with valid offset and limit": {
-//			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL), //messages/last/{chanIDs}
-//			token:  token,
-//			status: http.StatusOK,
-//		},
-//		"read page with negative offset": {
-//			url:    fmt.Sprintf("%s/messages/list/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
-//			token:  token,
-//			status: http.StatusOK,
-//		},
-//		"read page with negative limit": {
-//			url:    fmt.Sprintf("%s/messages/pumpRunningSeconds/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
-//			token:  token,
-//			status: http.StatusOK,
-//		},
-//		/*"read page with zero limit": {
-//			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
-//			token:  token,
-//			status: http.StatusBadRequest,
-//		},*/
-//	}
-//
-//	for desc, tc := range cases {
-//		req := testRequest{
-//			client: ts.Client(),
-//			method: http.MethodGet,
-//			url:    tc.url,
-//			token:  tc.token,
-//		}
-//		if desc == "read page with negative limit" {
-//			req.method = http.MethodPost
-//		}
-//		//todo
-//		fmt.Println("request---------")
-//		fmt.Println("url : " + tc.url)
-//		fmt.Println("token : " + tc.token)
-//		fmt.Println("status : ", tc.status)
-//		//
-//		res, _ /*err*/ := req.make()
-//		//todo
-//		fmt.Println("rep---------")
-//		fmt.Println("StatusCode : ", res.StatusCode)
-//		fmt.Println("Status : ", res.Status)
-//		msg := res.Header.Get("messages")
-//		fmt.Println("msg = " + msg)
-//		//
-//		//assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
-//		//assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
-//	}
-//}

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -5,8 +5,12 @@ package api_test
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/mainflux/mainflux"
@@ -89,6 +93,197 @@ func (tr testRequest) make() (*http.Response, error) {
 	return tr.client.Do(req)
 }
 
+func TestGetLastMeasurement(t *testing.T) {
+	svc := newService()
+	tc := mocks.NewThingsService()
+	ts := newServer(svc, tc)
+	defer ts.Close()
+
+	cases := []struct {
+		url   string
+		token string
+	}{
+		{
+			url:   fmt.Sprintf("%s/messages/last/e17d05dc-f022-40b1-90b5-e7cb7de50ab0,4a68d620-edb4-4882-82fc-f5c0fccc0c31", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/last/8723d86d-85d5-4eba-9da2-3d9855772bf0,e17d05dc-f022-40b1-90b5-e7cb7de50ab0", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/last/4a68d620-edb4-4882-82fc-f5c0fccc0c31", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/last/83374d41-64b2-47a7-8981-e8ccd09c9159", ts.URL),
+			token: token,
+		},
+	}
+	for i := range cases {
+		req := testRequest{
+			client: ts.Client(),
+			method: http.MethodGet,
+			url:    cases[i].url,
+			token:  cases[i].token,
+		}
+		log.Println("request:")
+		log.Println("url : " + cases[i].url)
+		log.Println("token : " + cases[i].token)
+
+		res, err := http.NewRequest(req.method, req.url, nil)
+		q := res.URL.Query() // Query解析RawQuery并返回相应的值。也就是解析？后面的参数
+		q.Add("name", "pump_1")
+		res.URL.RawQuery = q.Encode() //重新赋值给URL的RawQuery字段
+		//res.Header.Add("content-type","application/x-www-form-urlencoded")
+		if err != nil {
+			//return nil, err
+		}
+		if req.token != "" {
+			res.Header.Set("Authorization", req.token)
+		}
+		do, err := req.client.Do(res)
+
+		//todo
+		log.Println("rep:")
+		log.Println("Status : ", do.Status)
+		msg := do.Header.Get("messages")
+		log.Println("msg = " + msg)
+	}
+}
+
+func TestPumpRunningSeconds(t *testing.T) {
+	svc := newService()
+	tc := mocks.NewThingsService()
+	ts := newServer(svc, tc)
+	defer ts.Close()
+	cases := []struct {
+		url   string
+		token string
+	}{
+		{
+			url:   fmt.Sprintf("%s/messages/pumpRunningSeconds/e17d05dc-f022-40b1-90b5-e7cb7de50ab0,4a68d620-edb4-4882-82fc-f5c0fccc0c31", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/pumpRunningSeconds/8723d86d-85d5-4eba-9da2-3d9855772bf0,e17d05dc-f022-40b1-90b5-e7cb7de50ab0", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/pumpRunningSeconds/4a68d620-edb4-4882-82fc-f5c0fccc0c31", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/pumpRunningSeconds/83374d41-64b2-47a7-8981-e8ccd09c9159,e17d05dc-f022-40b1-90b5-e7cb7de50ab0,8723d86d-85d5-4eba-9da2-3d9855772bf0", ts.URL),
+			token: token,
+		},
+	}
+
+	for i := range cases {
+		req := testRequest{
+			client: ts.Client(),
+			method: http.MethodPost,
+			url:    cases[i].url,
+			token:  cases[i].token,
+		}
+		log.Println("request:")
+		log.Println("url : " + cases[i].url)
+		log.Println("token : " + cases[i].token)
+		m := url.Values{
+			"from": {
+				"2021-01-21T04:33:18Z",
+			},
+			"to": {
+				"2021-01-21T05:38:18Z",
+			},
+			"name": {
+				"pump_1,pump_2",
+			},
+		}
+		res, err := http.NewRequest(req.method, req.url, strings.NewReader(m.Encode()))
+		res.Header.Add("content-type", "application/x-www-form-urlencoded")
+		if err != nil {
+			//return nil, err
+		}
+		if req.token != "" {
+			res.Header.Set("Authorization", req.token)
+		}
+		do, err := req.client.Do(res)
+
+		//todo
+		log.Println("rep:")
+		log.Println("Status : ", do.Status)
+		msg := do.Header.Get("messages")
+		log.Println("msg = " + msg)
+	}
+}
+
+func TestGetMessageByPublisher(t *testing.T) {
+	svc := newService()
+	tc := mocks.NewThingsService()
+	ts := newServer(svc, tc)
+	defer ts.Close()
+	cases := []struct {
+		url   string
+		token string
+	}{
+		{
+			url:   fmt.Sprintf("%s/messages/list/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/list/8723d86d-85d5-4eba-9da2-3d9855772bf0", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/list/4a68d620-edb4-4882-82fc-f5c0fccc0c31", ts.URL),
+			token: token,
+		},
+		{
+			url:   fmt.Sprintf("%s/messages/list/83374d41-64b2-47a7-8981-e8ccd09c9159", ts.URL),
+			token: token,
+		},
+	}
+
+	for i := range cases {
+		req := testRequest{
+			client: ts.Client(),
+			method: http.MethodGet,
+			url:    cases[i].url,
+			token:  cases[i].token,
+		}
+		//todo
+		fmt.Println("request---------")
+		fmt.Println("url : " + cases[i].url)
+		fmt.Println("token : " + cases[i].token)
+		res, err := http.NewRequest(req.method, req.url, nil)
+
+		q := res.URL.Query()
+		q.Add("name", "pump_1")
+		q.Add("from", "2021-01-21T04:33:18Z")
+		q.Add("to", "2021-01-21T05:38:18Z")
+		q.Add("aggregationType", "mean")
+		q.Add("interval", "15m")
+		q.Add("limit", "8")
+		q.Add("offset", "0")
+		res.URL.RawQuery = q.Encode()
+		//res.Header.Add("content-type","application/x-www-form-urlencoded")
+		if err != nil {
+			//return nil, err
+		}
+		if req.token != "" {
+			res.Header.Set("Authorization", req.token)
+		}
+		do, err := req.client.Do(res)
+		//todo
+		fmt.Println("rep---------")
+		fmt.Println("StatusCode : ", do.StatusCode)
+		fmt.Println("Status : ", do.Status)
+		msg := do.Header.Get("messages")
+		fmt.Println("msg = " + msg)
+		//fmt.Println(do.)
+	}
+}
 func TestReadAll(t *testing.T) {
 	svc := newService()
 	tc := mocks.NewThingsService()
@@ -101,25 +296,100 @@ func TestReadAll(t *testing.T) {
 		status int
 	}{
 		"read page with valid offset and limit": {
-			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL), //messages/last/{chanIDs}
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
 			token:  token,
 			status: http.StatusOK,
 		},
 		"read page with negative offset": {
-			url:    fmt.Sprintf("%s/messages/list/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with negative limit": {
-			url:    fmt.Sprintf("%s/messages/pumpRunningSeconds/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
-			token:  token,
-			status: http.StatusOK,
-		},
-		/*"read page with zero limit": {
-			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=-1&limit=10", ts.URL, chanID),
 			token:  token,
 			status: http.StatusBadRequest,
-		},*/
+		},
+		"read page with negative limit": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=-10", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with zero limit": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=0", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with non-integer offset": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=abc&limit=10", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with non-integer limit": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=abc", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with invalid channel id": {
+			url:    fmt.Sprintf("%s/channels//messages?offset=0&limit=10", ts.URL),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with invalid token": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
+			token:  invalid,
+			status: http.StatusForbidden,
+		},
+		"read page with multiple offset": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&offset=1&limit=10", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with multiple limit": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=20&limit=10", ts.URL, chanID),
+			token:  token,
+			status: http.StatusBadRequest,
+		},
+		"read page with empty token": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
+			token:  "",
+			status: http.StatusForbidden,
+		},
+		"read page with default offset": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?limit=10", ts.URL, chanID),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with default limit": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0", ts.URL, chanID),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with value": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?v=%f", ts.URL, chanID, v),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with boolean value": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?vb=%t", ts.URL, chanID, vb),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with string value": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?vs=%s", ts.URL, chanID, vd),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with data value": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?vd=%s", ts.URL, chanID, vd),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with from": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?from=1608651539.673909", ts.URL, chanID),
+			token:  token,
+			status: http.StatusOK,
+		},
+		"read page with to": {
+			url:    fmt.Sprintf("%s/channels/%s/messages?to=1508651539.673909", ts.URL, chanID),
+			token:  token,
+			status: http.StatusOK,
+		},
 	}
 
 	for desc, tc := range cases {
@@ -129,24 +399,73 @@ func TestReadAll(t *testing.T) {
 			url:    tc.url,
 			token:  tc.token,
 		}
-		if desc == "read page with negative limit" {
-			req.method = http.MethodPost
-		}
-		//todo
-		fmt.Println("request---------")
-		fmt.Println("url : " + tc.url)
-		fmt.Println("token : " + tc.token)
-		fmt.Println("status : ", tc.status)
-		//
-		res, _ /*err*/ := req.make()
-		//todo
-		fmt.Println("rep---------")
-		fmt.Println("StatusCode : ", res.StatusCode)
-		fmt.Println("Status : ", res.Status)
-		msg := res.Header.Get("messages")
-		fmt.Println("msg = " + msg)
-		//
-		//assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
-		//assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
+		res, err := req.make()
+		log.Println("resp:")
+		log.Println(res.Header.Get("messages"))
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
 	}
 }
+
+//
+//func TestReadAll(t *testing.T) {
+//	svc := newService()
+//	tc := mocks.NewThingsService()
+//	ts := newServer(svc, tc)
+//	defer ts.Close()
+//
+//	cases := map[string]struct {
+//		url    string
+//		token  string
+//		status int
+//	}{
+//		"read page with valid offset and limit": {
+//			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL), //messages/last/{chanIDs}
+//			token:  token,
+//			status: http.StatusOK,
+//		},
+//		"read page with negative offset": {
+//			url:    fmt.Sprintf("%s/messages/list/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+//			token:  token,
+//			status: http.StatusOK,
+//		},
+//		"read page with negative limit": {
+//			url:    fmt.Sprintf("%s/messages/pumpRunningSeconds/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+//			token:  token,
+//			status: http.StatusOK,
+//		},
+//		/*"read page with zero limit": {
+//			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+//			token:  token,
+//			status: http.StatusBadRequest,
+//		},*/
+//	}
+//
+//	for desc, tc := range cases {
+//		req := testRequest{
+//			client: ts.Client(),
+//			method: http.MethodGet,
+//			url:    tc.url,
+//			token:  tc.token,
+//		}
+//		if desc == "read page with negative limit" {
+//			req.method = http.MethodPost
+//		}
+//		//todo
+//		fmt.Println("request---------")
+//		fmt.Println("url : " + tc.url)
+//		fmt.Println("token : " + tc.token)
+//		fmt.Println("status : ", tc.status)
+//		//
+//		res, _ /*err*/ := req.make()
+//		//todo
+//		fmt.Println("rep---------")
+//		fmt.Println("StatusCode : ", res.StatusCode)
+//		fmt.Println("Status : ", res.Status)
+//		msg := res.Header.Get("messages")
+//		fmt.Println("msg = " + msg)
+//		//
+//		//assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
+//		//assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
+//	}
+//}

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mainflux/mainflux/readers"
 	"github.com/mainflux/mainflux/readers/api"
 	"github.com/mainflux/mainflux/readers/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -102,100 +101,25 @@ func TestReadAll(t *testing.T) {
 		status int
 	}{
 		"read page with valid offset and limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
+			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL), //messages/last/{chanIDs}
 			token:  token,
 			status: http.StatusOK,
 		},
 		"read page with negative offset": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=-1&limit=10", ts.URL, chanID),
+			url:    fmt.Sprintf("%s/messages/list/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
 			token:  token,
-			status: http.StatusBadRequest,
+			status: http.StatusOK,
 		},
 		"read page with negative limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=-10", ts.URL, chanID),
+			url:    fmt.Sprintf("%s/messages/pumpRunningSeconds/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
+			token:  token,
+			status: http.StatusOK,
+		},
+		/*"read page with zero limit": {
+			url:    fmt.Sprintf("%s/messages/last/ba22f57d-642e-4b82-9718-5e3b68809ac0", ts.URL),
 			token:  token,
 			status: http.StatusBadRequest,
-		},
-		"read page with zero limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=0", ts.URL, chanID),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with non-integer offset": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=abc&limit=10", ts.URL, chanID),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with non-integer limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=abc", ts.URL, chanID),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with invalid channel id": {
-			url:    fmt.Sprintf("%s/channels//messages?offset=0&limit=10", ts.URL),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with invalid token": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
-			token:  invalid,
-			status: http.StatusForbidden,
-		},
-		"read page with multiple offset": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&offset=1&limit=10", ts.URL, chanID),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with multiple limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=20&limit=10", ts.URL, chanID),
-			token:  token,
-			status: http.StatusBadRequest,
-		},
-		"read page with empty token": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0&limit=10", ts.URL, chanID),
-			token:  "",
-			status: http.StatusForbidden,
-		},
-		"read page with default offset": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?limit=10", ts.URL, chanID),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with default limit": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?offset=0", ts.URL, chanID),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with value": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?v=%f", ts.URL, chanID, v),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with boolean value": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?vb=%t", ts.URL, chanID, vb),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with string value": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?vs=%s", ts.URL, chanID, vd),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with data value": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?vd=%s", ts.URL, chanID, vd),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with from": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?from=1608651539.673909", ts.URL, chanID),
-			token:  token,
-			status: http.StatusOK,
-		},
-		"read page with to": {
-			url:    fmt.Sprintf("%s/channels/%s/messages?to=1508651539.673909", ts.URL, chanID),
-			token:  token,
-			status: http.StatusOK,
-		},
+		},*/
 	}
 
 	for desc, tc := range cases {
@@ -205,19 +129,24 @@ func TestReadAll(t *testing.T) {
 			url:    tc.url,
 			token:  tc.token,
 		}
+		if desc == "read page with negative limit" {
+			req.method = http.MethodPost
+		}
 		//todo
 		fmt.Println("request---------")
 		fmt.Println("url : " + tc.url)
 		fmt.Println("token : " + tc.token)
 		fmt.Println("status : ", tc.status)
 		//
-		res, err := req.make()
+		res, _ /*err*/ := req.make()
 		//todo
 		fmt.Println("rep---------")
 		fmt.Println("StatusCode : ", res.StatusCode)
 		fmt.Println("Status : ", res.Status)
+		msg := res.Header.Get("messages")
+		fmt.Println("msg = " + msg)
 		//
-		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
-		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
+		//assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", desc, err))
+		//assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected %d got %d", desc, tc.status, res.StatusCode))
 	}
 }

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -98,6 +98,10 @@ func TestGetLastMeasurement(t *testing.T) {
 	tc := mocks.NewThingsService()
 	ts := newServer(svc, tc)
 	defer ts.Close()
+	//fmt.Println(ts.URL)
+	//for ;true; {
+	//
+	//}
 
 	cases := []struct {
 		url   string
@@ -148,6 +152,12 @@ func TestGetLastMeasurement(t *testing.T) {
 		log.Println("Status : ", do.Status)
 		msg := do.Header.Get("messages")
 		log.Println("msg = " + msg)
+		temp := make([]byte, 10240)
+		//temp := []byte{}//这种声明定义  切片的大小为0 不能用于read读取数据
+		do.Body.Read(temp)
+
+		log.Println("temp :" + string(temp))
+		do.Body.Close()
 	}
 }
 
@@ -214,6 +224,12 @@ func TestPumpRunningSeconds(t *testing.T) {
 		log.Println("Status : ", do.Status)
 		msg := do.Header.Get("messages")
 		log.Println("msg = " + msg)
+		temp := make([]byte, 10240)
+		//temp := []byte{}//这种声明定义  切片的大小为0 不能用于read读取数据
+		do.Body.Read(temp)
+
+		log.Println("temp :" + string(temp))
+		do.Body.Close()
 	}
 }
 
@@ -281,6 +297,12 @@ func TestGetMessageByPublisher(t *testing.T) {
 		msg := do.Header.Get("messages")
 		fmt.Println("msg = " + msg)
 		//fmt.Println(do.)
+		temp := make([]byte, 300)
+		//temp := []byte{}//这种声明定义  切片的大小为0 不能用于read读取数据
+		do.Body.Read(temp)
+
+		log.Println("temp :" + string(temp))
+		do.Body.Close()
 	}
 }
 func TestReadAll(t *testing.T) {

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -20,6 +20,18 @@ type loggingMiddleware struct {
 	svc    readers.MessageRepository
 }
 
+func (lm *loggingMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
+func (lm *loggingMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
+func (lm *loggingMiddleware) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
 // LoggingMiddleware adds logging facilities to the core service.
 func LoggingMiddleware(svc readers.MessageRepository, logger logger.Logger) readers.MessageRepository {
 	return &loggingMiddleware{

--- a/readers/api/logging.go
+++ b/readers/api/logging.go
@@ -20,11 +20,11 @@ type loggingMiddleware struct {
 	svc    readers.MessageRepository
 }
 
-func (lm *loggingMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (lm *loggingMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	panic("implement me")
 }
 
-func (lm *loggingMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (lm *loggingMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	panic("implement me")
 }
 

--- a/readers/api/metrics.go
+++ b/readers/api/metrics.go
@@ -20,6 +20,18 @@ type metricsMiddleware struct {
 	svc     readers.MessageRepository
 }
 
+func (mm *metricsMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
+func (mm *metricsMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
+func (mm *metricsMiddleware) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
 // MetricsMiddleware instruments core service by tracking request count and latency.
 func MetricsMiddleware(svc readers.MessageRepository, counter metrics.Counter, latency metrics.Histogram) readers.MessageRepository {
 	return &metricsMiddleware{

--- a/readers/api/metrics.go
+++ b/readers/api/metrics.go
@@ -20,11 +20,11 @@ type metricsMiddleware struct {
 	svc     readers.MessageRepository
 }
 
-func (mm *metricsMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (mm *metricsMiddleware) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	panic("implement me")
 }
 
-func (mm *metricsMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (mm *metricsMiddleware) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	panic("implement me")
 }
 

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -14,6 +14,28 @@ type listMessagesReq struct {
 	query  map[string]string
 }
 
+//定义处理lastMeasurement请求的请求体
+type lastMeasurementReq struct {
+	chanIDs []string
+	query   map[string]string
+}
+
+//定义处理pumpRunningSeconds请求的请求体
+type pumpRunningReq struct {
+	chanIDs []string
+	query   map[string]string
+}
+
+//定义处理getMessageByChannal请求的请求体
+type getMessageReq struct {
+	chanID          string
+	offset          uint64
+	limit           uint64
+	aggregationType string
+	interval        string
+	query           map[string]string
+}
+
 func (req listMessagesReq) validate() error {
 	if req.limit < 1 {
 		return errInvalidRequest

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -22,6 +22,10 @@ type pageRes struct {
 	Limit    uint64            `json:"limit"`
 	Messages []readers.Message `json:"messages,omitempty"`
 }
+type res struct {
+	Total    uint64            `json:"total"`
+	Messages []readers.Message `json:"messages,omitempty"`
+}
 
 func (res pageRes) Headers() map[string]string {
 	var ret map[string]string = make(map[string]string)
@@ -39,11 +43,9 @@ func (res pageRes) Headers() map[string]string {
 func temp(msg interface{}) string {
 	message, ok := msg.(senml.Message)
 	if ok == false {
-		//fmt.Println("temp func : error")
 		return "error"
 	}
 	jsonstr, _ := json.MarshalIndent(message, "", "	")
-	//fmt.Println("responses:message = " , message)
 	fmt.Println("responses:jsonstr = " + string(jsonstr))
 	return string(jsonstr)
 }
@@ -58,4 +60,24 @@ func (res pageRes) Empty() bool {
 
 type errorRes struct {
 	Err string `json:"error"`
+}
+
+func (res res) Headers() map[string]string {
+	var ret map[string]string = make(map[string]string)
+	ret["total"] = strconv.FormatUint(res.Total, 10)
+
+	str := ""
+	for i := range res.Messages {
+		str = str + "\n" + temp(res.Messages[i])
+	}
+	ret["messages"] = str
+	return ret
+}
+
+func (res res) Code() int {
+	return http.StatusOK
+}
+
+func (res res) Empty() bool {
+	return false
 }

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -39,10 +39,11 @@ func (res pageRes) Headers() map[string]string {
 func temp(msg interface{}) string {
 	message, ok := msg.(senml.Message)
 	if ok == false {
-		fmt.Println("temp func : error")
+		//fmt.Println("temp func : error")
 		return "error"
 	}
 	jsonstr, _ := json.MarshalIndent(message, "", "	")
+	//fmt.Println("responses:message = " , message)
 	fmt.Println("responses:jsonstr = " + string(jsonstr))
 	return string(jsonstr)
 }

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -4,13 +4,10 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/mainflux/mainflux"
-	"github.com/mainflux/mainflux/pkg/transformers/senml"
 	"github.com/mainflux/mainflux/readers"
 )
 
@@ -33,21 +30,13 @@ func (res pageRes) Headers() map[string]string {
 	ret["offset"] = strconv.FormatUint(res.Offset, 10)
 	ret["total"] = strconv.FormatUint(res.Total, 10)
 
-	str := ""
-	for i := range res.Messages {
-		str = str + "\n" + temp(res.Messages[i])
-	}
-	ret["messages"] = str
+	//jsonStr, err := json.MarshalIndent(res.Messages, "", "	")
+	//if err != nil {
+	//	ret["messages"] = "error"
+	//} else {
+	//	ret["messages"] = string(jsonStr)
+	//}
 	return ret
-}
-func temp(msg interface{}) string {
-	message, ok := msg.(senml.Message)
-	if ok == false {
-		return "error"
-	}
-	jsonstr, _ := json.MarshalIndent(message, "", "	")
-	fmt.Println("responses:jsonstr = " + string(jsonstr))
-	return string(jsonstr)
 }
 
 func (res pageRes) Code() int {
@@ -66,11 +55,12 @@ func (res res) Headers() map[string]string {
 	var ret map[string]string = make(map[string]string)
 	ret["total"] = strconv.FormatUint(res.Total, 10)
 
-	str := ""
-	for i := range res.Messages {
-		str = str + "\n" + temp(res.Messages[i])
-	}
-	ret["messages"] = str
+	//jsonStr, err := json.MarshalIndent(res.Messages, "", "	")
+	//if err != nil {
+	//	ret["messages"] = "error"
+	//} else {
+	//	ret["messages"] = string(jsonStr)
+	//}
 	return ret
 }
 

--- a/readers/api/responses.go
+++ b/readers/api/responses.go
@@ -4,9 +4,13 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/pkg/transformers/senml"
 	"github.com/mainflux/mainflux/readers"
 )
 
@@ -20,7 +24,27 @@ type pageRes struct {
 }
 
 func (res pageRes) Headers() map[string]string {
-	return map[string]string{}
+	var ret map[string]string = make(map[string]string)
+	ret["limit"] = strconv.FormatUint(res.Limit, 10)
+	ret["offset"] = strconv.FormatUint(res.Offset, 10)
+	ret["total"] = strconv.FormatUint(res.Total, 10)
+
+	str := ""
+	for i := range res.Messages {
+		str = str + "\n" + temp(res.Messages[i])
+	}
+	ret["messages"] = str
+	return ret
+}
+func temp(msg interface{}) string {
+	message, ok := msg.(senml.Message)
+	if ok == false {
+		fmt.Println("temp func : error")
+		return "error"
+	}
+	jsonstr, _ := json.MarshalIndent(message, "", "	")
+	fmt.Println("responses:jsonstr = " + string(jsonstr))
+	return string(jsonstr)
 }
 
 func (res pageRes) Code() int {

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -73,7 +74,8 @@ func MakeHandler(svc readers.MessageRepository, tc mainflux.ThingsServiceClient,
 
 	mux.GetFunc("/version", mainflux.Version(svcName))
 	mux.Handle("/metrics", promhttp.Handler())
-
+	//todo
+	fmt.Println("注册成功")
 	return mux
 }
 
@@ -114,11 +116,13 @@ func decodeMessageByChannal(_ context.Context, r *http.Request) (interface{}, er
 		query[format] = defFormat
 	}
 
-	req := listMessagesReq{
-		chanID: chanID,
-		offset: offset,
-		limit:  limit,
-		query:  query,
+	req := getMessageReq{
+		aggregationType: query["aggregationType"],
+		interval:        query["interval"],
+		chanID:          chanID,
+		offset:          offset,
+		limit:           limit,
+		query:           query,
 	}
 
 	return req, nil
@@ -224,9 +228,11 @@ func decodeLast(_ context.Context, r *http.Request) (interface{}, error) {
 }
 
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	fmt.Println("encodeResponse func -----------------------------------")
 	w.Header().Set("Content-Type", contentType)
 
 	if ar, ok := response.(mainflux.Response); ok {
+		//fmt.Println("encodeResponse func: response = mainflux.Response")
 		for k, v := range ar.Headers() {
 			w.Header().Set(k, v)
 		}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -37,6 +37,12 @@ var (
 	queryFields           = []string{"format", "subtopic", "publisher", "protocol", "name", "v", "vs", "vb", "vd", "from", "to"}
 )
 
+type resMessage struct {
+	messages   map[string]interface{}
+	statusCode uint64
+	desc       string
+}
+
 // MakeHandler returns a HTTP handler for API endpoints.
 func MakeHandler(svc readers.MessageRepository, tc mainflux.ThingsServiceClient, svcName string) http.Handler {
 	auth = tc
@@ -228,10 +234,26 @@ func decodeLast(_ context.Context, r *http.Request) (interface{}, error) {
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", contentType)
 	if ar, ok := response.(mainflux.Response); ok {
-		for k, v := range ar.Headers() {
-			w.Header().Add(k, v)
-		}
+		//messages := map[string]interface{}{}
+		//for k, v := range ar.Headers() {
+		//	//w.Header().Add(k, v)
+		//	//messages[k] = v
+		//	//log.Println("k:" + k + " v:" + v)
+		//}
+		//s := messages["messages"].(string)
+		//var data []byte = []byte(s)
+		//var arr []senml.Message
+		//err := json.Unmarshal(data, &arr)
+		//if err != nil {
+		//	return err
+		//}
+		//messages["messages"] = arr
+		//marshal, _ := json.MarshalIndent(resMessage{
+		//	messages: messages,
+		//}, "", "	")
 		w.WriteHeader(ar.Code())
+		//log.Println("marshal : "+string(marshal[:]))
+		//w.Write([]byte{})
 		if ar.Empty() {
 			return nil
 		}

--- a/readers/api/transport.go
+++ b/readers/api/transport.go
@@ -6,7 +6,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -127,7 +126,6 @@ func decodeMessageByChannal(_ context.Context, r *http.Request) (interface{}, er
 }
 
 func decodepumpRunning(_ context.Context, r *http.Request) (interface{}, error) {
-	log.Println("decodepumpRunning URL: ", r.URL.Path)
 	chanIDs := bone.GetValue(r, "chanIDs")
 	if chanIDs == "" {
 		return nil, errInvalidRequest
@@ -159,7 +157,6 @@ func decodepumpRunning(_ context.Context, r *http.Request) (interface{}, error) 
 	return req, nil
 }
 func decodeList(_ context.Context, r *http.Request) (interface{}, error) {
-	log.Println("decodeList URL: ", r.URL.Path)
 	chanID := bone.GetValue(r, "chanID")
 	if chanID == "" {
 		return nil, errInvalidRequest
@@ -211,19 +208,11 @@ func decodeLast(_ context.Context, r *http.Request) (interface{}, error) {
 			return nil, err
 		}
 	}
-	fmt.Println("**********")
+
 	q := r.URL.Query()
 	id := q.Get("name")
 	query := map[string]string{}
 	query["name"] = id
-	//r.ParseForm()
-	//for k, v := range r.PostForm {
-	//	if len(v) < 1 {
-	//		continue
-	//	}
-	//	query[k] = v[0]
-	//	fmt.Println(query[k], " = ", v[0])
-	//}
 	if query[format] == "" {
 		query[format] = defFormat
 	}
@@ -237,20 +226,16 @@ func decodeLast(_ context.Context, r *http.Request) (interface{}, error) {
 }
 
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
-	fmt.Println("encodeResponse func -----------------------------------")
 	w.Header().Set("Content-Type", contentType)
-
 	if ar, ok := response.(mainflux.Response); ok {
 		for k, v := range ar.Headers() {
 			w.Header().Add(k, v)
-			//result[k] = v
 		}
 		w.WriteHeader(ar.Code())
 		if ar.Empty() {
 			return nil
 		}
 	}
-
 	return json.NewEncoder(w).Encode(response)
 }
 

--- a/readers/influxdb/messages.go
+++ b/readers/influxdb/messages.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gofrs/uuid"
 	"reflect"
 	"strconv"
 	"strings"
@@ -38,6 +39,21 @@ func New(client influxdata.Client, database string) readers.MessageRepository {
 		database,
 		client,
 	}
+}
+
+func (repo *influxRepository) GetLastMeasurement(publishers []uuid.UUID, sensorName string) (readers.MessagesPage, error) {
+	//todo
+	return readers.MessagesPage{}, nil
+}
+
+func PumpRunningSeconds(publishers []uuid.UUID, names []string, startTime string, endTime string) ([]readers.MessagesPage, error) {
+	//todo
+	return []readers.MessagesPage{}, nil
+}
+
+func GetTimeseriesByPublisher(publisher uuid.UUID, sensorName string, startTime string, endTime string, aggregationType string, interval string) (readers.MessagesPage, error) {
+	//todo
+	return readers.MessagesPage{}, nil
 }
 
 func (repo *influxRepository) ReadAll(chanID string, offset, limit uint64, query map[string]string) (readers.MessagesPage, error) {

--- a/readers/influxdb/messages.go
+++ b/readers/influxdb/messages.go
@@ -170,11 +170,6 @@ func (repo *InfluxRepository) GetMessageByPublisher(chanID string, offset, limit
 		Database: repo.database,
 	}
 
-	total, err := repo.count(measurement, condition)
-	if err != nil {
-		return readers.MessagesPage{}, errors.Wrap(errReadMessages, err)
-	}
-
 	var ret []readers.Message
 	//查询数据库
 	resp, err := repo.client.Query(q)
@@ -194,13 +189,8 @@ func (repo *InfluxRepository) GetMessageByPublisher(chanID string, offset, limit
 		ret = append(ret, parseMessageByFieldsAndTags(result.Tags, result.Columns, v))
 	}
 
-	//total, err := repo.count(measurement, condition)
-	//if err != nil {
-	//	return readers.MessagesPage{}, errors.Wrap(errReadMessages, err)
-	//}
-
 	return readers.MessagesPage{
-		Total:    total,
+		Total:    uint64(len(ret)),
 		Offset:   0,
 		Limit:    0,
 		Messages: ret,

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -13,6 +13,12 @@ type MessageRepository interface {
 	// ReadAll skips given number of messages for given channel and returns next
 	// limited number of messages.
 	ReadAll(chanID string, offset, limit uint64, query map[string]string) (MessagesPage, error)
+
+	GetLastMeasurement(chanIDs []string, query map[string]string) (MessagesPage, error)
+
+	PumpRunningSeconds(chanIDs []string, query map[string]string) (MessagesPage, error)
+
+	GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (MessagesPage, error)
 }
 
 // Message represents any message format.

--- a/readers/messages.go
+++ b/readers/messages.go
@@ -14,9 +14,9 @@ type MessageRepository interface {
 	// limited number of messages.
 	ReadAll(chanID string, offset, limit uint64, query map[string]string) (MessagesPage, error)
 
-	GetLastMeasurement(chanIDs []string, query map[string]string) (MessagesPage, error)
+	GetLastMeasurement(chanIDs []string, query map[string]string) (Messages, error)
 
-	PumpRunningSeconds(chanIDs []string, query map[string]string) (MessagesPage, error)
+	PumpRunningSeconds(chanIDs []string, query map[string]string) (Messages, error)
 
 	GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (MessagesPage, error)
 }
@@ -30,5 +30,9 @@ type MessagesPage struct {
 	Total    uint64
 	Offset   uint64
 	Limit    uint64
+	Messages []Message
+}
+type Messages struct {
+	Total    uint64
 	Messages []Message
 }

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -4,9 +4,13 @@
 package mocks
 
 import (
+	"fmt"
+	influxdata "github.com/influxdata/influxdb/client/v2"
+	"log"
 	"sync"
 
 	"github.com/mainflux/mainflux/readers"
+	"github.com/mainflux/mainflux/readers/influxdb"
 )
 
 var _ readers.MessageRepository = (*messageRepositoryMock)(nil)
@@ -14,6 +18,37 @@ var _ readers.MessageRepository = (*messageRepositoryMock)(nil)
 type messageRepositoryMock struct {
 	mutex    sync.Mutex
 	messages map[string][]readers.Message
+}
+
+func (repo *messageRepositoryMock) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+	connInflux := ConnInflux()
+	influx := influxdb.New(connInflux, "mainflux")
+
+	m := map[string]string{}
+	m["name"] = "pump_1"
+	return influx.GetLastMeasurement([]string{"ba22f57d-642e-4b82-9718-5e3b68809ac0"}, m)
+}
+
+func (repo *messageRepositoryMock) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+
+	connInflux := ConnInflux()
+	influx := influxdb.New(connInflux, "mainflux")
+
+	m := map[string]string{}
+	m["name"] = "pump_1"
+	m["from"] = "2020-10-13T06:00:00Z"
+	m["to"] = "2020-10-14T06:00:00Z"
+	return influx.PumpRunningSeconds([]string{"ba22f57d-642e-4b82-9718-5e3b68809ac0"}, m)
+}
+
+func (repo *messageRepositoryMock) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
+
+	connInflux := ConnInflux()
+	influx := influxdb.New(connInflux, "mainflux")
+
+	m := map[string]string{}
+	//m["name"] = "pump_1"
+	return influx.GetMessageByPublisher("ba22f57d-642e-4b82-9718-5e3b68809ac0", 1, 5, "", "", m)
 }
 
 // NewMessageRepository returns mock implementation of message repository.
@@ -24,7 +59,20 @@ func NewMessageRepository(messages map[string][]readers.Message) readers.Message
 	}
 }
 
+func ConnInflux() influxdata.Client {
+	cli, err := influxdata.NewHTTPClient(influxdata.HTTPConfig{
+		Addr:     "http://118.31.19.149:8086", /*"http://127.0.0.1:8086"*/
+		Username: "mainflux",                  /*"admin"*/
+		Password: "mainflux",                  /*""*/
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	return cli
+}
+
 func (repo *messageRepositoryMock) ReadAll(chanID string, offset, limit uint64, query map[string]string) (readers.MessagesPage, error) {
+	fmt.Println("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
 	repo.mutex.Lock()
 	defer repo.mutex.Unlock()
 

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -4,7 +4,6 @@
 package mocks
 
 import (
-	"fmt"
 	influxdata "github.com/influxdata/influxdb/client/v2"
 	"log"
 	"sync"
@@ -20,13 +19,13 @@ type messageRepositoryMock struct {
 	messages map[string][]readers.Message
 }
 
-func (repo *messageRepositoryMock) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (repo *messageRepositoryMock) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	connInflux := ConnInflux()
 	influx := influxdb.New(connInflux, "mainflux")
 	return influx.GetLastMeasurement(chanIDs, query)
 }
 
-func (repo *messageRepositoryMock) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
+func (repo *messageRepositoryMock) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.Messages, error) {
 	connInflux := ConnInflux()
 	influx := influxdb.New(connInflux, "mainflux")
 	return influx.PumpRunningSeconds(chanIDs, query)
@@ -59,7 +58,6 @@ func ConnInflux() influxdata.Client {
 }
 
 func (repo *messageRepositoryMock) ReadAll(chanID string, offset, limit uint64, query map[string]string) (readers.MessagesPage, error) {
-	fmt.Println("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
 	repo.mutex.Lock()
 	defer repo.mutex.Unlock()
 

--- a/readers/mocks/messages.go
+++ b/readers/mocks/messages.go
@@ -23,32 +23,19 @@ type messageRepositoryMock struct {
 func (repo *messageRepositoryMock) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
 	connInflux := ConnInflux()
 	influx := influxdb.New(connInflux, "mainflux")
-
-	m := map[string]string{}
-	m["name"] = "pump_1"
-	return influx.GetLastMeasurement([]string{"ba22f57d-642e-4b82-9718-5e3b68809ac0"}, m)
+	return influx.GetLastMeasurement(chanIDs, query)
 }
 
 func (repo *messageRepositoryMock) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.MessagesPage, error) {
-
 	connInflux := ConnInflux()
 	influx := influxdb.New(connInflux, "mainflux")
-
-	m := map[string]string{}
-	m["name"] = "pump_1"
-	m["from"] = "2020-10-13T06:00:00Z"
-	m["to"] = "2020-10-14T06:00:00Z"
-	return influx.PumpRunningSeconds([]string{"ba22f57d-642e-4b82-9718-5e3b68809ac0"}, m)
+	return influx.PumpRunningSeconds(chanIDs, query)
 }
 
 func (repo *messageRepositoryMock) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
-
 	connInflux := ConnInflux()
 	influx := influxdb.New(connInflux, "mainflux")
-
-	m := map[string]string{}
-	//m["name"] = "pump_1"
-	return influx.GetMessageByPublisher("ba22f57d-642e-4b82-9718-5e3b68809ac0", 1, 5, "", "", m)
+	return influx.GetMessageByPublisher(chanID, offset, limit, aggregationType, interval, query)
 }
 
 // NewMessageRepository returns mock implementation of message repository.

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -29,6 +29,18 @@ type mongoRepository struct {
 	db *mongo.Database
 }
 
+func (repo mongoRepository) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.Messages, error) {
+	panic("implement me")
+}
+
+func (repo mongoRepository) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.Messages, error) {
+	panic("implement me")
+}
+
+func (repo mongoRepository) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
 // New returns new MongoDB reader.
 func New(db *mongo.Database) readers.MessageRepository {
 	return mongoRepository{

--- a/readers/openapi.yml
+++ b/readers/openapi.yml
@@ -37,7 +37,7 @@ paths:
           description: Missing or invalid access token provided.
         '500':
           $ref: "#/components/responses/ServiceError"
-  /messages/list/{publisher}:
+  /messages/list/{chanID}:
     get:
       summary: Retrieves timeseries messages sent by things
       description: |
@@ -49,23 +49,23 @@ paths:
         - messages
       operationId: findMessagesByPublisher
       parameters:
-        - $ref: "#/parameters/Publisher"
-        - $ref: "#/parameters/SensorName"
-        - $ref: "#/parameters/StartTime"
-        - $ref: "#/parameters/EndTime"
+        - $ref: "#/components/parameters/ChanId"
+        - $ref: "#/components/parameters/Name"
+        - $ref: "#/components/parameters/From"
+        - $ref: "#/components/parameters/To"
         - $ref: "#/parameters/AggregationType"
         - $ref: "#/parameters/Interval"
       responses:
         200:
           #description: Data retrieved.
-          $ref: "#/components/schemas/TimeseriesData"
+          $ref: "#/components/responses/MessagesPageRes"
         400:
           description: Failed due to malformed query parameters.
         403:
           description: Missing or invalid access token provided.
         500:
           $ref: "#/responses/ServiceError"
-  /messages/last/{publishers}:
+  /messages/last/{chanIDs}:
     get:
       summary: Retrieves last timeseries messages sent by things identified by a list of publishers.
       description: |
@@ -75,12 +75,12 @@ paths:
         - messages
       operationId: getLastMeasurement
       parameters:
-        - $ref: "#/parameters/Publishers"
-        - $ref: "#/parameters/SensorName"
+        - $ref: "#/components/parameters/ChanIds"
+        - $ref: "#/parameters/Name"
       responses:
         200:
           #description: Data retrieved.
-          $ref: "#/components/schemas/TimeseriesData"
+          $ref: "#/components/responses/MessagesPageRes"
         400:
           description: Failed due to malformed query parameters.
         403:
@@ -88,7 +88,7 @@ paths:
         500:
           $ref: "#/responses/ServiceError"
 
-  /timeseries/pumpRunningSeconds/{publishers}:
+  /timeseries/pumpRunningSeconds/{chanIDs}:
     post:
       summary: 获取指定泵站的开启时间
       description: |
@@ -98,14 +98,14 @@ paths:
         - messages
       operationId: pumpRunningSeconds
       parameters:
-        - $ref: "#/parameters/Publishers"
-        - $ref: "#/parameters/SensorNames"
-        - $ref: "#/parameters/StartTime"
-        - $ref: "#/parameters/EndTime"
+        - $ref: "#/components/parameters/ChanIds"
+        - $ref: "#/parameters/Names"
+        - $ref: "#/components/parameters/From"
+        - $ref: "#/components/parameters/To"
       responses:
         200:
           #description: Data retrieved.
-          $ref: "#/components/schemas/TimeseriesData"
+          $ref: "#/components/responses/MessagesPageRes"
         400:
           description: Failed due to malformed query parameters.
         403:

--- a/readers/openapi.yml
+++ b/readers/openapi.yml
@@ -88,7 +88,7 @@ paths:
         500:
           $ref: "#/responses/ServiceError"
 
-  /timeseries/pumpRunningSeconds/{chanIDs}:
+  /messages/pumpRunningSeconds/{chanIDs}:
     post:
       summary: 获取指定泵站的开启时间
       description: |

--- a/readers/openapi.yml
+++ b/readers/openapi.yml
@@ -37,6 +37,81 @@ paths:
           description: Missing or invalid access token provided.
         '500':
           $ref: "#/components/responses/ServiceError"
+  /messages/list/{publisher}:
+    get:
+      summary: Retrieves timeseries messages sent by things
+      description: |
+        Retrieves a list of timeseries messages. Due to performance concerns,
+        data is retrieved in subsets. The API readers must ensure that the
+        entire dataset is consumed either by making subsequent requests, or
+        by increasing the subset size of the initial request.
+      tags:
+        - messages
+      operationId: findMessagesByPublisher
+      parameters:
+        - $ref: "#/parameters/Publisher"
+        - $ref: "#/parameters/SensorName"
+        - $ref: "#/parameters/StartTime"
+        - $ref: "#/parameters/EndTime"
+        - $ref: "#/parameters/AggregationType"
+        - $ref: "#/parameters/Interval"
+      responses:
+        200:
+          #description: Data retrieved.
+          $ref: "#/components/schemas/TimeseriesData"
+        400:
+          description: Failed due to malformed query parameters.
+        403:
+          description: Missing or invalid access token provided.
+        500:
+          $ref: "#/responses/ServiceError"
+  /messages/last/{publishers}:
+    get:
+      summary: Retrieves last timeseries messages sent by things identified by a list of publishers.
+      description: |
+        Retrieves last timeseries messages sent by things identified by a list of publishers.
+        Returned timeseries data can be grouped by sensor name or subtopic.
+      tags:
+        - messages
+      operationId: getLastMeasurement
+      parameters:
+        - $ref: "#/parameters/Publishers"
+        - $ref: "#/parameters/SensorName"
+      responses:
+        200:
+          #description: Data retrieved.
+          $ref: "#/components/schemas/TimeseriesData"
+        400:
+          description: Failed due to malformed query parameters.
+        403:
+          description: Missing or invalid access token provided.
+        500:
+          $ref: "#/responses/ServiceError"
+
+  /timeseries/pumpRunningSeconds/{publishers}:
+    post:
+      summary: 获取指定泵站的开启时间
+      description: |
+        统计多个指定泵站 每个泵站在给定时间(startTime, endTime)内开启的总时间
+        返回结果:TimeseriesData
+      tags:
+        - messages
+      operationId: pumpRunningSeconds
+      parameters:
+        - $ref: "#/parameters/Publishers"
+        - $ref: "#/parameters/SensorNames"
+        - $ref: "#/parameters/StartTime"
+        - $ref: "#/parameters/EndTime"
+      responses:
+        200:
+          #description: Data retrieved.
+          $ref: "#/components/schemas/TimeseriesData"
+        400:
+          description: Failed due to malformed query parameters.
+        403:
+          description: Missing or invalid access token provided.
+        500:
+          $ref: "#/responses/ServiceError"
 
 components:
   schemas:
@@ -95,7 +170,47 @@ components:
               updateTime:
                 type: number
                 description: Time of updating measurement.
-
+    TimeseriesData:
+      type: object
+      properties:
+        messages:
+          type: array
+          minItems: 0
+          uniqueItems: true
+          items:
+            $ref: "#/definitions/TimeseriesDataArray"
+    TimeseriesDataArray:
+      type: object
+      properties:
+        publisher:
+          type: string
+          description: Publisher ID.
+        name:
+          type: string
+          description: Name of the sensor.
+        subtopic:
+          type: string
+          description: Message subtopic.
+        unit:
+          type: string
+          description: Unit of the measurement.
+        total:
+          type: integer
+          description: Total number of datapoints.
+        data:
+          type: array
+          minItems: 0
+          items:
+            $ref: "#/definitions/TimeseriesDataPoint"
+    TimeseriesDataPoint:
+      type: object
+      properties:
+        value:
+          type: number
+          description: Measured value in number.
+        time:
+          type: string
+          description: Time of measurement.
   parameters:
     Authorization:
       name: Authorization
@@ -188,8 +303,66 @@ components:
       schema:
         type: float
       required: false
+    Publishers:
+      name: publishers
+      description: A comma-separated list of publisher identifiers.
+      in: path
+      schema:
+        type: string
+      required: true
+    SensorName:
+      name: sensorName
+      description: Filter by name of the sensor.
+      in: query
+      schema:
+        type: string
+    SensorNames:
+      name: SensorNames
+      description: SensorName list
+      in: query
+      schema:
+        type: string
+    SubTopic:
+      name: subTopic
+      description: Filter by name of the subtopic.
+      in: query
+      schema:
+        type: string
+    StartTime:
+      name: startTime
+      description: The start timestamp of the requested timeframe, in UTC milliseconds.
+      in: query
+      schema:
+        type: string
+    EndTime:
+      name: endTime
+      description: The end timestamp of the requested timeframe, in UTC milliseconds.
+      in: query
+      schema:
+        type: string
+    AggregationType:
+      name: aggregationType
+      description: The aggregation type for the resulting data points.
+      in: query
+      schema:
+        type: string
+#      enum:
+#        - AVG
+#        - COUNT
+#        - MAX
+#        - MEDIAN
+#        - MIN
+#        - PERCENTILE
+#        - SUM
+    Interval:
+      name: interval
+      description: Time interval
+      in: query
+      schema:
+        type: string
 
   responses:
+
     MessagesPageRes:
       description: Data retrieved.
       content:

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -30,6 +30,18 @@ type postgresRepository struct {
 	db *sqlx.DB
 }
 
+func (tr postgresRepository) GetLastMeasurement(chanIDs []string, query map[string]string) (readers.Messages, error) {
+	panic("implement me")
+}
+
+func (tr postgresRepository) PumpRunningSeconds(chanIDs []string, query map[string]string) (readers.Messages, error) {
+	panic("implement me")
+}
+
+func (tr postgresRepository) GetMessageByPublisher(chanID string, offset, limit uint64, aggregationType string, interval string, query map[string]string) (readers.MessagesPage, error) {
+	panic("implement me")
+}
+
 // New returns new PostgreSQL writer.
 func New(db *sqlx.DB) readers.MessageRepository {
 	return &postgresRepository{


### PR DESCRIPTION
### What does this do?
完成influxdb读写接口

### Which issue(s) does this PR fix/relate to?
涉及到了readers包下的 influxdb功能扩展。

### List any changes that modify/break current functionality
修改了readers/messages.go中的MessageRepository接口 向他添加了三个方法声明
修改了readers/api/requests.go,向其中添加了几个request请求结构体
修改了readers/api/transport.go,向其中添加了处理新增接口的request handler，修改了encodeResponse方法的返回结果方式
修改了readers/api/endpoint.go，向其中添加了请求处理方法
修改了readers/api/endpoint_test.go,向其中添加了test代码，已测试通过
修改了readers/influxdb/messages.go，向其中添加了查询influxdb新方法，并重写结果集解析函数和条件查询装配方法
由于MessageRepository被修改，导致其他实现接口的代码也要同步更新 实现接口新增方法，目前默认实现是抛出异常

### Have you included tests for your changes?
是的 包含了测试
### Did you document any new/modified functionality?
对influxdb数据库进行读写操作
1.根据publisher等参数查询数据
2.查询最后一条publishers对应的记录
3.查询指定多个publishers及时间段泵站的总开启时间
