### PR TITLE
NOISSUE - Add tests for AddPolicies

### DIFF
--- a/auth/api/http/policies/endpoint_test.go
+++ b/auth/api/http/policies/endpoint_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package policies_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mainflux/mainflux/auth"
+	httpapi "github.com/mainflux/mainflux/auth/api/http"
+	"github.com/mainflux/mainflux/auth/jwt"
+	"github.com/mainflux/mainflux/auth/mocks"
+	"github.com/mainflux/mainflux/pkg/uuid"
+	"github.com/opentracing/opentracing-go/mocktracer"
+)
+
+const (
+	secret       = "secret"
+	contentType  = "application/json"
+	id           = "123e4567-e89b-12d3-a456-000000000001"
+	email        = "user@example.com"
+	unauthzID    = "123e4567-e89b-12d3-a456-000000000002"
+	unauthzEmail = "unauthz@example.com"
+)
+
+type issueRequest struct {
+	Duration time.Duration `json:"duration,omitempty"`
+	Type     uint32        `json:"type,omitempty"`
+}
+
+type testRequest struct {
+	client      *http.Client
+	method      string
+	url         string
+	contentType string
+	token       string
+	body        io.Reader
+}
+
+func (tr testRequest) make() (*http.Response, error) {
+	req, err := http.NewRequest(tr.method, tr.url, tr.body)
+	if err != nil {
+		return nil, err
+	}
+	if tr.token != "" {
+		req.Header.Set("Authorization", tr.token)
+	}
+	if tr.contentType != "" {
+		req.Header.Set("Content-Type", tr.contentType)
+	}
+
+	req.Header.Set("Referer", "http://localhost")
+	return tr.client.Do(req)
+}
+
+func newService() auth.Service {
+	repo := mocks.NewKeyRepository()
+	groupRepo := mocks.NewGroupRepository()
+	idProvider := uuid.NewMock()
+	t := jwt.New(secret)
+
+	mockAuthzDB := map[string][]mocks.MockSubjectSet{}
+	mockAuthzDB[id] = append(mockAuthzDB[id], mocks.MockSubjectSet{Object: "authorities", Relation: "member"})
+	mockAuthzDB[unauthzID] = append(mockAuthzDB[unauthzID], mocks.MockSubjectSet{Object: "users", Relation: "member"})
+	ketoMock := mocks.NewKetoMock(mockAuthzDB)
+
+	return auth.New(repo, groupRepo, idProvider, t, ketoMock)
+}
+
+func newServer(svc auth.Service) *httptest.Server {
+	mux := httpapi.MakeHandler(svc, mocktracer.New())
+	return httptest.NewServer(mux)
+}
+
+func toJSON(data interface{}) string {
+	jsonData, _ := json.Marshal(data)
+	return string(jsonData)
+}
+
+type addPolicyRequest struct {
+	SubjectIDs []string `json:"subjects"`
+	Policies   []string `json:"policies"`
+	Object     string   `json:"object"`
+}
+
+func TestAddPolicies(t *testing.T) {
+	svc := newService()
+	_, loginSecret, err := svc.Issue(context.Background(), "", auth.Key{Type: auth.UserKey, IssuedAt: time.Now(), IssuerID: id, Subject: email})
+	assert.Nil(t, err, fmt.Sprintf("Issuing user key expected to succeed: %s", err))
+
+	_, userLoginSecret, err := svc.Issue(context.Background(), "", auth.Key{Type: auth.UserKey, IssuedAt: time.Now(), IssuerID: unauthzID, Subject: unauthzEmail})
+	assert.Nil(t, err, fmt.Sprintf("Issuing unauthorized user's key expected to succeed: %s", err))
+
+	ts := newServer(svc)
+	defer ts.Close()
+	client := ts.Client()
+
+	valid := addPolicyRequest{Object: "obj", Policies: []string{"read"}, SubjectIDs: []string{"user1", "user2"}}
+	invalidObject := addPolicyRequest{Object: "", Policies: []string{"read"}, SubjectIDs: []string{"user1", "user2"}}
+	invalidPolicies := addPolicyRequest{Object: "obj", Policies: []string{"read", "invalid"}, SubjectIDs: []string{"user1", "user2"}}
+	invalidSubjects := addPolicyRequest{Object: "obj", Policies: []string{"read", "access"}, SubjectIDs: []string{"", "user2"}}
+
+	cases := []struct {
+		desc   string
+		token  string
+		ct     string
+		status int
+		req    string
+	}{
+		{
+			desc:   "Add policies with authorized access",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusOK,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with unauthorized access",
+			token:  userLoginSecret,
+			ct:     contentType,
+			status: http.StatusForbidden,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with invalid token",
+			token:  "invalid",
+			ct:     contentType,
+			status: http.StatusForbidden,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with empty token",
+			token:  "",
+			ct:     contentType,
+			status: http.StatusForbidden,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with invalid content type",
+			token:  loginSecret,
+			ct:     "text/html",
+			status: http.StatusUnsupportedMediaType,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with empty content type",
+			token:  loginSecret,
+			ct:     "",
+			status: http.StatusUnsupportedMediaType,
+			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add policies with invalid object field in request body",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusBadRequest,
+			req:    toJSON(invalidObject),
+		},
+		{
+			desc:   "Add policies with invalid policies field in request body",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusBadRequest,
+			req:    toJSON(invalidPolicies),
+		},
+		{
+			desc:   "Add policies with invalid subjects field in request body",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusBadRequest,
+			req:    toJSON(invalidSubjects),
+		},
+		{
+			desc:   "Add policies with empty request body",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusBadRequest,
+			req:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		req := testRequest{
+			client:      client,
+			method:      http.MethodPost,
+			url:         fmt.Sprintf("%s/policy", ts.URL),
+			contentType: tc.ct,
+			token:       tc.token,
+			body:        strings.NewReader(tc.req),
+		}
+
+		res, err := req.make()
+		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+		assert.Equal(t, tc.status, res.StatusCode, fmt.Sprintf("%s: expected status code %d got %d", tc.desc, tc.status, res.StatusCode))
+	}
+}

--- a/auth/api/http/policies/endpoint_test.go
+++ b/auth/api/http/policies/endpoint_test.go
@@ -105,6 +105,7 @@ func TestAddPolicies(t *testing.T) {
 	client := ts.Client()
 
 	valid := addPolicyRequest{Object: "obj", Policies: []string{"read"}, SubjectIDs: []string{"user1", "user2"}}
+	multipleValid := addPolicyRequest{Object: "obj", Policies: []string{"write", "delete"}, SubjectIDs: []string{"user1", "user2"}}
 	invalidObject := addPolicyRequest{Object: "", Policies: []string{"read"}, SubjectIDs: []string{"user1", "user2"}}
 	invalidPolicies := addPolicyRequest{Object: "obj", Policies: []string{"read", "invalid"}, SubjectIDs: []string{"user1", "user2"}}
 	invalidSubjects := addPolicyRequest{Object: "obj", Policies: []string{"read", "access"}, SubjectIDs: []string{"", "user2"}}
@@ -122,6 +123,13 @@ func TestAddPolicies(t *testing.T) {
 			ct:     contentType,
 			status: http.StatusOK,
 			req:    toJSON(valid),
+		},
+		{
+			desc:   "Add multiple policies to multiple user",
+			token:  loginSecret,
+			ct:     contentType,
+			status: http.StatusOK,
+			req:    toJSON(multipleValid),
 		},
 		{
 			desc:   "Add policies with unauthorized access",

--- a/auth/api/http/policies/endpoint_test.go
+++ b/auth/api/http/policies/endpoint_test.go
@@ -26,16 +26,11 @@ import (
 const (
 	secret       = "secret"
 	contentType  = "application/json"
-	id           = "123e4567-e89b-12d3-a456-000000000001"
+	id           = uuid.Prefix + "-000000000001"
 	email        = "user@example.com"
-	unauthzID    = "123e4567-e89b-12d3-a456-000000000002"
+	unauthzID    = uuid.Prefix + "-000000000002"
 	unauthzEmail = "unauthz@example.com"
 )
-
-type issueRequest struct {
-	Duration time.Duration `json:"duration,omitempty"`
-	Type     uint32        `json:"type,omitempty"`
-}
 
 type testRequest struct {
 	client      *http.Client

--- a/auth/api/http/policies/requests.go
+++ b/auth/api/http/policies/requests.go
@@ -1,6 +1,18 @@
 package policies
 
-import "github.com/mainflux/mainflux/auth"
+import (
+	"github.com/mainflux/mainflux/auth"
+	"github.com/mainflux/mainflux/things"
+)
+
+const (
+	readPolicy   = "read"
+	writePolicy  = "write"
+	deletePolicy = "delete"
+	accessPolicy = "access"
+	memberPolicy = "member"
+	createPolicy = "create"
+)
 
 type createPolicyReq struct {
 	token      string
@@ -16,6 +28,19 @@ func (req createPolicyReq) validate() error {
 
 	if len(req.SubjectIDs) == 0 || len(req.Policies) == 0 || req.Object == "" {
 		return auth.ErrMalformedEntity
+	}
+
+	for _, policy := range req.Policies {
+		if policy != readPolicy && policy != writePolicy && policy != deletePolicy &&
+			policy != accessPolicy && policy != memberPolicy && policy != createPolicy {
+			return things.ErrMalformedEntity
+		}
+	}
+
+	for _, subject := range req.SubjectIDs {
+		if subject == "" {
+			return things.ErrMalformedEntity
+		}
 	}
 
 	return nil

--- a/auth/api/http/policies/requests.go
+++ b/auth/api/http/policies/requests.go
@@ -5,14 +5,36 @@ import (
 	"github.com/mainflux/mainflux/things"
 )
 
+// Action represents an enum for the policies used in the Mainflux.
+type Action int
+
 const (
-	readPolicy   = "read"
-	writePolicy  = "write"
-	deletePolicy = "delete"
-	accessPolicy = "access"
-	memberPolicy = "member"
-	createPolicy = "create"
+	Create Action = iota
+	Read
+	Write
+	Delete
+	Access
+	Member
+	unknown
 )
+
+var actions = [...]string{
+	Create: "create",
+	Read:   "read",
+	Write:  "write",
+	Delete: "delete",
+	Access: "access",
+	Member: "member",
+}
+
+func parsePolicy(incomingAction string) Action {
+	for i, action := range actions {
+		if incomingAction == action {
+			return Action(i)
+		}
+	}
+	return unknown
+}
 
 type createPolicyReq struct {
 	token      string
@@ -31,8 +53,7 @@ func (req createPolicyReq) validate() error {
 	}
 
 	for _, policy := range req.Policies {
-		if policy != readPolicy && policy != writePolicy && policy != deletePolicy &&
-			policy != accessPolicy && policy != memberPolicy && policy != createPolicy {
+		if action := parsePolicy(policy); action > Member || action < Create {
 			return things.ErrMalformedEntity
 		}
 	}

--- a/auth/service.go
+++ b/auth/service.go
@@ -183,7 +183,7 @@ func (svc service) AddPolicies(ctx context.Context, token, object string, subjec
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := svc.Authorize(ctx, PolicyReq{Object: "", Relation: "", Subject: user.ID}); err != nil {
+	if err := svc.Authorize(ctx, PolicyReq{Object: "authorities", Relation: "member", Subject: user.ID}); err != nil {
 		return err
 	}
 

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -1009,18 +1009,36 @@ func TestAddPolicies(t *testing.T) {
 
 	tmpID := "tmpid"
 	readPolicy := "read"
+	writePolicy := "write"
+	deletePolicy := "delete"
+
+	// Add read policy to users.
 	err = svc.AddPolicies(context.Background(), apiToken, thingID, []string{id, tmpID}, []string{readPolicy})
 	require.Nil(t, err, fmt.Sprintf("adding policies expected to succeed: %s", err))
 
+	// Add write and delete policies to users.
+	err = svc.AddPolicies(context.Background(), apiToken, thingID, []string{id, tmpID}, []string{writePolicy, deletePolicy})
+	require.Nil(t, err, fmt.Sprintf("adding multiple policies expected to succeed: %s", err))
+
+	// Verify policies of the user with id.
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: readPolicy, Subject: id})
 	require.Nil(t, err, fmt.Sprintf("authorizing valid 'read' policy for '%s' expected to succeed: %s", id, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: writePolicy, Subject: id})
+	require.Nil(t, err, fmt.Sprintf("authorizing valid 'write' policy for '%s' expected to succeed: %s", id, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: deletePolicy, Subject: id})
+	require.Nil(t, err, fmt.Sprintf("authorizing valid 'delete' policy for '%s' expected to succeed: %s", id, err))
 
+	// Verify policies of the user with tmpid.
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: readPolicy, Subject: tmpID})
 	require.Nil(t, err, fmt.Sprintf("authorizing valid 'read' policy for '%s' expected to succeed: %s", tmpID, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: writePolicy, Subject: tmpID})
+	require.Nil(t, err, fmt.Sprintf("authorizing valid 'write' policy for '%s' expected to succeed: %s", tmpID, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: deletePolicy, Subject: tmpID})
+	require.Nil(t, err, fmt.Sprintf("authorizing valid 'delete' policy for '%s' expected to succeed: %s", tmpID, err))
 
-	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: "write", Subject: id})
-	assert.True(t, errors.Contains(err, auth.ErrAuthorization), fmt.Sprintf("authorizing invalid 'write' policy for '%s' expected to fail: %s", id, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: "access", Subject: id})
+	assert.True(t, errors.Contains(err, auth.ErrAuthorization), fmt.Sprintf("authorizing invalid 'access' policy for '%s' expected to fail: %s", id, err))
 
-	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: "write", Subject: tmpID})
-	assert.True(t, errors.Contains(err, auth.ErrAuthorization), fmt.Sprintf("authorizing invalid 'write' policy for '%s' expected to fail: %s", tmpID, err))
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingID, Relation: "access", Subject: tmpID})
+	assert.True(t, errors.Contains(err, auth.ErrAuthorization), fmt.Sprintf("authorizing invalid 'access' policy for '%s' expected to fail: %s", tmpID, err))
 }


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?

This PR introduces an endpoint and service test for `AddPolicies`. Also, it adds verification for the request body for adding new policies. So that, arbitrary policies are not allowed and It returns `400` with a `malformed entity` error in case of unknown policy requests.

### Which issue(s) does this PR fix/relate to?

### List any changes that modify/break current functionality

### Have you included tests for your changes?
Yes
### Did you document any new/modified functionality?

### Notes
