### PR TITLE
NOISSUE - dont retrieve groups when retrieving users

### DIFF
--- a/users/api/responses.go
+++ b/users/api/responses.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/mainflux/mainflux"
-	"github.com/mainflux/mainflux/auth"
 )
 
 var (
@@ -93,7 +92,6 @@ func (res updateUserRes) Empty() bool {
 type viewUserRes struct {
 	ID       string                 `json:"id"`
 	Email    string                 `json:"email"`
-	Groups   []auth.Group           `json:"groups"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION

### What does this do?
when retrieving users response will not show groups

### Which issue(s) does this PR fix/relate to?
None

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Not needed

### Did you document any new/modified functionality?
Yes

### Notes
