### PR TITLE
MF-1627 - Fix SDK interface function signature

### DIFF
--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -164,7 +164,7 @@ type SDK interface {
 
 	// ThingsByChannel returns page of things that are connected or not connected
 	// to specified channel.
-	ThingsByChannel(token, chanID string, offset, limit uint64, connected bool) (ThingsPage, error)
+	ThingsByChannel(token, chanID string, offset, limit uint64, disconnected bool) (ThingsPage, error)
 
 	// Thing returns thing object by id.
 	Thing(id, token string) (Thing, error)


### PR DESCRIPTION
Change function ThingsByChannel param name from connected to disconnected to match with request params

### What does this do?
Just fixes the SDK interface, changing the function ThingByChannel last param name from connected to disconnected to avoid confusion

Resolves #1627 

