### PR TITLE
NOISSUE - Fix CoAP adapter

### DIFF
--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -20,8 +20,8 @@ import (
 	"github.com/mainflux/mainflux/coap"
 	"github.com/mainflux/mainflux/coap/api"
 	logger "github.com/mainflux/mainflux/logger"
-	"github.com/mainflux/mainflux/pkg/messaging/nats"
 	thingsapi "github.com/mainflux/mainflux/things/api/auth/grpc"
+	broker "github.com/nats-io/nats.go"
 	opentracing "github.com/opentracing/opentracing-go"
 	gocoap "github.com/plgd-dev/go-coap/v2"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -77,14 +77,13 @@ func main() {
 
 	tc := thingsapi.NewClient(conn, thingsTracer, cfg.thingsAuthTimeout)
 
-	pubsub, err := nats.NewPubSub(cfg.natsURL, "coap", logger)
+	nc, err := broker.Connect(cfg.natsURL)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
+	defer nc.Close()
 
-	defer pubsub.Close()
-
-	svc := coap.New(tc, pubsub)
+	svc := coap.New(tc, nc)
 
 	svc = api.LoggingMiddleware(svc, logger)
 

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mainflux/mainflux/pkg/errors"
@@ -55,6 +56,14 @@ func New(auth mainflux.ThingsServiceClient, nc *broker.Conn) Service {
 		observers: make(map[string]observers),
 		obsLock:   sync.Mutex{},
 	}
+	go func() {
+		for {
+			time.Sleep(10 * time.Second)
+			as.obsLock.Lock()
+			fmt.Println("LEN", len(as.observers), as.observers)
+			as.obsLock.Unlock()
+		}
+	}()
 
 	return as
 }
@@ -97,11 +106,6 @@ func (svc *adapterService) Subscribe(ctx context.Context, key, chanID, subtopic 
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
 
-	go func() {
-		<-c.Done()
-		svc.remove(subject, c.Token())
-	}()
-
 	obs, err := NewObserver(subject, c, svc.conn)
 	if err != nil {
 		c.Cancel()
@@ -111,13 +115,13 @@ func (svc *adapterService) Subscribe(ctx context.Context, key, chanID, subtopic 
 }
 
 func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopic, token string) error {
-	ar := &mainflux.AccessByKeyReq{
-		Token:  key,
-		ChanID: chanID,
-	}
-	if _, err := svc.auth.CanAccessByKey(ctx, ar); err != nil {
-		return errors.Wrap(errors.ErrAuthorization, err)
-	}
+	// ar := &mainflux.AccessByKeyReq{
+	// 	Token:  key,
+	// 	ChanID: chanID,
+	// }
+	// if _, err := svc.auth.CanAccessByKey(ctx, ar); err != nil {
+	// 	return errors.Wrap(errors.ErrAuthorization, err)
+	// }
 	subject := fmt.Sprintf("%s.%s", chansPrefix, chanID)
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
@@ -126,15 +130,15 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopi
 	return svc.remove(subject, token)
 }
 
-func (svc *adapterService) put(endpoint, token string, o Observer) error {
+func (svc *adapterService) put(topic, token string, o Observer) error {
 	svc.obsLock.Lock()
 	defer svc.obsLock.Unlock()
 
-	obs, ok := svc.observers[endpoint]
+	obs, ok := svc.observers[topic]
 	// If there are no observers, create map and assign it to the endpoint.
 	if !ok {
 		obs = observers{token: o}
-		svc.observers[endpoint] = obs
+		svc.observers[topic] = obs
 		return nil
 	}
 	// If observer exists, cancel subscription and replace it.
@@ -147,11 +151,11 @@ func (svc *adapterService) put(endpoint, token string, o Observer) error {
 	return nil
 }
 
-func (svc *adapterService) remove(endpoint, token string) error {
+func (svc *adapterService) remove(topic, token string) error {
 	svc.obsLock.Lock()
 	defer svc.obsLock.Unlock()
 
-	obs, ok := svc.observers[endpoint]
+	obs, ok := svc.observers[topic]
 	if !ok {
 		return nil
 	}
@@ -163,7 +167,7 @@ func (svc *adapterService) remove(endpoint, token string) error {
 	delete(obs, token)
 	// If there are no observers left for the endpint, remove the map.
 	if len(obs) == 0 {
-		delete(svc.observers, endpoint)
+		delete(svc.observers, topic)
 	}
 	return nil
 }

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mainflux/mainflux/pkg/errors"
@@ -56,14 +55,6 @@ func New(auth mainflux.ThingsServiceClient, nc *broker.Conn) Service {
 		observers: make(map[string]observers),
 		obsLock:   sync.Mutex{},
 	}
-	go func() {
-		for {
-			time.Sleep(10 * time.Second)
-			as.obsLock.Lock()
-			fmt.Println("LEN", len(as.observers), as.observers)
-			as.obsLock.Unlock()
-		}
-	}()
 
 	return as
 }
@@ -115,13 +106,13 @@ func (svc *adapterService) Subscribe(ctx context.Context, key, chanID, subtopic 
 }
 
 func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopic, token string) error {
-	// ar := &mainflux.AccessByKeyReq{
-	// 	Token:  key,
-	// 	ChanID: chanID,
-	// }
-	// if _, err := svc.auth.CanAccessByKey(ctx, ar); err != nil {
-	// 	return errors.Wrap(errors.ErrAuthorization, err)
-	// }
+	ar := &mainflux.AccessByKeyReq{
+		Token:  key,
+		ChanID: chanID,
+	}
+	if _, err := svc.auth.CanAccessByKey(ctx, ar); err != nil {
+		return errors.Wrap(errors.ErrAuthorization, err)
+	}
 	subject := fmt.Sprintf("%s.%s", chansPrefix, chanID)
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)

--- a/coap/api/logging.go
+++ b/coap/api/logging.go
@@ -61,11 +61,20 @@ func (lm *loggingMiddleware) Subscribe(ctx context.Context, key, chanID, subtopi
 	return lm.svc.Subscribe(ctx, key, chanID, subtopic, c)
 }
 
-func (lm *loggingMiddleware) Unsubscribe(ctx context.Context, key, chanID, subtopic, token string) error {
+func (lm *loggingMiddleware) Unsubscribe(ctx context.Context, key, chanID, subtopic, token string) (err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method unsubscribe for the client %s from the channel %s and subtopic %s took %s to complete without errors.", token, chanID, subtopic, time.Since(begin))
-		lm.logger.Info(fmt.Sprintf(message))
+		destChannel := chanID
+		if subtopic != "" {
+			destChannel = fmt.Sprintf("%s.%s", destChannel, subtopic)
+		}
+		message := fmt.Sprintf("Method unsubscribe for the client %s from the channel %s and subtopic %s took %s to complete without errors.", token, destChannel, subtopic, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
 
 	return lm.svc.Unsubscribe(ctx, key, chanID, subtopic, token)
+
 }

--- a/coap/api/logging.go
+++ b/coap/api/logging.go
@@ -67,7 +67,7 @@ func (lm *loggingMiddleware) Unsubscribe(ctx context.Context, key, chanID, subto
 		if subtopic != "" {
 			destChannel = fmt.Sprintf("%s.%s", destChannel, subtopic)
 		}
-		message := fmt.Sprintf("Method unsubscribe for the client %s from the channel %s and subtopic %s took %s to complete without errors.", token, destChannel, subtopic, time.Since(begin))
+		message := fmt.Sprintf("Method unsubscribe for the client %s from the channel %s took %s to complete", token, destChannel, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -66,7 +66,6 @@ func sendResp(w mux.ResponseWriter, resp *message.Message, send *bool) {
 }
 
 func handler(w mux.ResponseWriter, m *mux.Message) {
-	fmt.Println("Received message:", m)
 	resp := message.Message{
 		Code:    codes.Content,
 		Token:   m.Token,
@@ -108,7 +107,6 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 			break
 		}
 		service.Unsubscribe(context.Background(), key, msg.Channel, msg.Subtopic, m.Token.String())
-		fmt.Println("SEND")
 		send = false
 	case codes.POST:
 		err = service.Publish(context.Background(), key, msg)
@@ -168,9 +166,6 @@ func parseID(path string) string {
 }
 
 func parseKey(msg *mux.Message) (string, error) {
-	if obs, _ := msg.Options.Observe(); obs != 0 && msg.Code == codes.GET {
-		return "", nil
-	}
 	authKey, err := msg.Options.GetString(message.URIQuery)
 	if err != nil {
 		return "", err

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	protocol  = "coap"
-	authQuery = "auth"
+	protocol     = "coap"
+	authQuery    = "auth"
+	startObserve = 0 // observe option value that indicates start of observation
 )
 
 var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*)?(\?.*)?$`)
@@ -124,7 +125,7 @@ func handleGet(m *mux.Message, c mux.Client, msg messaging.Message, key string) 
 		logger.Warn(fmt.Sprintf("Error reading observe option: %s", err))
 		return errBadOptions
 	}
-	if obs == 0 {
+	if obs == startObserve {
 		c := coap.NewClient(c, m.Token, logger)
 		return service.Subscribe(context.Background(), key, msg.Channel, msg.Subtopic, c)
 	}

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -33,6 +33,12 @@ const (
 
 var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*)?(\?.*)?$`)
 
+const (
+	numGroups    = 3 // entire expression + channel group + subtopic group
+	channelGroup = 2 // channel group is second in channel regexp
+
+)
+
 var (
 	errMalformedSubtopic = errors.New("malformed subtopic")
 	errBadOptions        = errors.New("bad options")
@@ -135,11 +141,11 @@ func decodeMessage(msg *mux.Message) (messaging.Message, error) {
 		return messaging.Message{}, err
 	}
 	channelParts := channelPartRegExp.FindStringSubmatch(path)
-	if len(channelParts) < 3 {
+	if len(channelParts) < numGroups {
 		return messaging.Message{}, errMalformedSubtopic
 	}
 
-	st, err := parseSubtopic(channelParts[2])
+	st, err := parseSubtopic(channelParts[channelGroup])
 	if err != nil {
 		return messaging.Message{}, err
 	}

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -36,7 +36,6 @@ var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*
 const (
 	numGroups    = 3 // entire expression + channel group + subtopic group
 	channelGroup = 2 // channel group is second in channel regexp
-
 )
 
 var (

--- a/coap/client.go
+++ b/coap/client.go
@@ -62,7 +62,6 @@ func (c *client) Cancel() error {
 	if err := c.client.WriteMessage(&m); err != nil {
 		c.logger.Error(fmt.Sprintf("Error sending message: %s.", err))
 	}
-	fmt.Println("sent done")
 	return c.client.Close()
 }
 
@@ -77,29 +76,6 @@ func (c *client) SendMessage(msg messaging.Message) error {
 		Context: c.client.Context(),
 		Body:    bytes.NewReader(msg.Payload),
 	}
-
-	// var opts message.Options
-	// var buf []byte
-	// opts, n, err := opts.SetContentFormat(buf, message.TextPlain)
-	// if err == message.ErrTooSmall {
-	// 	buf = append(buf, make([]byte, n)...)
-	// 	opts, _, err = opts.SetContentFormat(buf, message.TextPlain)
-	// }
-	// if err != nil {
-	// 	return fmt.Errorf("cannot set content format to response: %w", err)
-	// }
-	// if obs >= 0 {
-	// 	opts, n, err = opts.SetObserve(buf, uint32(obs))
-	// 	if err == message.ErrTooSmall {
-	// 		buf = append(buf, make([]byte, n)...)
-	// 		opts, _, err = opts.SetObserve(buf, uint32(obs))
-	// 	}
-	// 	if err != nil {
-	// 		return fmt.Errorf("cannot set options to response: %w", err)
-	// 	}
-	// }
-	// m.Options = opts
-	// return cc.WriteMessage(&m)
 
 	atomic.AddUint32(&c.observe, 1)
 	var opts message.Options
@@ -125,10 +101,4 @@ func (c *client) SendMessage(msg messaging.Message) error {
 
 	m.Options = opts
 	return c.client.WriteMessage(&m)
-	// go func() {
-	// 	if err := c.client.WriteMessage(&m); err != nil {
-	// 		c.logger.Error(fmt.Sprintf("Error sending message: %s.", err))
-	// 	}
-	// }()
-	// return nil
 }

--- a/coap/client.go
+++ b/coap/client.go
@@ -79,7 +79,6 @@ func (c *client) SendMessage(msg messaging.Message) error {
 	atomic.AddUint32(&c.observe, 1)
 	var opts message.Options
 	var buff []byte
-	fmt.Println("Sending message 1")
 	opts, n, err := opts.SetContentFormat(buff, message.TextPlain)
 	if err == message.ErrTooSmall {
 		buff = append(buff, make([]byte, n)...)
@@ -91,7 +90,6 @@ func (c *client) SendMessage(msg messaging.Message) error {
 	}
 	opts = append(opts, message.Option{ID: message.Observe, Value: []byte{byte(c.observe)}})
 	m.Options = opts
-	fmt.Println("Sending message 2")
 	go func() {
 		if err := c.client.WriteMessage(&m); err != nil {
 			c.logger.Error(fmt.Sprintf("Error sending message: %s.", err))

--- a/coap/observer.go
+++ b/coap/observer.go
@@ -4,35 +4,43 @@
 package coap
 
 import (
-	"github.com/mainflux/mainflux/pkg/messaging/nats"
+	"github.com/gogo/protobuf/proto"
+	"github.com/mainflux/mainflux/pkg/messaging"
 	broker "github.com/nats-io/nats.go"
 )
 
 // Observer represents an internal observer used to handle CoAP observe messages.
 type Observer interface {
-	Cancel(topic string) error
+	Cancel() error
 }
 
 // NewObserver returns a new Observer instance.
-func NewObserver(subject string, c Client, pubsub nats.PubSub) (Observer, error) {
-	err := pubsub.Subscribe(subject, c.SendMessage)
+func NewObserver(subject string, c Client, conn *broker.Conn) (Observer, error) {
+	sub, err := conn.Subscribe(subject, func(m *broker.Msg) {
+		var msg messaging.Message
+		if err := proto.Unmarshal(m.Data, &msg); err != nil {
+			return
+		}
+		// There is no error handling, but the client takes care to log the error.
+		c.SendMessage(msg)
+	})
 	if err != nil {
 		return nil, err
 	}
 	ret := &observer{
 		client: c,
-		pubsub: pubsub,
+		sub:    sub,
 	}
 	return ret, nil
 }
 
 type observer struct {
 	client Client
-	pubsub nats.PubSub
+	sub    *broker.Subscription
 }
 
-func (o *observer) Cancel(topic string) error {
-	if err := o.pubsub.Unsubscribe(topic); err != nil && err != broker.ErrConnectionClosed {
+func (o *observer) Cancel() error {
+	if err := o.sub.Unsubscribe(); err != nil && err != broker.ErrConnectionClosed {
 		return err
 	}
 	return o.client.Cancel()

--- a/coap/observer.go
+++ b/coap/observer.go
@@ -4,6 +4,8 @@
 package coap
 
 import (
+	"fmt"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/mainflux/mainflux/pkg/messaging"
 	broker "github.com/nats-io/nats.go"
@@ -22,6 +24,7 @@ func NewObserver(subject string, c Client, conn *broker.Conn) (Observer, error) 
 			return
 		}
 		// There is no error handling, but the client takes care to log the error.
+		fmt.Println("Calling handler")
 		c.SendMessage(msg)
 	})
 	if err != nil {

--- a/coap/observer.go
+++ b/coap/observer.go
@@ -4,8 +4,6 @@
 package coap
 
 import (
-	"fmt"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/mainflux/mainflux/pkg/messaging"
 	broker "github.com/nats-io/nats.go"
@@ -24,7 +22,6 @@ func NewObserver(subject string, c Client, conn *broker.Conn) (Observer, error) 
 			return
 		}
 		// There is no error handling, but the client takes care to log the error.
-		fmt.Println("Calling handler")
 		c.SendMessage(msg)
 	})
 	if err != nil {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,6 +105,8 @@ services:
       - ./nats/:/etc/nats
     networks:
       - mainflux-base-net
+    ports:
+    - 4222:4222
 
   auth-db:
     image: postgres:13.3-alpine


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes the CoAP adapter in observe mode.
Since NATS PubSub implementation is limited to one subscriber per topic, and CoAP will have multiple subscribers with different tokens per single topic, NATS PubSub wrapper won't work for the CoAP adapter.

### Which issue(s) does this PR fix/relate to?
There are no such issues.

### List any changes that modify/break current functionality
There are no breaking changes. Observe mod now takes into account the Observe option.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No, since now the adapter acts according to the protocol spec.

### Notes
N/A