### PR TITLE
MF-1365 - Add ADOPTERS.md file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -27,10 +27,10 @@ Pull request commit must be [signed](https://docs.github.com/en/github/authentic
 
 **The list of organizations/users that have publicly shared the usage of Mainflux:**
 
-**Note**: There are several other organizations/users that couldn't publicly share their usage details but are active project contributors and Mainflux Community members.
+**Note**: Several other organizations/users couldn't publicly share their usage details but are active project contributors and Mainflux Community members.
 
 
 ## Adopters list (alphabetical)
 
 
-**Note:** The list is maintained by the user themselves. If you find yourself on this list, and you think it's inappropriate. Please contact [project maintainers](https://github.com/mainflux/mainflux/blob/master/MAINTAINERS) and you will be permanently removed from the list.
+**Note:** The list is maintained by the users themselves. If you find yourself on this list, and you think it's inappropriate. Please contact [project maintainers](https://github.com/mainflux/mainflux/blob/master/MAINTAINERS) and you will be permanently removed from the list.

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,32 @@
+# Adopters
+
+As Mainflux Community grows, we'd like to keep track of Mainflux adopters to grow the community, contact other users, share experiences and best practices.
+
+To accomplish this, we created a public ledger. The list of organizations and users who consider themselves as Mainflux adopters and that **publicly/officially** shared information and/or details of their adoption journey(optional).
+Where users themselves directly maintain the list.
+
+## Adding yourself as an adopter
+If you are using Mainflux, please consider adding yourself as an adopter with a brief description of your use case by opening a pull request to this file and adding a section describing your adoption of Mainflux technology.
+
+**Please send PRs to add or remove organizations/users**
+
+### Format
+
+```
+N: Name of user (company or individual)
+D: Short Use Case Description (optional)
+L: Link with further information (optional)
+T: Type of adaptation: Evaluation, Core Technology, Production Usage (optional)
+```
+
+## Requirements
+* You must represent the user or organization listed. Do NOT add entries on behalf of other organizations or individuals.
+Pull request commit must be [signed](https://docs.github.com/en/github/authenticating-to-github/signing-commits) and auto-checked with [ Developer Certificate of Origin (DCO)](https://probot.github.io/apps/dco/)
+* There is no minimum requirement or adaptation size, but we request to list permanent deployments only, i.e., no demo or trial deployments. Commercial or production use is not required. A well-done home lab setup can be equally impressive as a large-scale commercial deployment.
+
+
+**The list of organizations/users that have publicly shared the usage of Mainflux:**
+
+**Note**: There are several other organizations/users that couldn't publicly share their usage details but are active project contributors and Mainflux Community members.
+
+## Adopters list (alphabetical)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -29,4 +29,8 @@ Pull request commit must be [signed](https://docs.github.com/en/github/authentic
 
 **Note**: There are several other organizations/users that couldn't publicly share their usage details but are active project contributors and Mainflux Community members.
 
+
 ## Adopters list (alphabetical)
+
+
+**Note:** The list is maintained by the user themselves. If you find yourself on this list, and you think it's inappropriate. Please contact [project maintainers](https://github.com/mainflux/mainflux/blob/master/MAINTAINERS) and you will be permanently removed from the list.


### PR DESCRIPTION
### What does this do?
It adds the ADOPTERS.md file, a public ledger that tracks Mainflux technology adopters. Maintained by users themselves.
### Which issue(s) does this PR fix/relate to?
Resolve #1365 
### List any changes that modify/break current functionality
NA
### Have you included tests for your changes?
NA
### Did you document any new/modified functionality?
NA
### Notes
NA