### PR TITLE
MF-1454 - Add Policies for sharing a Thing

### DIFF
--- a/api/things.yml
+++ b/api/things.yml
@@ -177,6 +177,32 @@ paths:
           description: Missing or invalid access token provided.
         '500':
           $ref: "#/components/responses/ServiceError"
+  /things/{thingId}/share:
+    post:
+      summary: Shares a thing with user identified by request body.
+      description: |
+        Adds 'read', 'write' or 'delete' policies to the user identified by the request body.
+        Sharing a particular thing is only allowed to users who have 'write' access to that thing.
+      tags:
+        - things
+      parameters:
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/ThingId"
+      requestBody:
+        $ref: "#/components/requestBodies/ShareThingReq"
+      responses:
+        '200':
+          description: Policies shared.
+        '400':
+          description: Failed due to malformed JSON.
+        '401':
+          description: Missing or invalid access token provided.
+        '403':
+          description: Lack of policies in order to share the thing.
+        '415':
+          description: Missing or invalid content type.
+        '500':
+          $ref: "#/components/responses/ServiceError"
   /things/{thingId}/key:
     patch:
       summary: Updates thing key
@@ -756,6 +782,19 @@ components:
           description: Thing IDs
           items:
             type: string
+    ShareThingReqSchema:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID.
+          items:
+            type: string
+        policies:
+          type: array
+          description: Policies
+          items:
+            type: string
 
   parameters:
     Authorization:
@@ -970,6 +1009,13 @@ components:
                 type: string
                 format: uuid
                 description: Thing ID by which thing is uniquely identified.
+    ShareThingReq:
+      description: JSON-formatted document describing sharing things policies.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ShareThingReqSchema"
 
   responses:
     CreateThingRes:

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -228,7 +228,7 @@ func (svc *mainfluxThings) Identify(context.Context, string) (string, error) {
 	panic("not implemented")
 }
 
-func (svc *mainfluxThings) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+func (svc *mainfluxThings) ShareThing(ctx context.Context, token, thingID string, actions, userIDs []string) error {
 	panic("not implemented")
 }
 

--- a/bootstrap/mocks/things.go
+++ b/bootstrap/mocks/things.go
@@ -228,6 +228,10 @@ func (svc *mainfluxThings) Identify(context.Context, string) (string, error) {
 	panic("not implemented")
 }
 
+func (svc *mainfluxThings) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+	panic("not implemented")
+}
+
 func findIndex(list []string, val string) int {
 	for i, v := range list {
 		if v == val {

--- a/certs/service_test.go
+++ b/certs/service_test.go
@@ -62,7 +62,8 @@ func newService(tokens map[string]string) (certs.Service, error) {
 	ac := bsmocks.NewAuthClient(map[string]string{token: email})
 	server := newThingsServer(newThingsService(ac))
 
-	auth := thmocks.NewAuthService(tokens)
+	policies := []thmocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := thmocks.NewAuthService(tokens, map[string][]thmocks.MockSubjectSet{email: policies})
 	config := mfsdk.Config{
 		ThingsURL: server.URL,
 	}

--- a/cli/provision.go
+++ b/cli/provision.go
@@ -19,10 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	jsonExt = ".json"
-	csvExt  = ".csv"
-)
+const jsonExt = ".json"
+const csvExt = ".csv"
 
 var cmdProvision = []cobra.Command{
 	{

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -40,7 +40,8 @@ var (
 )
 
 func newThingsService(tokens map[string]string) things.Service {
-	auth := mocks.NewAuthService(tokens)
+	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)
@@ -211,7 +212,7 @@ func TestThing(t *testing.T) {
 			desc:     "get non-existent thing",
 			thID:     "43",
 			token:    token,
-			err:      createError(sdk.ErrFailedFetch, http.StatusNotFound),
+			err:      createError(sdk.ErrFailedFetch, http.StatusForbidden),
 			response: sdk.Thing{},
 		},
 		{
@@ -491,7 +492,7 @@ func TestUpdateThing(t *testing.T) {
 				Metadata: metadata,
 			},
 			token: token,
-			err:   createError(sdk.ErrFailedUpdate, http.StatusNotFound),
+			err:   createError(sdk.ErrFailedUpdate, http.StatusForbidden),
 		},
 		{
 			desc: "update channel with invalid id",
@@ -561,7 +562,7 @@ func TestDeleteThing(t *testing.T) {
 			desc:    "delete non-existing thing",
 			thingID: "2",
 			token:   token,
-			err:     nil,
+			err:     createError(sdk.ErrFailedRemoval, http.StatusForbidden),
 		},
 		{
 			desc:    "delete thing with invalid id",

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mainflux/mainflux/users/mocks"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -144,7 +145,8 @@ func TestCreateToken(t *testing.T) {
 
 	tkn, _ := auth.Issue(context.Background(), &mainflux.IssueReq{Id: user.ID, Email: user.Email, Type: 0})
 	token := tkn.GetValue()
-	mainfluxSDK.CreateUser(token, user)
+	_, err := mainfluxSDK.CreateUser(token, user)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := []struct {
 		desc  string

--- a/things/api/auth/grpc/setup_test.go
+++ b/things/api/auth/grpc/setup_test.go
@@ -42,7 +42,8 @@ func startServer() {
 }
 
 func newService(tokens map[string]string) things.Service {
-	auth := mocks.NewAuthService(tokens)
+	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)

--- a/things/api/auth/http/endpoint_test.go
+++ b/things/api/auth/http/endpoint_test.go
@@ -66,7 +66,8 @@ func toJSON(data interface{}) string {
 }
 
 func newService(tokens map[string]string) things.Service {
-	auth := mocks.NewAuthService(tokens)
+	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -52,7 +52,7 @@ func (lm *loggingMiddleware) UpdateThing(ctx context.Context, token string, thin
 	return lm.svc.UpdateThing(ctx, token, thing)
 }
 
-func (lm *loggingMiddleware) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) (err error) {
+func (lm *loggingMiddleware) ShareThing(ctx context.Context, token, thingID string, actions, userIDs []string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method share_thing for token %s and thing %s took %s to complete", token, thingID, time.Since(begin))
 		if err != nil {
@@ -62,7 +62,7 @@ func (lm *loggingMiddleware) ShareThing(ctx context.Context, token, thingID stri
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+	return lm.svc.ShareThing(ctx, token, thingID, actions, userIDs)
 }
 
 func (lm *loggingMiddleware) UpdateKey(ctx context.Context, token, id, key string) (err error) {

--- a/things/api/logging.go
+++ b/things/api/logging.go
@@ -52,6 +52,19 @@ func (lm *loggingMiddleware) UpdateThing(ctx context.Context, token string, thin
 	return lm.svc.UpdateThing(ctx, token, thing)
 }
 
+func (lm *loggingMiddleware) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method share_thing for token %s and thing %s took %s to complete", token, thingID, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+}
+
 func (lm *loggingMiddleware) UpdateKey(ctx context.Context, token, id, key string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method update_key for thing %s and key %s took %s to complete", id, key, time.Since(begin))

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -48,13 +48,13 @@ func (ms *metricsMiddleware) UpdateThing(ctx context.Context, token string, thin
 	return ms.svc.UpdateThing(ctx, token, thing)
 }
 
-func (ms *metricsMiddleware) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+func (ms *metricsMiddleware) ShareThing(ctx context.Context, token, thingID string, actions, userIDs []string) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "share_thing").Add(1)
 		ms.latency.With("method", "share_thing").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+	return ms.svc.ShareThing(ctx, token, thingID, actions, userIDs)
 }
 
 func (ms *metricsMiddleware) UpdateKey(ctx context.Context, token, id, key string) error {

--- a/things/api/metrics.go
+++ b/things/api/metrics.go
@@ -48,6 +48,15 @@ func (ms *metricsMiddleware) UpdateThing(ctx context.Context, token string, thin
 	return ms.svc.UpdateThing(ctx, token, thing)
 }
 
+func (ms *metricsMiddleware) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "share_thing").Add(1)
+		ms.latency.With("method", "share_thing").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+}
+
 func (ms *metricsMiddleware) UpdateKey(ctx context.Context, token, id, key string) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "update_key").Add(1)

--- a/things/api/things/http/endpoint.go
+++ b/things/api/things/http/endpoint.go
@@ -81,6 +81,21 @@ func createThingsEndpoint(svc things.Service) endpoint.Endpoint {
 	}
 }
 
+func shareThingEndpoint(svc things.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(shareThingReq)
+		if err := req.validate(); err != nil {
+			return nil, err
+		}
+
+		if err := svc.ShareThing(ctx, req.token, req.thingID, req.Policies, req.UserIDs); err != nil {
+			return nil, err
+		}
+
+		return shareThingRes{}, nil
+	}
+}
+
 func updateThingEndpoint(svc things.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(updateThingReq)

--- a/things/api/things/http/requests.go
+++ b/things/api/things/http/requests.go
@@ -15,6 +15,9 @@ const (
 	idOrder      = "id"
 	ascDir       = "asc"
 	descDir      = "desc"
+	readPolicy   = "read"
+	writePolicy  = "write"
+	deletePolicy = "delete"
 )
 
 type createThingReq struct {
@@ -56,6 +59,29 @@ func (req createThingsReq) validate() error {
 		}
 	}
 
+	return nil
+}
+
+type shareThingReq struct {
+	token    string
+	thingID  string
+	UserIDs  []string `json:"user_ids"`
+	Policies []string `json:"policies"`
+}
+
+func (req shareThingReq) validate() error {
+	if req.token == "" {
+		return things.ErrUnauthorizedAccess
+	}
+
+	if req.thingID == "" || len(req.UserIDs) == 0 || len(req.Policies) == 0 {
+		return things.ErrMalformedEntity
+	}
+	for _, p := range req.Policies {
+		if p != readPolicy && p != writePolicy && p != deletePolicy {
+			return things.ErrMalformedEntity
+		}
+	}
 	return nil
 }
 

--- a/things/api/things/http/responses.go
+++ b/things/api/things/http/responses.go
@@ -22,6 +22,7 @@ var (
 	_ mainflux.Response = (*connectRes)(nil)
 	_ mainflux.Response = (*disconnectThingRes)(nil)
 	_ mainflux.Response = (*disconnectRes)(nil)
+	_ mainflux.Response = (*shareThingRes)(nil)
 )
 
 type removeRes struct{}
@@ -67,6 +68,20 @@ func (res thingRes) Headers() map[string]string {
 
 func (res thingRes) Empty() bool {
 	return true
+}
+
+type shareThingRes struct{}
+
+func (res shareThingRes) Code() int {
+	return http.StatusOK
+}
+
+func (res shareThingRes) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (res shareThingRes) Empty() bool {
+	return false
 }
 
 type thingsRes struct {

--- a/things/api/things/http/transport.go
+++ b/things/api/things/http/transport.go
@@ -57,6 +57,13 @@ func MakeHandler(tracer opentracing.Tracer, svc things.Service) http.Handler {
 		opts...,
 	))
 
+	r.Post("/things/:id/share", kithttp.NewServer(
+		kitot.TraceServer(tracer, "share_thing")(shareThingEndpoint(svc)),
+		decodeShareThing,
+		encodeResponse,
+		opts...,
+	))
+
 	r.Patch("/things/:id/key", kithttp.NewServer(
 		kitot.TraceServer(tracer, "update_key")(updateKeyEndpoint(svc)),
 		decodeKeyUpdate,
@@ -216,6 +223,19 @@ func decodeThingsCreation(_ context.Context, r *http.Request) (interface{}, erro
 
 	req := createThingsReq{token: r.Header.Get("Authorization")}
 	if err := json.NewDecoder(r.Body).Decode(&req.Things); err != nil {
+		return nil, errors.Wrap(things.ErrMalformedEntity, err)
+	}
+
+	return req, nil
+}
+
+func decodeShareThing(ctx context.Context, r *http.Request) (interface{}, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), contentType) {
+		return nil, errors.ErrUnsupportedContentType
+	}
+
+	req := shareThingReq{token: r.Header.Get("Authorization"), thingID: bone.GetValue(r, "id")}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(things.ErrMalformedEntity, err)
 	}
 

--- a/things/mocks/auth.go
+++ b/things/mocks/auth.go
@@ -57,6 +57,10 @@ func (svc authServiceMock) Authorize(ctx context.Context, req *mainflux.Authoriz
 }
 
 func (svc authServiceMock) AddPolicy(ctx context.Context, in *mainflux.AddPolicyReq, opts ...grpc.CallOption) (*mainflux.AddPolicyRes, error) {
+	if in.GetAct() == "" || in.GetObj() == "" || in.GetSub() == "" {
+		return &mainflux.AddPolicyRes{}, things.ErrMalformedEntity
+	}
+
 	// Mock thingsRepository saves the thing ID after padding the ID by 3. (see things/mocks/things.go)
 	// Since we are adding policies within the Service layer, we are storing them as a full ID which is
 	// eventually not compatible with the one inside  of the mock things repository. Therefore, we are

--- a/things/mocks/auth.go
+++ b/things/mocks/auth.go
@@ -15,13 +15,19 @@ import (
 
 var _ mainflux.AuthServiceClient = (*authServiceMock)(nil)
 
+type MockSubjectSet struct {
+	Object   string
+	Relation string
+}
+
 type authServiceMock struct {
-	users map[string]string
+	users    map[string]string
+	policies map[string][]MockSubjectSet
 }
 
 // NewAuthService creates mock of users service.
-func NewAuthService(users map[string]string) mainflux.AuthServiceClient {
-	return &authServiceMock{users}
+func NewAuthService(users map[string]string, policies map[string][]MockSubjectSet) mainflux.AuthServiceClient {
+	return &authServiceMock{users, policies}
 }
 
 func (svc authServiceMock) Identify(ctx context.Context, in *mainflux.Token, opts ...grpc.CallOption) (*mainflux.UserIdentity, error) {
@@ -42,8 +48,8 @@ func (svc authServiceMock) Issue(ctx context.Context, in *mainflux.IssueReq, opt
 }
 
 func (svc authServiceMock) Authorize(ctx context.Context, req *mainflux.AuthorizeReq, _ ...grpc.CallOption) (r *mainflux.AuthorizeRes, err error) {
-	if email, ok := svc.users["token"]; ok {
-		if email == req.GetSub() {
+	for _, policy := range svc.policies[req.GetSub()] {
+		if policy.Relation == req.GetAct() && policy.Object == req.GetObj() {
 			return &mainflux.AuthorizeRes{Authorized: true}, nil
 		}
 	}
@@ -51,6 +57,13 @@ func (svc authServiceMock) Authorize(ctx context.Context, req *mainflux.Authoriz
 }
 
 func (svc authServiceMock) AddPolicy(ctx context.Context, in *mainflux.AddPolicyReq, opts ...grpc.CallOption) (*mainflux.AddPolicyRes, error) {
+	// Mock thingsRepository saves the thing ID after padding the ID by 3. (see things/mocks/things.go)
+	// Since we are adding policies within the Service layer, we are storing them as a full ID which is
+	// eventually not compatible with the one inside  of the mock things repository. Therefore, we are
+	// getting last three part of the ID as below.
+	obj := in.GetObj()
+	obj = obj[len(obj)-3:]
+	svc.policies[in.GetSub()] = append(svc.policies[in.GetSub()], MockSubjectSet{Object: obj, Relation: in.GetAct()})
 	return &mainflux.AddPolicyRes{Authorized: true}, nil
 }
 

--- a/things/postgres/things.go
+++ b/things/postgres/things.go
@@ -76,7 +76,7 @@ func (tr thingRepository) Save(ctx context.Context, ths ...things.Thing) ([]thin
 }
 
 func (tr thingRepository) Update(ctx context.Context, t things.Thing) error {
-	q := `UPDATE things SET name = :name, metadata = :metadata WHERE owner = :owner AND id = :id;`
+	q := `UPDATE things SET name = :name, metadata = :metadata WHERE id = :id;`
 
 	dbth, err := toDBThing(t)
 	if err != nil {
@@ -145,14 +145,11 @@ func (tr thingRepository) UpdateKey(ctx context.Context, owner, id, key string) 
 }
 
 func (tr thingRepository) RetrieveByID(ctx context.Context, owner, id string) (things.Thing, error) {
-	q := `SELECT name, key, metadata FROM things WHERE id = $1 AND owner = $2;`
+	q := `SELECT name, key, metadata FROM things WHERE id = $1;`
 
-	dbth := dbThing{
-		ID:    id,
-		Owner: owner,
-	}
+	dbth := dbThing{ID: id}
 
-	if err := tr.db.QueryRowxContext(ctx, q, id, owner).StructScan(&dbth); err != nil {
+	if err := tr.db.QueryRowxContext(ctx, q, id).StructScan(&dbth); err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if err == sql.ErrNoRows || ok && errInvalid == pqErr.Code.Name() {
 			return things.Thing{}, errors.Wrap(things.ErrNotFound, err)
@@ -400,7 +397,7 @@ func (tr thingRepository) Remove(ctx context.Context, owner, id string) error {
 		ID:    id,
 		Owner: owner,
 	}
-	q := `DELETE FROM things WHERE id = :id AND owner = :owner;`
+	q := `DELETE FROM things WHERE id = :id`
 	if _, err := tr.db.NamedExecContext(ctx, q, dbth); err != nil {
 		return errors.Wrap(things.ErrRemoveEntity, err)
 	}

--- a/things/postgres/things_test.go
+++ b/things/postgres/things_test.go
@@ -150,7 +150,7 @@ func TestThingUpdate(t *testing.T) {
 				ID:    thing.ID,
 				Owner: wrongValue,
 			},
-			err: things.ErrNotFound,
+			err: nil,
 		},
 		{
 			desc: "update non-existing thing with non-existing user",
@@ -308,11 +308,6 @@ func TestSingleThingRetrieval(t *testing.T) {
 		"retrieve non-existing thing with existing user": {
 			owner: th.Owner,
 			ID:    nonexistentThingID,
-			err:   things.ErrNotFound,
-		},
-		"retrieve thing with non-existing owner": {
-			owner: wrongValue,
-			ID:    th.ID,
 			err:   things.ErrNotFound,
 		},
 		"retrieve thing with malformed ID": {

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -82,6 +82,10 @@ func (es eventStore) UpdateKey(ctx context.Context, token, id, key string) error
 	return es.svc.UpdateKey(ctx, token, id, key)
 }
 
+func (es eventStore) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+	return es.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+}
+
 func (es eventStore) ViewThing(ctx context.Context, token, id string) (things.Thing, error) {
 	return es.svc.ViewThing(ctx, token, id)
 }

--- a/things/redis/streams.go
+++ b/things/redis/streams.go
@@ -82,8 +82,8 @@ func (es eventStore) UpdateKey(ctx context.Context, token, id, key string) error
 	return es.svc.UpdateKey(ctx, token, id, key)
 }
 
-func (es eventStore) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
-	return es.svc.ShareThing(ctx, token, thingID, policies, userIDs)
+func (es eventStore) ShareThing(ctx context.Context, token, thingID string, actions, userIDs []string) error {
+	return es.svc.ShareThing(ctx, token, thingID, actions, userIDs)
 }
 
 func (es eventStore) ViewThing(ctx context.Context, token, id string) (things.Thing, error) {

--- a/things/redis/streams_test.go
+++ b/things/redis/streams_test.go
@@ -39,7 +39,8 @@ const (
 )
 
 func newService(tokens map[string]string) things.Service {
-	auth := mocks.NewAuthService(tokens)
+	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)

--- a/things/service.go
+++ b/things/service.go
@@ -261,18 +261,14 @@ func (ts *thingsService) claimOwnership(ctx context.Context, thingID string, pol
 		for _, policy := range policies {
 			apr, err := ts.auth.AddPolicy(ctx, &mainflux.AddPolicyReq{Obj: thingID, Act: policy, Sub: userID})
 			if err != nil {
-				errs = accumulateError(errs, errors.Wrap(ErrAuthorization, err), thingID, userID)
+				errs = errors.Wrap(fmt.Errorf("cannot claim ownership on thing '%s' by user '%s': %s", thingID, userID, err), errs)
 			}
 			if !apr.GetAuthorized() {
-				errs = accumulateError(errs, ErrAuthorization, thingID, userID)
+				errs = errors.Wrap(fmt.Errorf("cannot claim ownership on thing '%s' by user '%s': unauthorized", thingID, userID), errs)
 			}
 		}
 	}
 	return errs
-}
-
-func accumulateError(errs, newErr error, thingID, userID string) error {
-	return errors.Wrap(newErr, errors.Wrap(fmt.Errorf("cannot claim ownership on thing: %s by user: %s", thingID, userID), errs))
 }
 
 func (ts *thingsService) UpdateKey(ctx context.Context, token, id, key string) error {

--- a/things/service.go
+++ b/things/service.go
@@ -5,8 +5,7 @@ package things
 
 import (
 	"context"
-
-	"github.com/mainflux/mainflux/users"
+	"fmt"
 
 	"github.com/mainflux/mainflux/pkg/errors"
 
@@ -49,8 +48,10 @@ var (
 
 const (
 	usersObjectKey    = "users"
-	ownerRelationKey  = "owner"
 	memberRelationKey = "member"
+	readRelationKey   = "read"
+	writeRelationKey  = "write"
+	deleteRelationKey = "delete"
 )
 
 // Service specifies an API that must be fullfiled by the domain service
@@ -62,6 +63,9 @@ type Service interface {
 	// UpdateThing updates the thing identified by the provided ID, that
 	// belongs to the user identified by the provided key.
 	UpdateThing(ctx context.Context, token string, thing Thing) error
+
+	// ShareThing gives an access policy of thingID to the given user IDs.
+	ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error
 
 	// UpdateKey updates key value of the existing thing. A non-nil error is
 	// returned to indicate operation failure.
@@ -193,13 +197,13 @@ func (ts *thingsService) CreateThings(ctx context.Context, token string, things 
 	return ths, nil
 }
 
+// createThing saves the Thing and adds identity as an owner(Read, Write, Delete policies) of the Thing.
 func (ts *thingsService) createThing(ctx context.Context, thing *Thing, identity *mainflux.UserIdentity) (Thing, error) {
 	thID, err := ts.idProvider.ID()
 	if err != nil {
 		return Thing{}, errors.Wrap(ErrCreateUUID, err)
 	}
 	thing.ID = thID
-
 	thing.Owner = identity.GetEmail()
 
 	if thing.Key == "" {
@@ -209,17 +213,8 @@ func (ts *thingsService) createThing(ctx context.Context, thing *Thing, identity
 		}
 	}
 
-	req := &mainflux.AddPolicyReq{
-		Sub: identity.GetId(),
-		Obj: thing.ID,
-		Act: ownerRelationKey,
-	}
-	apr, err := ts.auth.AddPolicy(ctx, req)
-	if err != nil {
+	if err := ts.claimOwnership(ctx, thing.ID, []string{readRelationKey, writeRelationKey, deleteRelationKey}, []string{identity.GetId()}); err != nil {
 		return Thing{}, err
-	}
-	if !apr.GetAuthorized() {
-		return Thing{}, users.ErrAuthorization
 	}
 
 	ths, err := ts.things.Save(ctx, *thing)
@@ -238,7 +233,7 @@ func (ts *thingsService) UpdateThing(ctx context.Context, token string, thing Th
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := ts.authorize(ctx, res.GetId(), thing.ID, ownerRelationKey); err != nil {
+	if err := ts.authorize(ctx, res.GetId(), thing.ID, writeRelationKey); err != nil {
 		return err
 	}
 
@@ -247,13 +242,46 @@ func (ts *thingsService) UpdateThing(ctx context.Context, token string, thing Th
 	return ts.things.Update(ctx, thing)
 }
 
+func (ts *thingsService) ShareThing(ctx context.Context, token, thingID string, policies, userIDs []string) error {
+	res, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
+	if err != nil {
+		return errors.Wrap(ErrUnauthorizedAccess, err)
+	}
+
+	if err := ts.authorize(ctx, res.GetId(), thingID, writeRelationKey); err != nil {
+		return err
+	}
+
+	return ts.claimOwnership(ctx, thingID, policies, userIDs)
+}
+
+func (ts *thingsService) claimOwnership(ctx context.Context, thingID string, policies, userIDs []string) error {
+	var errs error
+	for _, userID := range userIDs {
+		for _, policy := range policies {
+			apr, err := ts.auth.AddPolicy(ctx, &mainflux.AddPolicyReq{Obj: thingID, Act: policy, Sub: userID})
+			if err != nil {
+				errs = accumulateError(errs, errors.Wrap(ErrAuthorization, err), thingID, userID)
+			}
+			if !apr.GetAuthorized() {
+				errs = accumulateError(errs, ErrAuthorization, thingID, userID)
+			}
+		}
+	}
+	return errs
+}
+
+func accumulateError(errs, newErr error, thingID, userID string) error {
+	return errors.Wrap(newErr, errors.Wrap(fmt.Errorf("cannot claim ownership on thing: %s by user: %s", thingID, userID), errs))
+}
+
 func (ts *thingsService) UpdateKey(ctx context.Context, token, id, key string) error {
 	res, err := ts.auth.Identify(ctx, &mainflux.Token{Value: token})
 	if err != nil {
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := ts.authorize(ctx, res.GetId(), id, ownerRelationKey); err != nil {
+	if err := ts.authorize(ctx, res.GetId(), id, writeRelationKey); err != nil {
 		return err
 	}
 
@@ -268,7 +296,7 @@ func (ts *thingsService) ViewThing(ctx context.Context, token, id string) (Thing
 		return Thing{}, errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := ts.authorize(ctx, res.GetId(), id, ownerRelationKey); err != nil {
+	if err := ts.authorize(ctx, res.GetId(), id, readRelationKey); err != nil {
 		return Thing{}, err
 	}
 
@@ -299,7 +327,7 @@ func (ts *thingsService) RemoveThing(ctx context.Context, token, id string) erro
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := ts.authorize(ctx, res.GetId(), id, ownerRelationKey); err != nil {
+	if err := ts.authorize(ctx, res.GetId(), id, deleteRelationKey); err != nil {
 		return err
 	}
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -32,7 +32,8 @@ var (
 )
 
 func newService(tokens map[string]string) things.Service {
-	auth := mocks.NewAuthService(tokens)
+	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)
@@ -101,7 +102,7 @@ func TestUpdateThing(t *testing.T) {
 			desc:  "update non-existing thing",
 			thing: other,
 			token: token,
-			err:   things.ErrNotFound,
+			err:   things.ErrAuthorization,
 		},
 	}
 
@@ -144,7 +145,7 @@ func TestUpdateKey(t *testing.T) {
 			token: token,
 			id:    wrongID,
 			key:   wrongValue,
-			err:   things.ErrNotFound,
+			err:   things.ErrAuthorization,
 		},
 	}
 
@@ -152,6 +153,55 @@ func TestUpdateKey(t *testing.T) {
 		err := svc.UpdateKey(context.Background(), tc.token, tc.id, tc.key)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 	}
+}
+
+func TestShareThing(t *testing.T) {
+	email2 := "user2@example.com"
+	svc := newService(map[string]string{token: email, token2: email2})
+	ths, err := svc.CreateThings(context.Background(), token, thing)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
+	th := ths[0]
+	policies := []string{"read"}
+
+	cases := []struct {
+		desc     string
+		token    string
+		thingID  string
+		policies []string
+		userIDs  []string
+		err      error
+	}{
+		{
+			desc:     "share a thing with a valid user",
+			token:    token,
+			thingID:  th.ID,
+			policies: policies,
+			userIDs:  []string{email2},
+			err:      nil,
+		},
+		{
+			desc:     "share a thing via unauthorized access",
+			token:    token2,
+			thingID:  th.ID,
+			policies: policies,
+			userIDs:  []string{email2},
+			err:      things.ErrAuthorization,
+		},
+		{
+			desc:     "share a thing with invalid token",
+			token:    wrongValue,
+			thingID:  th.ID,
+			policies: policies,
+			userIDs:  []string{email2},
+			err:      things.ErrUnauthorizedAccess,
+		},
+	}
+
+	for _, tc := range cases {
+		err := svc.ShareThing(context.Background(), tc.token, tc.thingID, tc.policies, tc.userIDs)
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+
 }
 
 func TestViewThing(t *testing.T) {
@@ -178,7 +228,7 @@ func TestViewThing(t *testing.T) {
 		"view non-existing thing": {
 			id:    wrongID,
 			token: token,
-			err:   things.ErrNotFound,
+			err:   things.ErrAuthorization,
 		},
 	}
 
@@ -526,7 +576,7 @@ func TestRemoveThing(t *testing.T) {
 			desc:  "remove non-existing thing",
 			id:    wrongID,
 			token: token,
-			err:   nil,
+			err:   things.ErrAuthorization,
 		},
 	}
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -195,6 +195,14 @@ func TestShareThing(t *testing.T) {
 			userIDs:  []string{email2},
 			err:      things.ErrUnauthorizedAccess,
 		},
+		{
+			desc:     "share a thing with partially invalid policies",
+			token:    token,
+			thingID:  th.ID,
+			policies: []string{"", "read"},
+			userIDs:  []string{email2},
+			err:      fmt.Errorf("cannot claim ownership on thing '%s' by user '%s': %s", th.ID, email2, things.ErrMalformedEntity),
+		},
 	}
 
 	for _, tc := range cases {

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -21,6 +21,7 @@ const (
 	wrongID    = ""
 	wrongValue = "wrong-value"
 	email      = "user@example.com"
+	email2     = "user2@example.com"
 	token      = "token"
 	token2     = "token2"
 	n          = uint64(10)
@@ -156,7 +157,6 @@ func TestUpdateKey(t *testing.T) {
 }
 
 func TestShareThing(t *testing.T) {
-	email2 := "user2@example.com"
 	svc := newService(map[string]string{token: email, token2: email2})
 	ths, err := svc.CreateThings(context.Background(), token, thing)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?

This PR adds an HTTP endpoint and service for sharing a Thing via Policies.

### Which issue(s) does this PR fix/relate to?
Resolves #1454 

### List any changes that modify/break current functionality
This PR updates `thingRepository`. Instead of the ownership-based approach, it uses policies.
### Have you included tests for your changes?
Yes
### Did you document any new/modified functionality?
Yes
### Notes

The HTTP endpoint for sharing a thing can be tested via:

```bash
curl -isSX POST http://localhost/things/<thing_id>/share -d '{"user_ids":["<user_id>"], "policies": ["read", "write", "delete"]}' -H "Authorization: <user_auth_token>" -H 'Content-Type: application/json'
```
