### PR TITLE
NOISSUE - Apply policies to Channels

### DIFF
--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -141,7 +141,7 @@ func TestCreateChannels(t *testing.T) {
 }
 
 func TestChannel(t *testing.T) {
-	svc := newThingsService(map[string]string{token: email})
+	svc := newThingsService(map[string]string{token: adminEmail})
 	ts := newThingsServer(svc)
 	defer ts.Close()
 	sdkConf := sdk.Config{
@@ -409,7 +409,7 @@ func TestChannelsByThing(t *testing.T) {
 }
 
 func TestUpdateChannel(t *testing.T) {
-	svc := newThingsService(map[string]string{token: email})
+	svc := newThingsService(map[string]string{token: adminEmail})
 	ts := newThingsServer(svc)
 	defer ts.Close()
 	sdkConf := sdk.Config{
@@ -467,7 +467,7 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestDeleteChannel(t *testing.T) {
-	svc := newThingsService(map[string]string{token: email})
+	svc := newThingsService(map[string]string{token: adminEmail})
 	ts := newThingsServer(svc)
 	defer ts.Close()
 	sdkConf := sdk.Config{

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -22,6 +22,7 @@ import (
 const (
 	contentType = "application/senml+json"
 	email       = "user@example.com"
+	adminEmail  = "admin@example.com"
 	otherEmail  = "other_user@example.com"
 	token       = "token"
 	otherToken  = "other_token"
@@ -40,8 +41,10 @@ var (
 )
 
 func newThingsService(tokens map[string]string) things.Service {
-	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
-	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
+	userPolicy := mocks.MockSubjectSet{Object: "users", Relation: "member"}
+	adminPolicy := mocks.MockSubjectSet{Object: "authorities", Relation: "member"}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{
+		adminEmail: {userPolicy, adminPolicy}, email: {userPolicy}})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)

--- a/things/api/things/http/endpoint_test.go
+++ b/things/api/things/http/endpoint_test.go
@@ -28,6 +28,7 @@ import (
 const (
 	contentType = "application/json"
 	email       = "user@example.com"
+	adminEmail  = "admin@example.com"
 	token       = "token"
 	wrongValue  = "wrong_value"
 	wrongID     = 0
@@ -80,8 +81,10 @@ func (tr testRequest) make() (*http.Response, error) {
 }
 
 func newService(tokens map[string]string) things.Service {
-	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
-	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
+	userPolicy := mocks.MockSubjectSet{Object: "users", Relation: "member"}
+	adminPolicy := mocks.MockSubjectSet{Object: "authorities", Relation: "member"}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{
+		adminEmail: {userPolicy, adminPolicy}, email: {userPolicy}})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)
@@ -1593,7 +1596,7 @@ func TestCreateChannels(t *testing.T) {
 }
 
 func TestUpdateChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	ts := newServer(svc)
 	defer ts.Close()
 
@@ -1713,7 +1716,7 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestViewChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	ts := newServer(svc)
 	defer ts.Close()
 
@@ -2184,7 +2187,7 @@ func TestListChannelsByThing(t *testing.T) {
 }
 
 func TestRemoveChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	ts := newServer(svc)
 	defer ts.Close()
 

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -145,8 +145,8 @@ func (cr channelRepository) RetrieveAll(ctx context.Context, owner string, pm th
 		whereClause = fmt.Sprintf(" WHERE %s", strings.Join(query, " AND "))
 	}
 
-	q := fmt.Sprintf(`SELECT id, name, metadata FROM channels 
-	%s ORDER BY %s %s LIMIT :limit OFFSET :offset;`, whereClause, oq, dq)
+	q := fmt.Sprintf(`SELECT id, name, metadata FROM channels
+		%s ORDER BY %s %s LIMIT :limit OFFSET :offset;`, whereClause, oq, dq)
 
 	params := map[string]interface{}{
 		"owner":    owner,

--- a/things/postgres/channels.go
+++ b/things/postgres/channels.go
@@ -103,13 +103,12 @@ func (cr channelRepository) Update(ctx context.Context, channel things.Channel) 
 }
 
 func (cr channelRepository) RetrieveByID(ctx context.Context, owner, id string) (things.Channel, error) {
-	q := `SELECT name, metadata FROM channels WHERE id = $1 AND owner = $2;`
+	q := `SELECT name, metadata, owner FROM channels WHERE id = $1;`
 
 	dbch := dbChannel{
-		ID:    id,
-		Owner: owner,
+		ID: id,
 	}
-	if err := cr.db.QueryRowxContext(ctx, q, id, owner).StructScan(&dbch); err != nil {
+	if err := cr.db.QueryRowxContext(ctx, q, id).StructScan(&dbch); err != nil {
 		pqErr, ok := err.(*pq.Error)
 		if err == sql.ErrNoRows || ok && errInvalid == pqErr.Code.Name() {
 			return things.Channel{}, things.ErrNotFound

--- a/things/postgres/channels_test.go
+++ b/things/postgres/channels_test.go
@@ -186,11 +186,6 @@ func TestSingleChannelRetrieval(t *testing.T) {
 			ID:    nonexistentChanID,
 			err:   things.ErrNotFound,
 		},
-		"retrieve channel with non-existing owner": {
-			owner: wrongValue,
-			ID:    ch.ID,
-			err:   things.ErrNotFound,
-		},
 		"retrieve channel with malformed ID": {
 			owner: ch.Owner,
 			ID:    wrongValue,

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -20,6 +20,7 @@ import (
 const (
 	wrongID    = ""
 	wrongValue = "wrong-value"
+	adminEmail = "admin@example.com"
 	email      = "user@example.com"
 	email2     = "user2@example.com"
 	token      = "token"
@@ -33,8 +34,10 @@ var (
 )
 
 func newService(tokens map[string]string) things.Service {
-	policies := []mocks.MockSubjectSet{{Object: "users", Relation: "member"}}
-	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{email: policies})
+	userPolicy := mocks.MockSubjectSet{Object: "users", Relation: "member"}
+	adminPolicy := mocks.MockSubjectSet{Object: "authorities", Relation: "member"}
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{
+		adminEmail: {userPolicy, adminPolicy}, email: {userPolicy}})
 	conns := make(chan mocks.Connection)
 	thingsRepo := mocks.NewThingRepository(conns)
 	channelsRepo := mocks.NewChannelRepository(thingsRepo, conns)
@@ -624,7 +627,7 @@ func TestCreateChannels(t *testing.T) {
 }
 
 func TestUpdateChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	chs, err := svc.CreateChannels(context.Background(), token, channel)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	ch := chs[0]
@@ -663,7 +666,7 @@ func TestUpdateChannel(t *testing.T) {
 }
 
 func TestViewChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	chs, err := svc.CreateChannels(context.Background(), token, channel)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	ch := chs[0]
@@ -1026,7 +1029,7 @@ func TestListChannelsByThing(t *testing.T) {
 }
 
 func TestRemoveChannel(t *testing.T) {
-	svc := newService(map[string]string{token: email})
+	svc := newService(map[string]string{token: adminEmail})
 	chs, err := svc.CreateChannels(context.Background(), token, channel)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
 	ch := chs[0]

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -204,7 +204,7 @@ func TestShareThing(t *testing.T) {
 			thingID:  th.ID,
 			policies: []string{"", "read"},
 			userIDs:  []string{email2},
-			err:      fmt.Errorf("cannot claim ownership on thing '%s' by user '%s': %s", th.ID, email2, things.ErrMalformedEntity),
+			err:      fmt.Errorf("cannot claim ownership on object '%s' by user '%s': %s", th.ID, email2, things.ErrMalformedEntity),
 		},
 	}
 


### PR DESCRIPTION
### What does this do?

This PR adds policies for Channels entity encapsulating following operations; `view`, `update` and `delete`. The admin can do all of the operations on the all channels.

### Which issue(s) does this PR fix/relate to?

### List any changes that modify/break current functionality
Updated Channels repository and tests.
### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
