### PR TITLE
NOISSUE - Fix Update Channel Typo

### DIFF
--- a/cli/channels.go
+++ b/cli/channels.go
@@ -80,7 +80,7 @@ var cmdChannels = []cobra.Command{
 		},
 	},
 	{
-		Use:   "updatev <JSON_string> <user_auth_token>",
+		Use:   "update <JSON_string> <user_auth_token>",
 		Short: "Update channel",
 		Long:  `Updates channel record`,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: 0x6f736f646f <blackd0t@protonmail.com>

### What does this do?
It fixes update channel typo in the cli

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A