### PR TITLE
NOISSUE - Update group sharing policies

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -19,7 +19,6 @@ const (
 
 	thingsGroupType = "things"
 	memberRelation  = "member"
-	accessRelation  = "access"
 )
 
 var (
@@ -187,7 +186,7 @@ func (svc service) AddPolicies(ctx context.Context, token, object string, subjec
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	if err := svc.Authorize(ctx, PolicyReq{Object: "authorities", Relation: "member", Subject: user.ID}); err != nil {
+	if err := svc.Authorize(ctx, PolicyReq{Object: "authorities", Relation: memberRelation, Subject: user.ID}); err != nil {
 		return err
 	}
 
@@ -210,7 +209,7 @@ func (svc service) AssignGroupAccessRights(ctx context.Context, token, thingGrou
 	if _, err := svc.Identify(ctx, token); err != nil {
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
-	return svc.agent.AddPolicy(ctx, PolicyReq{Object: thingGroupID, Relation: "member", Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, memberRelation)})
+	return svc.agent.AddPolicy(ctx, PolicyReq{Object: thingGroupID, Relation: memberRelation, Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, memberRelation)})
 }
 
 func (svc service) tmpKey(duration time.Duration, key Key) (Key, string, error) {
@@ -360,7 +359,7 @@ func (svc service) Assign(ctx context.Context, token string, groupID, groupType 
 	}
 
 	if groupType == thingsGroupType {
-		ss := fmt.Sprintf("%s:%s#%s", "members", groupID, "member")
+		ss := fmt.Sprintf("%s:%s#%s", "members", groupID, memberRelation)
 		var errs error
 		for _, memberID := range memberIDs {
 			for _, action := range []string{"read", "write", "delete"} {
@@ -374,7 +373,7 @@ func (svc service) Assign(ctx context.Context, token string, groupID, groupType 
 
 	var errs error
 	for _, memberID := range memberIDs {
-		if err := svc.agent.AddPolicy(ctx, PolicyReq{Object: groupID, Relation: "member", Subject: memberID}); err != nil {
+		if err := svc.agent.AddPolicy(ctx, PolicyReq{Object: groupID, Relation: memberRelation, Subject: memberID}); err != nil {
 			errs = errors.Wrap(fmt.Errorf("cannot add user: '%s' to user group: '%s'", memberID, groupID), errs)
 		}
 	}
@@ -386,11 +385,11 @@ func (svc service) Unassign(ctx context.Context, token string, groupID string, m
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	ss := fmt.Sprintf("%s:%s#%s", "members", groupID, "member")
+	ss := fmt.Sprintf("%s:%s#%s", "members", groupID, memberRelation)
 	var errs error
 	for _, memberID := range memberIDs {
 		// If the member is a user, <groupID>#member@memberID must be deleted.
-		if err := svc.agent.DeletePolicy(ctx, PolicyReq{Object: groupID, Relation: "member", Subject: memberID}); err != nil {
+		if err := svc.agent.DeletePolicy(ctx, PolicyReq{Object: groupID, Relation: memberRelation, Subject: memberID}); err != nil {
 			errs = errors.Wrap(fmt.Errorf("cannot delete a membership of member '%s' from group '%s'", memberID, groupID), errs)
 		}
 

--- a/auth/service.go
+++ b/auth/service.go
@@ -210,7 +210,7 @@ func (svc service) AssignGroupAccessRights(ctx context.Context, token, thingGrou
 	if _, err := svc.Identify(ctx, token); err != nil {
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
-	return svc.agent.AddPolicy(ctx, PolicyReq{Object: thingGroupID, Relation: accessRelation, Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, memberRelation)})
+	return svc.agent.AddPolicy(ctx, PolicyReq{Object: thingGroupID, Relation: "member", Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, memberRelation)})
 }
 
 func (svc service) tmpKey(duration time.Duration, key Key) (Key, string, error) {
@@ -360,7 +360,7 @@ func (svc service) Assign(ctx context.Context, token string, groupID, groupType 
 	}
 
 	if groupType == thingsGroupType {
-		ss := fmt.Sprintf("%s:%s#%s", "members", groupID, accessRelation)
+		ss := fmt.Sprintf("%s:%s#%s", "members", groupID, "member")
 		var errs error
 		for _, memberID := range memberIDs {
 			for _, action := range []string{"read", "write", "delete"} {
@@ -374,7 +374,7 @@ func (svc service) Assign(ctx context.Context, token string, groupID, groupType 
 
 	var errs error
 	for _, memberID := range memberIDs {
-		if err := svc.agent.AddPolicy(ctx, PolicyReq{Object: groupID, Relation: accessRelation, Subject: memberID}); err != nil {
+		if err := svc.agent.AddPolicy(ctx, PolicyReq{Object: groupID, Relation: "member", Subject: memberID}); err != nil {
 			errs = errors.Wrap(fmt.Errorf("cannot add user: '%s' to user group: '%s'", memberID, groupID), errs)
 		}
 	}
@@ -386,13 +386,16 @@ func (svc service) Unassign(ctx context.Context, token string, groupID string, m
 		return errors.Wrap(ErrUnauthorizedAccess, err)
 	}
 
-	ss := fmt.Sprintf("%s:%s#%s", "members", groupID, accessRelation)
+	ss := fmt.Sprintf("%s:%s#%s", "members", groupID, "member")
 	var errs error
 	for _, memberID := range memberIDs {
+		// If the member is a user, <groupID>#member@memberID must be deleted.
+		if err := svc.agent.DeletePolicy(ctx, PolicyReq{Object: groupID, Relation: "member", Subject: memberID}); err != nil {
+			errs = errors.Wrap(fmt.Errorf("cannot delete a membership of member '%s' from group '%s'", memberID, groupID), errs)
+		}
+
+		// If the member is a Thing, memberID#read|write|delete@(members:groupID#member) must be deleted.
 		for _, action := range []string{"read", "write", "delete"} {
-			if err := svc.agent.DeletePolicy(ctx, PolicyReq{Object: groupID, Relation: accessRelation, Subject: memberID}); err != nil {
-				errs = errors.Wrap(fmt.Errorf("cannot delete a membership of member '%s' from group '%s'", memberID, groupID), errs)
-			}
 			if err := svc.agent.DeletePolicy(ctx, PolicyReq{Object: memberID, Relation: action, Subject: ss}); err != nil {
 				errs = errors.Wrap(fmt.Errorf("cannot delete '%s' policy from member '%s'", action, memberID), errs)
 			}

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -27,7 +27,7 @@ const (
 	groupName   = "mfx"
 	description = "Description"
 
-	memberRel      = "member"
+	memberRelation = "member"
 	authoritiesObj = "authorities"
 )
 
@@ -37,7 +37,7 @@ func newService() auth.Service {
 	idProvider := uuid.NewMock()
 
 	mockAuthzDB := map[string][]mocks.MockSubjectSet{}
-	mockAuthzDB[id] = append(mockAuthzDB[id], mocks.MockSubjectSet{Object: authoritiesObj, Relation: memberRel})
+	mockAuthzDB[id] = append(mockAuthzDB[id], mocks.MockSubjectSet{Object: authoritiesObj, Relation: memberRelation})
 	ketoMock := mocks.NewKetoMock(mockAuthzDB)
 
 	t := jwt.New(secret)
@@ -332,7 +332,7 @@ func TestCreateGroup(t *testing.T) {
 	parent, err := svc.CreateGroup(context.Background(), apiToken, parentGroup)
 	assert.Nil(t, err, fmt.Sprintf("Creating parent group expected to succeed: %s", err))
 
-	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: parent.ID, Relation: "member", Subject: id})
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: parent.ID, Relation: memberRelation, Subject: id})
 	assert.Nil(t, err, fmt.Sprintf("Checking parent group owner's policy expected to succeed: %s", err))
 
 	cases := []struct {
@@ -373,7 +373,7 @@ func TestCreateGroup(t *testing.T) {
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 
 		if err == nil {
-			authzErr := svc.Authorize(context.Background(), auth.PolicyReq{Object: g.ID, Relation: "member", Subject: g.OwnerID})
+			authzErr := svc.Authorize(context.Background(), auth.PolicyReq{Object: g.ID, Relation: memberRelation, Subject: g.OwnerID})
 			assert.Nil(t, authzErr, fmt.Sprintf("%s - Checking group owner's policy expected to succeed: %s", tc.desc, authzErr))
 		}
 	}
@@ -937,7 +937,7 @@ func TestAssign(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("member assign save unexpected error: %s", err))
 
 	// check access control policies things members.
-	subjectSet := fmt.Sprintf("%s:%s#%s", "members", group.ID, "member")
+	subjectSet := fmt.Sprintf("%s:%s#%s", "members", group.ID, memberRelation)
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: mid, Relation: "read", Subject: subjectSet})
 	require.Nil(t, err, fmt.Sprintf("entites having an access to group %s must have %s policy on %s: %s", group.ID, "read", mid, err))
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: mid, Relation: "write", Subject: subjectSet})
@@ -1011,7 +1011,7 @@ func TestUnassign(t *testing.T) {
 func TestAuthorize(t *testing.T) {
 	svc := newService()
 
-	pr := auth.PolicyReq{Object: authoritiesObj, Relation: memberRel, Subject: id}
+	pr := auth.PolicyReq{Object: authoritiesObj, Relation: memberRelation, Subject: id}
 	err := svc.Authorize(context.Background(), pr)
 	require.Nil(t, err, fmt.Sprintf("authorizing initial %v policy expected to succeed: %s", pr, err))
 }
@@ -1030,7 +1030,7 @@ func TestAddPolicy(t *testing.T) {
 func TestDeletePolicy(t *testing.T) {
 	svc := newService()
 
-	pr := auth.PolicyReq{Object: authoritiesObj, Relation: memberRel, Subject: id}
+	pr := auth.PolicyReq{Object: authoritiesObj, Relation: memberRelation, Subject: id}
 	err := svc.DeletePolicy(context.Background(), pr)
 	require.Nil(t, err, fmt.Sprintf("deleting %v policy expected to succeed: %s", pr, err))
 }
@@ -1057,7 +1057,7 @@ func TestAssignAccessRights(t *testing.T) {
 	err = svc.AssignGroupAccessRights(context.Background(), apiToken, thingGroupID, userGroupID)
 	require.Nil(t, err, fmt.Sprintf("sharing the user group with thing group expected to succeed: %v", err))
 
-	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingGroupID, Relation: "member", Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, "member")})
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingGroupID, Relation: memberRelation, Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, memberRelation)})
 	require.Nil(t, err, fmt.Sprintf("checking shared group access policy expected to be succeed: %#v", err))
 }
 

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -937,7 +937,7 @@ func TestAssign(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("member assign save unexpected error: %s", err))
 
 	// check access control policies things members.
-	subjectSet := fmt.Sprintf("%s:%s#%s", "members", group.ID, "access")
+	subjectSet := fmt.Sprintf("%s:%s#%s", "members", group.ID, "member")
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: mid, Relation: "read", Subject: subjectSet})
 	require.Nil(t, err, fmt.Sprintf("entites having an access to group %s must have %s policy on %s: %s", group.ID, "read", mid, err))
 	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: mid, Relation: "write", Subject: subjectSet})
@@ -1057,7 +1057,7 @@ func TestAssignAccessRights(t *testing.T) {
 	err = svc.AssignGroupAccessRights(context.Background(), apiToken, thingGroupID, userGroupID)
 	require.Nil(t, err, fmt.Sprintf("sharing the user group with thing group expected to succeed: %v", err))
 
-	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingGroupID, Relation: "access", Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, "member")})
+	err = svc.Authorize(context.Background(), auth.PolicyReq{Object: thingGroupID, Relation: "member", Subject: fmt.Sprintf("%s:%s#%s", "members", userGroupID, "member")})
 	require.Nil(t, err, fmt.Sprintf("checking shared group access policy expected to be succeed: %#v", err))
 }
 


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?

This PR updates policies created while assigning new members to the Group. So that, instead of having an `access` relation, now all members will have `member` relation.

### Which issue(s) does this PR fix/relate to?

### List any changes that modify/break current functionality
Update policies
### Have you included tests for your changes?
Yes
### Did you document any new/modified functionality?
No. The doc will be updated.
### Notes
