### PR TITLE
NOISSUE - Add nats wrapper for COAP

### DIFF
--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mainflux/mainflux/coap"
 	"github.com/mainflux/mainflux/coap/api"
 	logger "github.com/mainflux/mainflux/logger"
+	"github.com/mainflux/mainflux/pkg/messaging/nats"
 	thingsapi "github.com/mainflux/mainflux/things/api/auth/grpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	gocoap "github.com/plgd-dev/go-coap/v2"
@@ -76,7 +77,12 @@ func main() {
 
 	tc := thingsapi.NewClient(conn, thingsTracer, cfg.thingsAuthTimeout)
 
-	svc := coap.New(tc, cfg.natsURL, logger)
+	pubsub, err := nats.NewPubSub(cfg.natsURL, "coap", logger)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	svc := coap.New(tc, pubsub)
 
 	svc = api.LoggingMiddleware(svc, logger)
 

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/mainflux/mainflux/coap/api"
 	logger "github.com/mainflux/mainflux/logger"
 	thingsapi "github.com/mainflux/mainflux/things/api/auth/grpc"
-	broker "github.com/nats-io/nats.go"
 	opentracing "github.com/opentracing/opentracing-go"
 	gocoap "github.com/plgd-dev/go-coap/v2"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -77,13 +76,7 @@ func main() {
 
 	tc := thingsapi.NewClient(conn, thingsTracer, cfg.thingsAuthTimeout)
 
-	nc, err := broker.Connect(cfg.natsURL)
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-	defer nc.Close()
-
-	svc := coap.New(tc, nc)
+	svc := coap.New(tc, cfg.natsURL, logger)
 
 	svc = api.LoggingMiddleware(svc, logger)
 

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -82,7 +82,7 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	defer pubsub.conn.Close()
+	defer pubsub.Close()
 
 	svc := coap.New(tc, pubsub)
 

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -82,6 +82,8 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
+	defer pubsub.conn.Close()
+
 	svc := coap.New(tc, pubsub)
 
 	svc = api.LoggingMiddleware(svc, logger)

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -115,20 +115,20 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopi
 	return svc.remove(subject, token)
 }
 
-func (svc *adapterService) put(endpoint, token string, o Observer) error {
+func (svc *adapterService) put(topic, token string, o Observer) error {
 	svc.obsLock.Lock()
 	defer svc.obsLock.Unlock()
 
-	obs, ok := svc.observers[endpoint]
-	// If there are no observers, create map and assign it to the endpoint.
+	obs, ok := svc.observers[topic]
+	// If there are no observers, create map and assign it to the topic.
 	if !ok {
 		obs = observers{token: o}
-		svc.observers[endpoint] = obs
+		svc.observers[topic] = obs
 		return nil
 	}
 	// If observer exists, cancel subscription and replace it.
 	if sub, ok := obs[token]; ok {
-		if err := sub.Cancel(endpoint); err != nil {
+		if err := sub.Cancel(topic); err != nil {
 			return errors.Wrap(ErrUnsubscribe, err)
 		}
 	}
@@ -136,23 +136,23 @@ func (svc *adapterService) put(endpoint, token string, o Observer) error {
 	return nil
 }
 
-func (svc *adapterService) remove(endpoint, token string) error {
+func (svc *adapterService) remove(topic, token string) error {
 	svc.obsLock.Lock()
 	defer svc.obsLock.Unlock()
 
-	obs, ok := svc.observers[endpoint]
+	obs, ok := svc.observers[topic]
 	if !ok {
 		return nil
 	}
 	if current, ok := obs[token]; ok {
-		if err := current.Cancel(endpoint); err != nil {
+		if err := current.Cancel(topic); err != nil {
 			return errors.Wrap(ErrUnsubscribe, err)
 		}
 	}
 	delete(obs, token)
 	// If there are no observers left for the endpint, remove the map.
 	if len(obs) == 0 {
-		delete(svc.observers, endpoint)
+		delete(svc.observers, topic)
 	}
 	return nil
 }

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -9,10 +9,7 @@ package coap
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
-
-	log "github.com/mainflux/mainflux/logger"
 
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/mainflux/mainflux/pkg/messaging/nats"
@@ -50,12 +47,7 @@ type adapterService struct {
 }
 
 // New instantiates the CoAP adapter implementation.
-func New(auth mainflux.ThingsServiceClient, url string, logger log.Logger) Service {
-	pubsub, err := nats.NewPubSub(url, "coap", logger)
-	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(1)
-	}
+func New(auth mainflux.ThingsServiceClient, pubsub nats.PubSub) Service {
 	as := &adapterService{
 		auth:      auth,
 		pubsub:    pubsub,

--- a/coap/observer.go
+++ b/coap/observer.go
@@ -4,43 +4,35 @@
 package coap
 
 import (
-	"github.com/gogo/protobuf/proto"
-	"github.com/mainflux/mainflux/pkg/messaging"
+	"github.com/mainflux/mainflux/pkg/messaging/nats"
 	broker "github.com/nats-io/nats.go"
 )
 
 // Observer represents an internal observer used to handle CoAP observe messages.
 type Observer interface {
-	Cancel() error
+	Cancel(topic string) error
 }
 
 // NewObserver returns a new Observer instance.
-func NewObserver(subject string, c Client, conn *broker.Conn) (Observer, error) {
-	sub, err := conn.Subscribe(subject, func(m *broker.Msg) {
-		var msg messaging.Message
-		if err := proto.Unmarshal(m.Data, &msg); err != nil {
-			return
-		}
-		// There is no error handling, but the client takes care to log the error.
-		c.SendMessage(msg)
-	})
+func NewObserver(subject string, c Client, pubsub nats.PubSub) (Observer, error) {
+	err := pubsub.Subscribe(subject, c.SendMessage)
 	if err != nil {
 		return nil, err
 	}
 	ret := &observer{
 		client: c,
-		sub:    sub,
+		pubsub: pubsub,
 	}
 	return ret, nil
 }
 
 type observer struct {
 	client Client
-	sub    *broker.Subscription
+	pubsub nats.PubSub
 }
 
-func (o *observer) Cancel() error {
-	if err := o.sub.Unsubscribe(); err != nil && err != broker.ErrConnectionClosed {
+func (o *observer) Cancel(topic string) error {
+	if err := o.pubsub.Unsubscribe(topic); err != nil && err != broker.ErrConnectionClosed {
 		return err
 	}
 	return o.client.Cancel()


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
Makes the COAP service use the nats wrapper instead of talking directly to the broker

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
N/A

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
