### PR TITLE
NOISSUE - Add policy addition endpoint

### DIFF
--- a/auth/api/http/policies/endpoint.go
+++ b/auth/api/http/policies/endpoint.go
@@ -13,7 +13,7 @@ func createPolicyEndpoint(svc auth.Service) endpoint.Endpoint {
 			return createPolicyRes{}, err
 		}
 
-		if err := svc.AddPolicyBulk(ctx, req.token, req.Object, req.SubjectIDs, req.Policies); err != nil {
+		if err := svc.AddPolicies(ctx, req.token, req.Object, req.SubjectIDs, req.Policies); err != nil {
 			return createPolicyRes{}, err
 		}
 

--- a/auth/api/http/policies/endpoint.go
+++ b/auth/api/http/policies/endpoint.go
@@ -1,0 +1,22 @@
+package policies
+
+import (
+	"context"
+	"github.com/go-kit/kit/endpoint"
+	"github.com/mainflux/mainflux/auth"
+)
+
+func createPolicyEndpoint(svc auth.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(createPolicyReq)
+		if err := req.validate(); err != nil {
+			return createPolicyRes{}, err
+		}
+
+		if err := svc.AddPolicyBulk(ctx, req.token, req.Object, req.SubjectIDs, req.Policies); err != nil {
+			return createPolicyRes{}, err
+		}
+
+		return createPolicyRes{}, nil
+	}
+}

--- a/auth/api/http/policies/requests.go
+++ b/auth/api/http/policies/requests.go
@@ -1,0 +1,22 @@
+package policies
+
+import "github.com/mainflux/mainflux/auth"
+
+type createPolicyReq struct {
+	token      string
+	SubjectIDs []string `json:"subjects"`
+	Policies   []string `json:"policies"`
+	Object     string   `json:"object"`
+}
+
+func (req createPolicyReq) validate() error {
+	if req.token == "" {
+		return auth.ErrUnauthorizedAccess
+	}
+
+	if len(req.SubjectIDs) == 0 || len(req.Policies) == 0 || req.Object == "" {
+		return auth.ErrMalformedEntity
+	}
+
+	return nil
+}

--- a/auth/api/http/policies/responses.go
+++ b/auth/api/http/policies/responses.go
@@ -1,0 +1,21 @@
+package policies
+
+import "net/http"
+
+type createPolicyRes struct{}
+
+func (res createPolicyRes) Code() int {
+	return http.StatusOK
+}
+
+func (res createPolicyRes) Headers() map[string]string {
+	return map[string]string{}
+}
+
+func (res createPolicyRes) Empty() bool {
+	return false
+}
+
+type errorRes struct {
+	Err string `json:"error"`
+}

--- a/auth/api/http/policies/transport.go
+++ b/auth/api/http/policies/transport.go
@@ -1,0 +1,105 @@
+package policies
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	kitot "github.com/go-kit/kit/tracing/opentracing"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/go-zoo/bone"
+	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/auth"
+	"github.com/mainflux/mainflux/pkg/errors"
+	"github.com/opentracing/opentracing-go"
+)
+
+var (
+	errUnsupportedContentType = errors.New("unsupported content type")
+)
+
+const (
+	contentType = "application/json"
+)
+
+// MakeHandler returns a HTTP handler for API endpoints.
+func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer) *bone.Mux {
+	opts := []kithttp.ServerOption{
+		kithttp.ServerErrorEncoder(encodeError),
+	}
+
+	mux.Post("/policy", kithttp.NewServer(
+		kitot.TraceServer(tracer, "create_policy_bulk")(createPolicyEndpoint(svc)),
+		decodeCreatePolicyRequest,
+		encodeResponse,
+		opts...,
+	))
+
+	return mux
+}
+
+func decodeCreatePolicyRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), contentType) {
+		return nil, auth.ErrUnsupportedContentType
+	}
+
+	var req createPolicyReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, errors.Wrap(auth.ErrFailedDecode, err)
+	}
+
+	req.token = r.Header.Get("Authorization")
+	return req, nil
+}
+
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", contentType)
+
+	if ar, ok := response.(mainflux.Response); ok {
+		for k, v := range ar.Headers() {
+			w.Header().Set(k, v)
+		}
+
+		w.WriteHeader(ar.Code())
+
+		if ar.Empty() {
+			return nil
+		}
+	}
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
+	switch {
+	case errors.Contains(err, auth.ErrMalformedEntity):
+		w.WriteHeader(http.StatusBadRequest)
+	case errors.Contains(err, auth.ErrUnauthorizedAccess):
+		w.WriteHeader(http.StatusForbidden)
+	case errors.Contains(err, auth.ErrNotFound):
+		w.WriteHeader(http.StatusNotFound)
+	case errors.Contains(err, auth.ErrConflict):
+		w.WriteHeader(http.StatusConflict)
+	case errors.Contains(err, auth.ErrAuthorization):
+		w.WriteHeader(http.StatusForbidden)
+	case errors.Contains(err, auth.ErrMemberAlreadyAssigned):
+		w.WriteHeader(http.StatusConflict)
+	case errors.Contains(err, io.EOF):
+		w.WriteHeader(http.StatusBadRequest)
+	case errors.Contains(err, io.ErrUnexpectedEOF):
+		w.WriteHeader(http.StatusBadRequest)
+	case errors.Contains(err, errUnsupportedContentType):
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	errorVal, ok := err.(errors.Error)
+	if ok {
+		if err := json.NewEncoder(w).Encode(errorRes{Err: errorVal.Msg()}); err != nil {
+			w.Header().Set("Content-Type", contentType)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}

--- a/auth/api/http/policies/transport.go
+++ b/auth/api/http/policies/transport.go
@@ -16,13 +16,9 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-var (
-	errUnsupportedContentType = errors.New("unsupported content type")
-)
+var errUnsupportedContentType = errors.New("unsupported content type")
 
-const (
-	contentType = "application/json"
-)
+const contentType = "application/json"
 
 // MakeHandler returns a HTTP handler for API endpoints.
 func MakeHandler(svc auth.Service, mux *bone.Mux, tracer opentracing.Tracer) *bone.Mux {

--- a/auth/api/http/transport.go
+++ b/auth/api/http/transport.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mainflux/mainflux/auth"
 	"github.com/mainflux/mainflux/auth/api/http/groups"
 	"github.com/mainflux/mainflux/auth/api/http/keys"
+	"github.com/mainflux/mainflux/auth/api/http/policies"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -18,6 +19,7 @@ func MakeHandler(svc auth.Service, tracer opentracing.Tracer) http.Handler {
 	mux := bone.New()
 	mux = keys.MakeHandler(svc, mux, tracer)
 	mux = groups.MakeHandler(svc, mux, tracer)
+	mux = policies.MakeHandler(svc, mux, tracer)
 	mux.GetFunc("/version", mainflux.Version("auth"))
 	mux.Handle("/metrics", promhttp.Handler())
 	return mux

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -106,6 +106,19 @@ func (lm *loggingMiddleware) AddPolicy(ctx context.Context, pr auth.PolicyReq) (
 	return lm.svc.AddPolicy(ctx, pr)
 }
 
+func (lm *loggingMiddleware) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method create_policy_bulk took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.AddPolicyBulk(ctx, token, object, subjectIDs, relations)
+}
+
 func (lm *loggingMiddleware) DeletePolicy(ctx context.Context, pr auth.PolicyReq) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method delete_policy took %s to complete", time.Since(begin))

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -106,7 +106,7 @@ func (lm *loggingMiddleware) AddPolicy(ctx context.Context, pr auth.PolicyReq) (
 	return lm.svc.AddPolicy(ctx, pr)
 }
 
-func (lm *loggingMiddleware) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
+func (lm *loggingMiddleware) AddPolicies(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method create_policy_bulk took %s to complete", time.Since(begin))
 		if err != nil {
@@ -116,7 +116,7 @@ func (lm *loggingMiddleware) AddPolicyBulk(ctx context.Context, token, object st
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
-	return lm.svc.AddPolicyBulk(ctx, token, object, subjectIDs, relations)
+	return lm.svc.AddPolicies(ctx, token, object, subjectIDs, relations)
 }
 
 func (lm *loggingMiddleware) DeletePolicy(ctx context.Context, pr auth.PolicyReq) (err error) {

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -80,13 +80,13 @@ func (ms *metricsMiddleware) AddPolicy(ctx context.Context, pr auth.PolicyReq) e
 	return ms.svc.AddPolicy(ctx, pr)
 }
 
-func (ms *metricsMiddleware) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
+func (ms *metricsMiddleware) AddPolicies(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "create_policy_bulk").Add(1)
 		ms.latency.With("method", "create_policy_bulk").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return ms.svc.AddPolicyBulk(ctx, token, object, subjectIDs, relations)
+	return ms.svc.AddPolicies(ctx, token, object, subjectIDs, relations)
 }
 
 func (ms *metricsMiddleware) DeletePolicy(ctx context.Context, pr auth.PolicyReq) error {

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -80,6 +80,15 @@ func (ms *metricsMiddleware) AddPolicy(ctx context.Context, pr auth.PolicyReq) e
 	return ms.svc.AddPolicy(ctx, pr)
 }
 
+func (ms *metricsMiddleware) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) (err error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "create_policy_bulk").Add(1)
+		ms.latency.With("method", "create_policy_bulk").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.AddPolicyBulk(ctx, token, object, subjectIDs, relations)
+}
+
 func (ms *metricsMiddleware) DeletePolicy(ctx context.Context, pr auth.PolicyReq) error {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "delete_policy").Add(1)

--- a/auth/policies.go
+++ b/auth/policies.go
@@ -30,6 +30,10 @@ type Authz interface {
 	// error in case of failures.
 	AddPolicy(ctx context.Context, pr PolicyReq) error
 
+	// AddPolicyBulk adds new policies for given subjects. This method is
+	// only allowed to use as an admin.
+	AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) error
+
 	// DeletePolicy removes a policy.
 	DeletePolicy(ctx context.Context, pr PolicyReq) error
 }

--- a/auth/policies.go
+++ b/auth/policies.go
@@ -30,9 +30,9 @@ type Authz interface {
 	// error in case of failures.
 	AddPolicy(ctx context.Context, pr PolicyReq) error
 
-	// AddPolicyBulk adds new policies for given subjects. This method is
+	// AddPolicies adds new policies for given subjects. This method is
 	// only allowed to use as an admin.
-	AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) error
+	AddPolicies(ctx context.Context, token, object string, subjectIDs, relations []string) error
 
 	// DeletePolicy removes a policy.
 	DeletePolicy(ctx context.Context, pr PolicyReq) error

--- a/auth/service.go
+++ b/auth/service.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/mainflux/mainflux"
@@ -174,6 +175,27 @@ func (svc service) Authorize(ctx context.Context, pr PolicyReq) error {
 
 func (svc service) AddPolicy(ctx context.Context, pr PolicyReq) error {
 	return svc.agent.AddPolicy(ctx, pr)
+}
+
+func (svc service) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) error {
+	user, err := svc.Identify(ctx, token)
+	if err != nil {
+		return errors.Wrap(ErrUnauthorizedAccess, err)
+	}
+
+	if err := svc.Authorize(ctx, PolicyReq{Object: "", Relation: "", Subject: user.ID}); err != nil {
+		return err
+	}
+
+	var errs error
+	for _, subjectID := range subjectIDs {
+		for _, relation := range relations {
+			if err := svc.AddPolicy(ctx, PolicyReq{Object: object, Relation: relation, Subject: subjectID}); err != nil {
+				errs = errors.Wrap(fmt.Errorf("cannot add '%s' policy on object '%s' for subject '%s': %s", relation, object, subjectID, err), errs)
+			}
+		}
+	}
+	return errs
 }
 
 func (svc service) DeletePolicy(ctx context.Context, pr PolicyReq) error {

--- a/auth/service.go
+++ b/auth/service.go
@@ -177,7 +177,7 @@ func (svc service) AddPolicy(ctx context.Context, pr PolicyReq) error {
 	return svc.agent.AddPolicy(ctx, pr)
 }
 
-func (svc service) AddPolicyBulk(ctx context.Context, token, object string, subjectIDs, relations []string) error {
+func (svc service) AddPolicies(ctx context.Context, token, object string, subjectIDs, relations []string) error {
 	user, err := svc.Identify(ctx, token)
 	if err != nil {
 		return errors.Wrap(ErrUnauthorizedAccess, err)


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?

This PR introduces a new endpoint on Auth package. This new endpoint allows an admin to create new policies.

Example:
```bash
curl -isSX POST http://localhost:<service_port>/policy -d '{"subjects":["<subject>"],"policies": ["<policy>"], "object": "<object>"}' -H "Authorization: <admin_auth_token>" -H 'Content-Type: application/json'
```

### Which issue(s) does this PR fix/relate to?
`-`

### List any changes that modify/break current functionality
`-`
### Have you included tests for your changes?
No, not yet

### Did you document any new/modified functionality?
`-`
### Notes
