### PR TITLE
MF-1435 - Fix fetching user members of an empty group

### DIFF
--- a/users/postgres/users.go
+++ b/users/postgres/users.go
@@ -168,12 +168,20 @@ func (ur userRepository) RetrieveAll(ctx context.Context, offset, limit uint64, 
 	if mq != "" {
 		query = append(query, mq)
 	}
-	if len(userIDs) > 0 {
-		query = append(query, fmt.Sprintf("id IN ('%s')", strings.Join(userIDs, "','")))
+
+	if len(userIDs) == 0 {
+		return users.UserPage{
+			Users: []users.User{},
+			PageMetadata: users.PageMetadata{
+				Total:  0,
+				Offset: offset,
+				Limit:  limit,
+			},
+		}, nil
 	}
-	if len(query) > 0 {
-		emq = fmt.Sprintf(" WHERE %s", strings.Join(query, " AND "))
-	}
+
+	query = append(query, fmt.Sprintf("id IN ('%s')", strings.Join(userIDs, "','")))
+	emq = fmt.Sprintf(" WHERE %s", strings.Join(query, " AND "))
 
 	q := fmt.Sprintf(`SELECT id, email, metadata FROM users %s ORDER BY email LIMIT :limit OFFSET :offset;`, emq)
 	params := map[string]interface{}{

--- a/users/postgres/users_test.go
+++ b/users/postgres/users_test.go
@@ -137,6 +137,7 @@ func TestRetrieveAll(t *testing.T) {
 			limit:  nUsers,
 			size:   nUsers,
 			total:  nUsers,
+			ids:    ids,
 		},
 		"retrieve all users by email with limit and offset": {
 			email:  "All",
@@ -144,6 +145,7 @@ func TestRetrieveAll(t *testing.T) {
 			limit:  5,
 			size:   5,
 			total:  nUsers,
+			ids:    ids,
 		},
 		"retrieve all users by metadata": {
 			email:    "All",
@@ -152,6 +154,7 @@ func TestRetrieveAll(t *testing.T) {
 			size:     metaNum,
 			total:    nUsers,
 			metadata: meta,
+			ids:      ids,
 		},
 		"retrieve users by metadata and ids": {
 			email:    "All",
@@ -169,6 +172,7 @@ func TestRetrieveAll(t *testing.T) {
 			size:     0,
 			total:    nUsers,
 			metadata: wrongMeta,
+			ids:      ids,
 		},
 		"retrieve users by wrong metadata and ids": {
 			email:    "All",
@@ -194,6 +198,15 @@ func TestRetrieveAll(t *testing.T) {
 			size:     1,
 			total:    nUsers,
 			ids:      ids[0:5],
+			metadata: meta,
+		},
+		"retrieve all users from empty ids": {
+			email:    "All",
+			offset:   1,
+			limit:    5,
+			size:     0,
+			total:    nUsers,
+			ids:      []string{},
 			metadata: meta,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?
This PR prevents fetching all user members from empty groups while using `/groups/<group_id>` endpoint of the `users` package.

### Which issue(s) does this PR fix/relate to?
Resolves #1435 

### List any changes that modify/break current functionality

I updated `users/postgres/users_test.go`

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
