### PR TITLE
MF-1670 - Improve error handling in SDK

### DIFF
--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -6,7 +6,6 @@ package sdk
 import (
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/internal/apiutil"
+	"github.com/mainflux/mainflux/pkg/errors"
 )
 
 const (
@@ -27,6 +27,8 @@ const (
 	// CTBinary represents binary content type.
 	CTBinary ContentType = "application/octet-stream"
 )
+
+var errEncodeError = errors.New("failed to encode response error")
 
 var (
 	// ErrFailedCreation indicates that entity creation failed.
@@ -407,4 +409,15 @@ func (pm PageMetadata) query() (string, error) {
 		q.Add("metadata", string(md))
 	}
 	return q.Encode(), nil
+}
+
+func encodeError(body []byte) error {
+	e := struct {
+		Err string `json:"error"`
+	}{}
+	if err := json.Unmarshal(body, &e); err != nil {
+		return errors.Wrap(errEncodeError, err)
+	}
+
+	return errors.New(e.Err)
 }

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -10,8 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"github.com/mainflux/mainflux/pkg/errors"
 )
 
 const (
@@ -47,8 +45,13 @@ func (sdk mfSDK) CreateThing(t Thing, token string) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
 	if resp.StatusCode != http.StatusCreated {
-		return "", errors.Wrap(ErrFailedCreation, errors.New(resp.Status))
+		return "", encodeError(body)
 	}
 
 	id := strings.TrimPrefix(resp.Header.Get("Location"), fmt.Sprintf("/%s/", thingsEndpoint))
@@ -73,14 +76,13 @@ func (sdk mfSDK) CreateThings(things []Thing, token string) ([]Thing, error) {
 		return []Thing{}, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated {
-		return []Thing{}, errors.Wrap(ErrFailedCreation, errors.New(resp.Status))
-	}
-
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return []Thing{}, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return []Thing{}, encodeError(body)
 	}
 
 	var ctr createThingsRes
@@ -114,7 +116,7 @@ func (sdk mfSDK) Things(token string, pm PageMetadata) (ThingsPage, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return ThingsPage{}, errors.Wrap(ErrFailedFetch, errors.New(resp.Status))
+		return ThingsPage{}, encodeError(body)
 	}
 
 	var tp ThingsPage
@@ -144,7 +146,7 @@ func (sdk mfSDK) ThingsByChannel(token, chanID string, offset, limit uint64, dis
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return ThingsPage{}, errors.Wrap(ErrFailedFetch, errors.New(resp.Status))
+		return ThingsPage{}, encodeError(body)
 	}
 
 	var tp ThingsPage
@@ -175,7 +177,7 @@ func (sdk mfSDK) Thing(id, token string) (Thing, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return Thing{}, errors.Wrap(ErrFailedFetch, errors.New(resp.Status))
+		return Thing{}, encodeError(body)
 	}
 
 	var t Thing
@@ -203,9 +205,15 @@ func (sdk mfSDK) UpdateThing(t Thing, token string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(ErrFailedUpdate, errors.New(resp.Status))
+		return encodeError(body)
 	}
 
 	return nil
@@ -223,9 +231,15 @@ func (sdk mfSDK) DeleteThing(id, token string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return errors.Wrap(ErrFailedRemoval, errors.New(resp.Status))
+		return encodeError(body)
 	}
 
 	return nil
@@ -256,7 +270,7 @@ func (sdk mfSDK) IdentifyThing(key string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Wrap(ErrFailedFetch, errors.New(resp.Status))
+		return "", encodeError(body)
 	}
 
 	var i identifyThingResp
@@ -283,9 +297,15 @@ func (sdk mfSDK) Connect(connIDs ConnectionIDs, token string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(ErrFailedConnect, errors.New(resp.Status))
+		return encodeError(body)
 	}
 
 	return nil
@@ -302,9 +322,15 @@ func (sdk mfSDK) DisconnectThing(thingID, chanID, token string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return errors.Wrap(ErrFailedDisconnect, errors.New(resp.Status))
+		return encodeError(body)
 	}
 
 	return nil

--- a/things/api/auth/http/requests.go
+++ b/things/api/auth/http/requests.go
@@ -11,7 +11,7 @@ type identifyReq struct {
 
 func (req identifyReq) validate() error {
 	if req.Token == "" {
-		return apiutil.ErrBearerToken
+		return apiutil.ErrBearerKey
 	}
 
 	return nil
@@ -24,7 +24,7 @@ type canAccessByKeyReq struct {
 
 func (req canAccessByKeyReq) validate() error {
 	if req.Token == "" {
-		return apiutil.ErrBearerToken
+		return apiutil.ErrBearerKey
 	}
 
 	if req.chanID == "" {


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
This pull request fixes error handling on the Maifnlux SDK.

### Which issue(s) does this PR fix/relate to?
This pull request resolves #1670.

### List any changes that modify/break current functionality
Errors returned by SDK are changed to include server errors for the respective request. 

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
N/A

### Notes
N/A