### PR TITLE
MF-1361 - Add StringValue and DataValue comparison filters

### DIFF
--- a/readers/cassandra/messages.go
+++ b/readers/cassandra/messages.go
@@ -150,10 +150,12 @@ func buildQuery(chanID string, rpm readers.PageMetadata) (string, []interface{})
 			condCQL = fmt.Sprintf(`%s AND bool_value = ?`, condCQL)
 		case "vs":
 			vals = append(vals, val)
-			condCQL = fmt.Sprintf(`%s AND string_value = ?`, condCQL)
+			comparator := readers.ParseValueComparator(query)
+			condCQL = fmt.Sprintf(`%s AND string_value %s ?`, condCQL, comparator)
 		case "vd":
 			vals = append(vals, val)
-			condCQL = fmt.Sprintf(`%s AND data_value = ?`, condCQL)
+			comparator := readers.ParseValueComparator(query)
+			condCQL = fmt.Sprintf(`%s AND data_value %s ?`, condCQL, comparator)
 		case "from":
 			vals = append(vals, val)
 			condCQL = fmt.Sprintf(`%s AND time >= ?`, condCQL)

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -401,6 +401,57 @@ func TestReadSenml(t *testing.T) {
 				Total:    uint64(len(dataMsgs)),
 				Messages: fromSenml(dataMsgs[0:limit]),
 			},
+		}, "read message with data value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
 		},
 		"read message with from": {
 			chanID: chanID,

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -325,6 +325,71 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
+		"read message with string value and equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs,
+				Comparator:  readers.EqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
 		"read message with data value": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{

--- a/readers/mongodb/messages.go
+++ b/readers/mongodb/messages.go
@@ -6,6 +6,7 @@ package mongodb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/mainflux/mainflux/pkg/transformers/senml"
@@ -20,6 +21,17 @@ const (
 	// Collection for SenML messages
 	defCollection = "messages"
 )
+
+// mongoDB comparison operators different than default mainflux
+// readers comparison operators. This map maps mainflux comparators
+// to mongoDB comparators.
+var mongoComparators = map[string]string{
+	readers.EqualKey:            "eq",
+	readers.LowerThanKey:        "lt",
+	readers.LowerThanEqualKey:   "lte",
+	readers.GreaterThanKey:      "gt",
+	readers.GreaterThanEqualKey: "gte",
+}
 
 var _ readers.MessageRepository = (*mongoRepository)(nil)
 
@@ -117,34 +129,32 @@ func fmtCondition(chanID string, rpm readers.PageMetadata) bson.D {
 			filter = append(filter, bson.E{Key: name, Value: value})
 		case "v":
 			bsonFilter := value
-			val, ok := query["comparator"]
-			if ok {
-				switch val.(string) {
-				case readers.EqualKey:
-					bsonFilter = value
-				case readers.LowerThanKey:
-					bsonFilter = bson.M{"$lt": value}
-				case readers.LowerThanEqualKey:
-					bsonFilter = bson.M{"$lte": value}
-				case readers.GreaterThanKey:
-					bsonFilter = bson.M{"$gt": value}
-				case readers.GreaterThanEqualKey:
-					bsonFilter = bson.M{"$gte": value}
-				}
+			if val, ok := query["comparator"].(string); ok {
+				comparator := fmt.Sprintf("$%s", mongoComparators[val]) // mongoDB comparison operator
+				bsonFilter = bson.M{comparator: value}
 			}
 			filter = append(filter, bson.E{Key: "value", Value: bsonFilter})
 		case "vb":
 			filter = append(filter, bson.E{Key: "bool_value", Value: value})
 		case "vs":
-			filter = append(filter, bson.E{Key: "string_value", Value: value})
+			bsonFilter := value
+			if val, ok := query["comparator"].(string); ok {
+				comparator := fmt.Sprintf("$%s", mongoComparators[val])
+				bsonFilter = bson.M{comparator: value}
+			}
+			filter = append(filter, bson.E{Key: "string_value", Value: bsonFilter})
 		case "vd":
-			filter = append(filter, bson.E{Key: "data_value", Value: value})
+			bsonFilter := value
+			if val, ok := query["comparator"].(string); ok {
+				comparator := fmt.Sprintf("$%s", mongoComparators[val])
+				bsonFilter = bson.M{comparator: value}
+			}
+			filter = append(filter, bson.E{Key: "data_value", Value: bsonFilter})
 		case "from":
 			filter = append(filter, bson.E{Key: "time", Value: bson.M{"$gte": value}})
 		case "to":
 			filter = append(filter, bson.E{Key: "time", Value: bson.M{"$lt": value}})
 		}
 	}
-
 	return filter
 }

--- a/readers/mongodb/messages_test.go
+++ b/readers/mongodb/messages_test.go
@@ -322,6 +322,57 @@ func TestReadSenml(t *testing.T) {
 				Total:    uint64(len(stringMsgs)),
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
+		}, "read message with string value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
 		},
 		"read message with data value": {
 			chanID: chanID,

--- a/readers/mongodb/messages_test.go
+++ b/readers/mongodb/messages_test.go
@@ -385,6 +385,57 @@ func TestReadSenml(t *testing.T) {
 				Total:    uint64(len(dataMsgs)),
 				Messages: fromSenml(dataMsgs[0:limit]),
 			},
+		}, "read message with data value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
 		},
 		"read message with from": {
 			chanID: chanID,

--- a/readers/postgres/messages.go
+++ b/readers/postgres/messages.go
@@ -149,9 +149,11 @@ func fmtCondition(chanID string, rpm readers.PageMetadata) string {
 		case "vb":
 			condition = fmt.Sprintf(`%s AND bool_value = :bool_value`, condition)
 		case "vs":
-			condition = fmt.Sprintf(`%s AND string_value = :string_value`, condition)
+			comparator := readers.ParseValueComparator(query)
+			condition = fmt.Sprintf(`%s AND string_value %s :string_value`, condition, comparator)
 		case "vd":
-			condition = fmt.Sprintf(`%s AND data_value = :data_value`, condition)
+			comparator := readers.ParseValueComparator(query)
+			condition = fmt.Sprintf(`%s AND data_value %s :data_value`, condition, comparator)
 		case "from":
 			condition = fmt.Sprintf(`%s AND time >= :from`, condition)
 		case "to":

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -393,6 +393,57 @@ func TestReadSenml(t *testing.T) {
 				Total:    uint64(len(dataMsgs)),
 				Messages: fromSenml(dataMsgs[0:limit]),
 			},
+		}, "read message with data value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd + string(rune(1)),
+				Comparator: readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
+		},
+		"read message with data value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:     0,
+				Limit:      limit,
+				DataValue:  vd[:len(vs)-1],
+				Comparator: readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(dataMsgs)),
+				Messages: fromSenml(dataMsgs[0:limit]),
+			},
 		},
 		"read message with from": {
 			chanID: chanID,

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -317,7 +317,6 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
-
 		"read message with string value and equal comparator": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{
@@ -331,7 +330,6 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
-
 		"read message with string value and lower-than comparator": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{
@@ -345,7 +343,6 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
-
 		"read message with string value and lower-than-or-equal comparator": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{
@@ -359,7 +356,6 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
-
 		"read message with string value and greater-than comparator": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{
@@ -386,7 +382,6 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
-
 		"read message with data value": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{

--- a/readers/postgres/messages_test.go
+++ b/readers/postgres/messages_test.go
@@ -317,6 +317,76 @@ func TestReadSenml(t *testing.T) {
 				Messages: fromSenml(stringMsgs[0:limit]),
 			},
 		},
+
+		"read message with string value and equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs,
+				Comparator:  readers.EqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+
+		"read message with string value and lower-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+
+		"read message with string value and lower-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs + string(rune(1)),
+				Comparator:  readers.LowerThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+
+		"read message with string value and greater-than comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+		"read message with string value and greater-than-or-equal comparator": {
+			chanID: chanID,
+			pageMeta: readers.PageMetadata{
+				Offset:      0,
+				Limit:       limit,
+				StringValue: vs[:len(vs)-1],
+				Comparator:  readers.GreaterThanEqualKey,
+			},
+			page: readers.MessagesPage{
+				Total:    uint64(len(stringMsgs)),
+				Messages: fromSenml(stringMsgs[0:limit]),
+			},
+		},
+
 		"read message with data value": {
 			chanID: chanID,
 			pageMeta: readers.PageMetadata{


### PR DESCRIPTION
### What does this do?
This pull request adds le `le` `lt` `ge` `gt` comparators for StringValue and DataValue
### Which issue(s) does this PR fix/relate to?
 Resolves #1361 
### List any changes that modify/break current functionality
There are no breaking changes. Now StringValue and DataValue comparisons are possible in database readers.

### Have you included tests for your changes?
Yes, test cases are added.

### Did you document any new/modified functionality?
No.
### Notes
N/A