### PR TITLE
NOISSUE - Add ordering direction in response body

### DIFF
--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -170,6 +170,7 @@ func (cr channelRepository) RetrieveAll(ctx context.Context, owner string, pm th
 			Offset: pm.Offset,
 			Limit:  pm.Limit,
 			Order:  pm.Order,
+			Dir:    pm.Dir,
 		},
 	}
 

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -237,6 +237,7 @@ func (tr thingRepository) RetrieveByIDs(ctx context.Context, thingIDs []string, 
 			Offset: pm.Offset,
 			Limit:  pm.Limit,
 			Order:  pm.Order,
+			Dir:    pm.Dir,
 		},
 	}
 
@@ -297,6 +298,7 @@ func (tr thingRepository) RetrieveAll(ctx context.Context, owner string, pm thin
 			Offset: pm.Offset,
 			Limit:  pm.Limit,
 			Order:  pm.Order,
+			Dir:    pm.Dir,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ivan Milosevic <iva@blokovi.com>

### What does this do?

Add order direction (asc/desc) in response metadata

### Which issue(s) does this PR fix/relate to?
No issue

