### PR TITLE
NOISSUE - Update the /disconnect endpoint HTTP method as PUT

### DIFF
--- a/api/things.yml
+++ b/api/things.yml
@@ -380,13 +380,13 @@ paths:
       summary: Disconnect things and channels using lists of IDs.
       description: |
         Disconnect things from channels specified by lists of IDs.
-        Channel and thing are owned by user identified using the provided access token.
+        Channels and things are owned by user identified using the provided access token.
       tags:
       - things
       parameters:
       - $ref: "#/components/parameters/Authorization"
       requestBody:
-        $ref: "#/components/requestBodies/DisConnCreateReq"
+        $ref: "#/components/requestBodies/DisconnReq"
       responses:
         '200':
           $ref: "#/components/responses/DisconnRes"
@@ -937,7 +937,7 @@ components:
         application/json:
           schema:
            $ref: "#/components/schemas/ConnectionReqSchema"
-    DisConnCreateReq:
+    DisconnReq:
       description: JSON-formatted document describing the entities for disconnection.
       required: true
       content:

--- a/api/things.yml
+++ b/api/things.yml
@@ -375,6 +375,31 @@ paths:
           description: Missing or invalid content type.
         '500':
           $ref: "#/components/responses/ServiceError"
+  /disconnect:
+    post:
+      summary: Disconnect things and channels using lists of IDs.
+      description: |
+        Disconnect things from channels specified by lists of IDs.
+        Channel and thing are owned by user identified using the provided access token.
+      tags:
+      - things
+      parameters:
+      - $ref: "#/components/parameters/Authorization"
+      requestBody:
+        $ref: "#/components/requestBodies/DisConnCreateReq"
+      responses:
+        '200':
+          $ref: "#/components/responses/DisconnRes"
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '404':
+          description: A non-existent entity request.
+        '415':
+          description: Missing or invalid content type.
+        '500':
+          $ref: "#/components/responses/ServiceError"
   /things/{thingId}/channels:
     get:
       summary: List of channels connected to specified thing
@@ -912,6 +937,13 @@ components:
         application/json:
           schema:
            $ref: "#/components/schemas/ConnectionReqSchema"
+    DisConnCreateReq:
+      description: JSON-formatted document describing the entities for disconnection.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectionReqSchema"
     IdentityReq:
       description: JSON-formatted document that contains thing key.
       required: true
@@ -993,6 +1025,8 @@ components:
                 type: string
                 description: Created thing's relative URL.
                 example: /things/{thingId}
+    DisconnRes:
+      description: Things disconnected.
     AccessGrantedRes:
       description: |
         Thing has access to the specified channel and the thing ID is returned.

--- a/api/things.yml
+++ b/api/things.yml
@@ -376,7 +376,7 @@ paths:
         '500':
           $ref: "#/components/responses/ServiceError"
   /disconnect:
-    post:
+    put:
       summary: Disconnect things and channels using lists of IDs.
       description: |
         Disconnect things from channels specified by lists of IDs.

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -2587,7 +2587,7 @@ func TestDisconnectList(t *testing.T) {
 
 		req := testRequest{
 			client:      ts.Client(),
-			method:      http.MethodDelete,
+			method:      http.MethodPost,
 			url:         fmt.Sprintf("%s/disconnect", ts.URL),
 			contentType: tc.contentType,
 			token:       tc.auth,

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -2587,7 +2587,7 @@ func TestDisconnectList(t *testing.T) {
 
 		req := testRequest{
 			client:      ts.Client(),
-			method:      http.MethodPost,
+			method:      http.MethodPut,
 			url:         fmt.Sprintf("%s/disconnect", ts.URL),
 			contentType: tc.contentType,
 			token:       tc.auth,

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -162,7 +162,7 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service) http.Handler {
 		opts...,
 	))
 
-	r.Post("/disconnect", kithttp.NewServer(
+	r.Put("/disconnect", kithttp.NewServer(
 		kitot.TraceServer(tracer, "disconnect")(disconnectEndpoint(svc)),
 		decodeConnectList,
 		encodeResponse,

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -162,7 +162,7 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service) http.Handler {
 		opts...,
 	))
 
-	r.Delete("/disconnect", kithttp.NewServer(
+	r.Post("/disconnect", kithttp.NewServer(
 		kitot.TraceServer(tracer, "disconnect")(disconnectEndpoint(svc)),
 		decodeConnectList,
 		encodeResponse,


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?
This PR updates the HTTP request method of the `/disconnect` endpoint (from `DELETE` to `PUT`). According to [OpenAPI specification](https://swagger.io/specification/#operationRequestBody):

> The requestBody is only supported in HTTP methods where the HTTP 1.1 specification RFC7231 has explicitly defined semantics for request bodies. In other cases where the HTTP spec is vague, requestBody SHALL be ignored by consumers.

Since the `DELETE` method does not have explicitly defined semantics, It is updated as the `PUT` method.

Furthermore, this PR adds OpenAPI specifications for the Swagger UI.

### Which issue(s) does this PR fix/relate to?
None
### List any changes that modify/break current functionality
The HTTP request method of the `/disconnect` endpoint is updated.

### Have you included tests for your changes?
The current tests are updated based on the new method.

### Did you document any new/modified functionality?
The documentation will be added.

### Notes
