### PR TITLE
MF-1678 - Fetching users returns an invalid status code response

### DIFF
--- a/api/openapi/users.yml
+++ b/api/openapi/users.yml
@@ -48,9 +48,9 @@ paths:
         '400':
           description: Failed due to malformed query parameters.
         '401':
-          description: |
-            Missing or invalid access token provided.
-            This endpoint is available only for administrators.
+          description: Missing or invalid access token provided.
+        '403':
+          description: This endpoint is available only for administrators.
         '404':
           description: A non-existent entity request.
         '422':

--- a/users/service.go
+++ b/users/service.go
@@ -252,7 +252,7 @@ func (svc usersService) ListUsers(ctx context.Context, token string, pm PageMeta
 	}
 
 	if err := svc.authorize(ctx, id.id, "authorities", "member"); err != nil {
-		return UserPage{}, errors.Wrap(errors.ErrAuthentication, err)
+		return UserPage{}, err
 	}
 	return svc.users.RetrieveAll(ctx, pm.Status, pm.Offset, pm.Limit, nil, pm.Email, pm.Metadata)
 }

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -246,6 +246,11 @@ func TestListUsers(t *testing.T) {
 			size:  0,
 			err:   nil,
 		},
+		"list users with unauthorized token": {
+			token: unauthzToken,
+			size:  0,
+			err:   errors.ErrAuthorization,
+		},
 		"list user with emtpy token": {
 			token: "",
 			size:  0,
@@ -256,6 +261,11 @@ func TestListUsers(t *testing.T) {
 			offset: 6,
 			limit:  nUsers,
 			size:   nUsers - 6,
+		},
+		"list users of non existence ": {
+			token: token,
+			email: nonExistingUser.Email,
+			err:   errors.ErrNotFound,
 		},
 	}
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -262,7 +262,7 @@ func TestListUsers(t *testing.T) {
 			limit:  nUsers,
 			size:   nUsers - 6,
 		},
-		"list users of non existence ": {
+		"list using non-existent user": {
 			token: token,
 			email: nonExistingUser.Email,
 			err:   errors.ErrNotFound,


### PR DESCRIPTION
Signed-off-by: Arvindh <arvindh91@gmail.com>

Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?
Fix the http response code and response body for unauthorized get request to list users endpoint   

### Which issue(s) does this PR fix/relate to?
Resolves #1678    

### List any changes that modify/break current functionality
It fixes the status code response for `/users` endpoint of Users service.

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
