### PR TITLE
MF-1403 - Change vernemq building source revision

### DIFF
--- a/docker/vernemq/Dockerfile
+++ b/docker/vernemq/Dockerfile
@@ -1,8 +1,9 @@
 # Builder
 FROM erlang:22-alpine AS builder
 RUN apk add --update git build-base bsd-compat-headers openssl-dev snappy-dev curl \
-    && git clone -b 1.11.0 https://github.com/vernemq/vernemq \
+    && git clone https://github.com/vernemq/vernemq \
     && cd vernemq \
+    && git checkout eb1a262035af47e90d9edf07f36c1b1503557c1f \
     && make -j 16 rel
 
 # Executor


### PR DESCRIPTION
Signed-off-by: Ivan Milosevic <iva@blokovi.com>

Since building vernemq docker image is broken on latest vernemq release, this fixes it by switching to revision where this issue is addressed.