### PR TITLE
MF-1580 - Influxdb Writer changes format of update-time to string

### DIFF
--- a/consumers/writers/influxdb/fields.go
+++ b/consumers/writers/influxdb/fields.go
@@ -9,7 +9,7 @@ import (
 type fields map[string]interface{}
 
 func senmlFields(msg senml.Message) fields {
-	updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
+	// updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
 	ret := fields{
 		"protocol":   msg.Protocol,
 		"unit":       msg.Unit,

--- a/consumers/writers/influxdb/fields.go
+++ b/consumers/writers/influxdb/fields.go
@@ -1,19 +1,16 @@
 package influxdb
 
 import (
-	"strconv"
-
 	"github.com/mainflux/mainflux/pkg/transformers/senml"
 )
 
 type fields map[string]interface{}
 
 func senmlFields(msg senml.Message) fields {
-	// updateTime := strconv.FormatFloat(msg.UpdateTime, 'f', -1, 64)
 	ret := fields{
 		"protocol":   msg.Protocol,
 		"unit":       msg.Unit,
-		"updateTime": updateTime,
+		"updateTime": msg.UpdateTime,
 	}
 
 	switch {


### PR DESCRIPTION

### What does this do?
This will stop influxdb-writer service from changing the datatype of update-time variable to string

### Which issue(s) does this PR fix/relate to?
Resolves #1580

### List any changes that modify/break current functionality
It won't break current functionality

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

