### PR TITLE
NOISSUE - Fix CoAP Adapter README

### DIFF
--- a/coap/README.md
+++ b/coap/README.md
@@ -56,5 +56,5 @@ $GOBIN/mainflux-coap
 
 ## Usage
 
-If CoAP adapter is running locally (on default 5683 port), a valid URL would be: `coap://localhost/channels/<channel_id>/messages?authorization=<thing_auth_key>`.
-Since CoAP protocol does not support `Authorization` header (option) and options have limited size, in order to send CoAP messages, valid `authorization` value (a valid Thing key) must be present in `Uri-Query` option.
+If CoAP adapter is running locally (on default 5683 port), a valid URL would be: `coap://localhost/channels/<channel_id>/messages?auth=<thing_auth_key>`.
+Since CoAP protocol does not support `Authorization` header (option) and options have limited size, in order to send CoAP messages, valid `auth` value (a valid Thing key) must be present in `Uri-Query` option.


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes CoAP Adapter README file. It fixes the use of `authorization` Uri-Query CoAP Option in favor of shorter `auth`.

### Which issue(s) does this PR fix/relate to?
There is no such issue.

### List any changes that modify/break current functionality
There are no such changes. 

### Have you included tests for your changes?
N/A.

### Did you document any new/modified functionality?
Yes, this is a documentation update.