### PR TITLE
NOISSUE - Update users create command for CLI

### DIFF
--- a/cli/users.go
+++ b/cli/users.go
@@ -17,7 +17,7 @@ func NewUsersCmd() *cobra.Command {
 		Short: "create <username> <password> <user_auth_token>",
 		Long:  `Creates new user`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 2 && len(args) != 3 {
+			if len(args) < 2 || len(args) > 3 {
 				logUsage(cmd.Short)
 				return
 			}

--- a/cli/users.go
+++ b/cli/users.go
@@ -17,9 +17,12 @@ func NewUsersCmd() *cobra.Command {
 		Short: "create <username> <password> <user_auth_token>",
 		Long:  `Creates new user`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
+			if len(args) != 2 && len(args) != 3 {
 				logUsage(cmd.Short)
 				return
+			}
+			if len(args) == 2 {
+				args = append(args, "")
 			}
 
 			user := mfxsdk.User{


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

### What does this do?
This PR updates `users create` command validation check in CLI. So, instead of forcing user to enter three arguments, if the user enters 2 arguments (such as `username` and `password`), the third argument will be created as empty string `""`. 
### Which issue(s) does this PR fix/relate to?

### List any changes that modify/break current functionality
Updated CLI command.
### Have you included tests for your changes?
No
### Did you document any new/modified functionality?

### Notes
