### PR TITLE
MF-1423 - Wrong error handling in JSON Transformer

### DIFF
--- a/pkg/transformers/json/transformer.go
+++ b/pkg/transformers/json/transformer.go
@@ -44,6 +44,9 @@ func transformer(msg messaging.Message) (interface{}, error) {
 		Channel:   msg.Channel,
 		Subtopic:  msg.Subtopic,
 	}
+	if ret.Subtopic == "" {
+		return nil, errors.Wrap(ErrTransform, errUnknownFormat)
+	}
 	subs := strings.Split(ret.Subtopic, ".")
 	if len(subs) == 0 {
 		return nil, errors.Wrap(ErrTransform, errUnknownFormat)

--- a/pkg/transformers/json/transformer_test.go
+++ b/pkg/transformers/json/transformer_test.go
@@ -56,6 +56,9 @@ func TestTransformJSON(t *testing.T) {
 		Format: msg.Subtopic,
 	}
 
+	invalidFmt := msg
+	invalidFmt.Subtopic = ""
+
 	listJSON := json.Messages{
 		Data: []json.Message{
 			{
@@ -99,6 +102,12 @@ func TestTransformJSON(t *testing.T) {
 			msg:  msg,
 			json: jsonMsg,
 			err:  nil,
+		},
+		{
+			desc: "test transform JSON with an invalid subtopic",
+			msg:  invalidFmt,
+			json: nil,
+			err:  json.ErrTransform,
 		},
 		{
 			desc: "test transform JSON array",


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes an empty subtopic bug in JSON Transformer.

### Which issue(s) does this PR fix/relate to?
This pull request fixes #1423.

### List any changes that modify/break current functionality
An empty subtopic in Mainflux Message will result in an error in JSON Transformer.

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
Yes.