### PR TITLE
NOISSUE - Change url for member groups in pkg

### DIFF
--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -127,7 +127,7 @@ func (sdk mfSDK) Unassign(token, groupID string, memberIDs ...string) error {
 }
 
 func (sdk mfSDK) Members(groupID, token string, offset, limit uint64) (MembersPage, error) {
-	url := fmt.Sprintf("%s, %s/%s/members?offset=%d&limit=%d&", sdk.authURL, groupsEndpoint, groupID, offset, limit)
+	url := fmt.Sprintf("%s/%s/%s/members?offset=%d&limit=%d&", sdk.authURL, groupsEndpoint, groupID, offset, limit)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return MembersPage{}, err


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It changes the URL the mainflux package is calling for getting members from a group.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality

Before

![Screenshot from 2022-01-26 21-16-36](https://user-images.githubusercontent.com/28790446/151229172-bd166bf7-cc47-4683-92ee-a447cc57f2c5.png)

After

![Screenshot from 2022-01-26 21-39-57](https://user-images.githubusercontent.com/28790446/151229175-4a338d6d-f038-4cb3-af5a-c50f93f17db0.png)

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A
