### PR TITLE
MF-1567 - Use Bearer, Thing or Basic scheme in Authorization header 

### DIFF
--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -55,7 +55,7 @@ func updateCertEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.UpdateCert(ctx, req.key, req.thingID, req.ClientCert, req.ClientKey, req.CACert); err != nil {
+		if err := svc.UpdateCert(ctx, req.token, req.thingID, req.ClientCert, req.ClientKey, req.CACert); err != nil {
 			return nil, err
 		}
 
@@ -73,7 +73,7 @@ func viewEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		config, err := svc.View(ctx, req.key, req.id)
+		config, err := svc.View(ctx, req.token, req.id)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +116,7 @@ func updateEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			Content: req.Content,
 		}
 
-		if err := svc.Update(ctx, req.key, config); err != nil {
+		if err := svc.Update(ctx, req.token, config); err != nil {
 			return nil, err
 		}
 
@@ -137,7 +137,7 @@ func updateConnEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.UpdateConnections(ctx, req.key, req.id, req.Channels); err != nil {
+		if err := svc.UpdateConnections(ctx, req.token, req.id, req.Channels); err != nil {
 			return nil, err
 		}
 
@@ -158,7 +158,7 @@ func listEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		page, err := svc.List(ctx, req.key, req.filter, req.offset, req.limit)
+		page, err := svc.List(ctx, req.token, req.filter, req.offset, req.limit)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func removeEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return removeRes{}, err
 		}
 
-		if err := svc.Remove(ctx, req.key, req.id); err != nil {
+		if err := svc.Remove(ctx, req.token, req.id); err != nil {
 			return nil, err
 		}
 
@@ -236,7 +236,7 @@ func stateEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		if err := svc.ChangeState(ctx, req.key, req.id, req.State); err != nil {
+		if err := svc.ChangeState(ctx, req.token, req.id, req.State); err != nil {
 			return nil, err
 		}
 

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -99,6 +99,7 @@ type testRequest struct {
 	url         string
 	contentType string
 	token       string
+	key         string
 	body        io.Reader
 }
 
@@ -124,6 +125,9 @@ func (tr testRequest) make() (*http.Response, error) {
 
 	if tr.token != "" {
 		req.Header.Set("Authorization", apiutil.BearerPrefix+tr.token)
+	}
+	if tr.key != "" {
+		req.Header.Set("Authorization", apiutil.ThingPrefix+tr.key)
 	}
 
 	if tr.contentType != "" {
@@ -1147,7 +1151,7 @@ func TestBootstrap(t *testing.T) {
 			client: bs.Client(),
 			method: http.MethodGet,
 			url:    fmt.Sprintf("%s/things/bootstrap/%s", bs.URL, tc.externalID),
-			token:  tc.externalKey,
+			key:    tc.externalKey,
 		}
 		res, err := req.make()
 		assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -44,13 +44,13 @@ func (req addReq) validate() error {
 }
 
 type entityReq struct {
-	key string
-	id  string
+	token string
+	id    string
 }
 
 func (req entityReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.id == "" {
@@ -61,15 +61,15 @@ func (req entityReq) validate() error {
 }
 
 type updateReq struct {
-	key     string
+	token   string
 	id      string
 	Name    string `json:"name"`
 	Content string `json:"content"`
 }
 
 func (req updateReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.id == "" {
@@ -80,7 +80,7 @@ func (req updateReq) validate() error {
 }
 
 type updateCertReq struct {
-	key        string
+	token      string
 	thingID    string
 	ClientCert string `json:"client_cert"`
 	ClientKey  string `json:"client_key"`
@@ -88,8 +88,8 @@ type updateCertReq struct {
 }
 
 func (req updateCertReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.thingID == "" {
@@ -100,14 +100,14 @@ func (req updateCertReq) validate() error {
 }
 
 type updateConnReq struct {
-	key      string
+	token    string
 	id       string
 	Channels []string `json:"channels"`
 }
 
 func (req updateConnReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.id == "" {
@@ -118,15 +118,15 @@ func (req updateConnReq) validate() error {
 }
 
 type listReq struct {
-	key    string
+	token  string
 	filter bootstrap.Filter
 	offset uint64
 	limit  uint64
 }
 
 func (req listReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.limit > maxLimitSize {
@@ -154,14 +154,14 @@ func (req bootstrapReq) validate() error {
 }
 
 type changeStateReq struct {
-	key   string
+	token string
 	id    string
 	State bootstrap.State `json:"state"`
 }
 
 func (req changeStateReq) validate() error {
-	if req.key == "" {
-		return apiutil.ErrBearerKey
+	if req.token == "" {
+		return apiutil.ErrBearerToken
 	}
 
 	if req.id == "" {

--- a/bootstrap/api/requests_test.go
+++ b/bootstrap/api/requests_test.go
@@ -54,28 +54,28 @@ func TestAddReqValidation(t *testing.T) {
 
 func TestEntityReqValidation(t *testing.T) {
 	cases := []struct {
-		desc string
-		key  string
-		id   string
-		err  error
+		desc  string
+		token string
+		id    string
+		err   error
 	}{
 		{
-			desc: "empty key",
-			key:  "",
-			id:   "id",
-			err:  apiutil.ErrBearerKey,
+			desc:  "empty token",
+			token: "",
+			id:    "id",
+			err:   apiutil.ErrBearerToken,
 		},
 		{
-			desc: "empty id",
-			key:  "key",
-			id:   "",
-			err:  apiutil.ErrMissingID,
+			desc:  "empty id",
+			token: "token",
+			id:    "",
+			err:   apiutil.ErrMissingID,
 		},
 	}
 
 	for _, tc := range cases {
 		req := entityReq{
-			key: tc.key,
+			token: tc.token,
 		}
 
 		err := req.validate()
@@ -85,29 +85,29 @@ func TestEntityReqValidation(t *testing.T) {
 
 func TestUpdateReqValidation(t *testing.T) {
 	cases := []struct {
-		desc string
-		key  string
-		id   string
-		err  error
+		desc  string
+		token string
+		id    string
+		err   error
 	}{
 		{
-			desc: "empty key",
-			key:  "",
-			id:   "id",
-			err:  apiutil.ErrBearerKey,
+			desc:  "empty token",
+			token: "",
+			id:    "id",
+			err:   apiutil.ErrBearerToken,
 		},
 		{
-			desc: "empty id",
-			key:  "key",
-			id:   "",
-			err:  apiutil.ErrMissingID,
+			desc:  "empty id",
+			token: "token",
+			id:    "",
+			err:   apiutil.ErrMissingID,
 		},
 	}
 
 	for _, tc := range cases {
 		req := updateReq{
-			key: tc.key,
-			id:  tc.id,
+			token: tc.token,
+			id:    tc.id,
 		}
 
 		err := req.validate()
@@ -118,19 +118,19 @@ func TestUpdateReqValidation(t *testing.T) {
 func TestUpdateCertReqValidation(t *testing.T) {
 	cases := []struct {
 		desc    string
-		key     string
+		token   string
 		thingID string
 		err     error
 	}{
 		{
-			desc:    "empty key",
-			key:     "",
+			desc:    "empty token",
+			token:   "",
 			thingID: "thingID",
-			err:     apiutil.ErrBearerKey,
+			err:     apiutil.ErrBearerToken,
 		},
 		{
 			desc:    "empty thing id",
-			key:     "key",
+			token:   "token",
 			thingID: "",
 			err:     apiutil.ErrMissingID,
 		},
@@ -138,7 +138,7 @@ func TestUpdateCertReqValidation(t *testing.T) {
 
 	for _, tc := range cases {
 		req := updateCertReq{
-			key:     tc.key,
+			token:   tc.token,
 			thingID: tc.thingID,
 		}
 
@@ -149,29 +149,29 @@ func TestUpdateCertReqValidation(t *testing.T) {
 
 func TestUpdateConnReqValidation(t *testing.T) {
 	cases := []struct {
-		desc string
-		key  string
-		id   string
-		err  error
+		desc  string
+		token string
+		id    string
+		err   error
 	}{
 		{
-			desc: "empty key",
-			key:  "",
-			id:   "id",
-			err:  apiutil.ErrBearerKey,
+			desc:  "empty token",
+			token: "",
+			id:    "id",
+			err:   apiutil.ErrBearerToken,
 		},
 		{
-			desc: "empty id",
-			key:  "key",
-			id:   "",
-			err:  apiutil.ErrMissingID,
+			desc:  "empty id",
+			token: "token",
+			id:    "",
+			err:   apiutil.ErrMissingID,
 		},
 	}
 
 	for _, tc := range cases {
 		req := updateReq{
-			key: tc.key,
-			id:  tc.id,
+			token: tc.token,
+			id:    tc.id,
 		}
 
 		err := req.validate()
@@ -183,27 +183,27 @@ func TestListReqValidation(t *testing.T) {
 	cases := []struct {
 		desc   string
 		offset uint64
-		key    string
+		token  string
 		limit  uint64
 		err    error
 	}{
 		{
-			desc:   "empty key",
-			key:    "",
+			desc:   "empty token",
+			token:  "",
 			offset: 0,
 			limit:  1,
-			err:    apiutil.ErrBearerKey,
+			err:    apiutil.ErrBearerToken,
 		},
 		{
 			desc:   "too large limit",
-			key:    "key",
+			token:  "token",
 			offset: 0,
 			limit:  maxLimitSize + 1,
 			err:    apiutil.ErrLimitSize,
 		},
 		{
 			desc:   "default limit",
-			key:    "key",
+			token:  "token",
 			offset: 0,
 			limit:  defLimit,
 			err:    nil,
@@ -212,7 +212,7 @@ func TestListReqValidation(t *testing.T) {
 
 	for _, tc := range cases {
 		req := listReq{
-			key:    tc.key,
+			token:  tc.token,
 			offset: tc.offset,
 			limit:  tc.limit,
 		}
@@ -257,28 +257,28 @@ func TestBootstrapReqValidation(t *testing.T) {
 func TestChangeStateReqValidation(t *testing.T) {
 	cases := []struct {
 		desc  string
-		key   string
+		token string
 		id    string
 		state bootstrap.State
 		err   error
 	}{
 		{
-			desc:  "empty key",
-			key:   "",
+			desc:  "empty token",
+			token: "",
 			id:    "id",
 			state: bootstrap.State(1),
-			err:   apiutil.ErrBearerKey,
+			err:   apiutil.ErrBearerToken,
 		},
 		{
 			desc:  "empty id",
-			key:   "key",
+			token: "token",
 			id:    "",
 			state: bootstrap.State(0),
 			err:   apiutil.ErrMissingID,
 		},
 		{
 			desc:  "invalid state",
-			key:   "key",
+			token: "token",
 			id:    "id",
 			state: bootstrap.State(14),
 			err:   apiutil.ErrBootstrapState,
@@ -287,7 +287,7 @@ func TestChangeStateReqValidation(t *testing.T) {
 
 	for _, tc := range cases {
 		req := changeStateReq{
-			key:   tc.key,
+			token: tc.token,
 			id:    tc.id,
 			State: tc.state,
 		}

--- a/bootstrap/api/transport.go
+++ b/bootstrap/api/transport.go
@@ -125,8 +125,8 @@ func decodeUpdateRequest(_ context.Context, r *http.Request) (interface{}, error
 	}
 
 	req := updateReq{
-		key: apiutil.ExtractBearerToken(r),
-		id:  bone.GetValue(r, "id"),
+		token: apiutil.ExtractBearerToken(r),
+		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
@@ -141,7 +141,7 @@ func decodeUpdateCertRequest(_ context.Context, r *http.Request) (interface{}, e
 	}
 
 	req := updateCertReq{
-		key:     apiutil.ExtractBearerToken(r),
+		token:   apiutil.ExtractBearerToken(r),
 		thingID: bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -157,8 +157,8 @@ func decodeUpdateConnRequest(_ context.Context, r *http.Request) (interface{}, e
 	}
 
 	req := updateConnReq{
-		key: apiutil.ExtractBearerToken(r),
-		id:  bone.GetValue(r, "id"),
+		token: apiutil.ExtractBearerToken(r),
+		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
@@ -184,7 +184,7 @@ func decodeListRequest(_ context.Context, r *http.Request) (interface{}, error) 
 	}
 
 	req := listReq{
-		key:    apiutil.ExtractBearerToken(r),
+		token:  apiutil.ExtractBearerToken(r),
 		filter: parseFilter(q),
 		offset: o,
 		limit:  l,
@@ -196,7 +196,7 @@ func decodeListRequest(_ context.Context, r *http.Request) (interface{}, error) 
 func decodeBootstrapRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	req := bootstrapReq{
 		id:  bone.GetValue(r, "external_id"),
-		key: apiutil.ExtractBearerToken(r),
+		key: apiutil.ExtractThingKey(r),
 	}
 
 	return req, nil
@@ -208,8 +208,8 @@ func decodeStateRequest(_ context.Context, r *http.Request) (interface{}, error)
 	}
 
 	req := changeStateReq{
-		key: apiutil.ExtractBearerToken(r),
-		id:  bone.GetValue(r, "id"),
+		token: apiutil.ExtractBearerToken(r),
+		id:    bone.GetValue(r, "id"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
@@ -220,8 +220,8 @@ func decodeStateRequest(_ context.Context, r *http.Request) (interface{}, error)
 
 func decodeEntityRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	req := entityReq{
-		key: apiutil.ExtractBearerToken(r),
-		id:  bone.GetValue(r, "id"),
+		token: apiutil.ExtractBearerToken(r),
+		id:    bone.GetValue(r, "id"),
 	}
 
 	return req, nil

--- a/certs/api/requests.go
+++ b/certs/api/requests.go
@@ -42,7 +42,7 @@ func (req *listReq) validate() error {
 	if req.token == "" {
 		return apiutil.ErrBearerToken
 	}
-	if req.limit > 1 || req.limit > maxLimitSize {
+	if req.limit > maxLimitSize {
 		return apiutil.ErrLimitSize
 	}
 	return nil

--- a/http/api/endpoint_test.go
+++ b/http/api/endpoint_test.go
@@ -50,7 +50,7 @@ func (tr testRequest) make() (*http.Response, error) {
 	}
 
 	if tr.token != "" {
-		req.Header.Set("Authorization", apiutil.BearerPrefix+tr.token)
+		req.Header.Set("Authorization", apiutil.ThingPrefix+tr.token)
 	}
 	if tr.basicAuth && tr.token != "" {
 		req.SetBasicAuth("", tr.token)

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -116,7 +116,7 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	case ok:
 		token = pass
 	case !ok:
-		token = apiutil.ExtractBearerToken(r)
+		token = apiutil.ExtractThingKey(r)
 	}
 
 	payload, err := ioutil.ReadAll(r.Body)

--- a/internal/apiutil/token.go
+++ b/internal/apiutil/token.go
@@ -11,6 +11,9 @@ import (
 // BearerPrefix represents the token prefix for Bearer authentication scheme.
 const BearerPrefix = "Bearer "
 
+// ThingPrefix represents the key prefix for Thing authentication scheme.
+const ThingPrefix = "Thing "
+
 // ExtractBearerToken returns value of the bearer token. If there is no bearer token - an empty value is returned.
 func ExtractBearerToken(r *http.Request) string {
 	token := r.Header.Get("Authorization")
@@ -20,4 +23,15 @@ func ExtractBearerToken(r *http.Request) string {
 	}
 
 	return strings.TrimPrefix(token, BearerPrefix)
+}
+
+// ExtractThingKey returns value of the thing key. If there is no thing key - an empty value is returned.
+func ExtractThingKey(r *http.Request) string {
+	token := r.Header.Get("Authorization")
+
+	if !strings.HasPrefix(token, ThingPrefix) {
+		return ""
+	}
+
+	return strings.TrimPrefix(token, ThingPrefix)
 }

--- a/pkg/sdk/go/message.go
+++ b/pkg/sdk/go/message.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
-func (sdk mfSDK) SendMessage(chanName, msg, token string) error {
+func (sdk mfSDK) SendMessage(chanName, msg, key string) error {
 	chanNameParts := strings.SplitN(chanName, ".", 2)
 	chanID := chanNameParts[0]
 	subtopicPart := ""
@@ -28,7 +28,7 @@ func (sdk mfSDK) SendMessage(chanName, msg, token string) error {
 		return err
 	}
 
-	resp, err := sdk.sendRequest(req, token, string(sdk.msgContentType))
+	resp, err := sdk.sendThingRequest(req, key, string(sdk.msgContentType))
 	if err != nil {
 		return err
 	}

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -337,3 +337,15 @@ func (sdk mfSDK) sendRequest(req *http.Request, token, contentType string) (*htt
 
 	return sdk.client.Do(req)
 }
+
+func (sdk mfSDK) sendThingRequest(req *http.Request, key, contentType string) (*http.Response, error) {
+	if key != "" {
+		req.Header.Set("Authorization", apiutil.ThingPrefix+key)
+	}
+
+	if contentType != "" {
+		req.Header.Add("Content-Type", contentType)
+	}
+
+	return sdk.client.Do(req)
+}

--- a/readers/api/requests.go
+++ b/readers/api/requests.go
@@ -17,11 +17,12 @@ type apiReq interface {
 type listMessagesReq struct {
 	chanID   string
 	token    string
+	key      string
 	pageMeta readers.PageMetadata
 }
 
 func (req listMessagesReq) validate() error {
-	if req.token == "" {
+	if req.token == "" && req.key == "" {
 		return apiutil.ErrBearerToken
 	}
 


### PR DESCRIPTION
### What does this do?
Use Bearer, Thing or Basic scheme in Authorization header.

### Which issue(s) does this PR fix/relate to?
Resolves: #1567 

### List any changes that modify/break current functionality
Authorization schemes must be respected from client side. 

### Have you included tests for your changes?
yes

### Did you document any new/modified functionality?
yes

