### PR TITLE
MF-1317

### DIFF
--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -4,12 +4,16 @@
 package api
 
 import (
+	"os"
+	"regexp"
+
 	"github.com/mainflux/mainflux/users"
 )
 
 const (
-	minPassLen  = 8
-	maxNameSize = 1024
+	minPassLen       = 8
+	maxNameSize      = 1024
+	defaultPassRegex = "^.{8,}$"
 )
 
 type userReq struct {
@@ -100,7 +104,13 @@ func (req passwChangeReq) validate() error {
 	if req.Token == "" {
 		return users.ErrUnauthorizedAccess
 	}
-	if len(req.Password) < minPassLen {
+	envPassRegex := os.Getenv("ENVPASSREGEX")
+	if envPassRegex != "" {
+		match, _ := regexp.MatchString(envPassRegex, req.Password)
+		if !match {
+			return users.ErrMalformedEntity
+		}
+	} else if match, _ := regexp.MatchString(defaultPassRegex, req.Password); !match {
 		return users.ErrMalformedEntity
 	}
 	if req.OldPassword == "" {


### PR DESCRIPTION
### What does this do?
It checks if user has defined a pattern for passwords with an environment var (envpassregex)
If this environment var is set, passwords should match with it
If this is not set, for backward compatibility a default regex will be used
This default regex only checks that password length be greater than or equal to 8 chars

### Which issue(s) does this PR fix/relate to?
Resolves #1317

### List any changes that modify/break current functionality
It doesn't break any functionality and it is completely backward compatible

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
