### PR TITLE
MF-1403 - Bump VerneMQ to 1.12.3

### DIFF
--- a/docker/vernemq/Dockerfile
+++ b/docker/vernemq/Dockerfile
@@ -1,9 +1,8 @@
 # Builder
-FROM erlang:22-alpine AS builder
+FROM erlang:23.3.2-alpine AS builder
 RUN apk add --update git build-base bsd-compat-headers openssl-dev snappy-dev curl \
-    && git clone https://github.com/vernemq/vernemq \
+    && git clone -b 1.12.3 https://github.com/vernemq/vernemq \
     && cd vernemq \
-    && git checkout eb1a262035af47e90d9edf07f36c1b1503557c1f \
     && make -j 16 rel
 
 # Executor


### PR DESCRIPTION
Signed-off-by: Ivan Milosevic <iva@blokovi.com>

### What does this do?

Building mainflux/vernemq docker image from VerneMQ source version 1.12.3

### Which issue(s) does this PR fix/relate to?
Resolves #1403 

### Notes

VerneMQ Release 1.12.3 is based on Erlang/OTP version 23.3.2, so base image is changed to `erlang:23.3.2-alpine`

https://github.com/vernemq/vernemq/releases/tag/1.12.3