### PR TITLE
MF-1681 - Failed to reconnect to NATS

### DIFF
--- a/docker/brokers/nats.yml
+++ b/docker/brokers/nats.yml
@@ -1,7 +1,7 @@
 services:
   broker:
     image: nats:2.2.4-alpine
-    command: "-c /etc/nats/nats.conf"
+    command: "-c /etc/nats/nats.conf -DV"
     volumes:
       - ./../nats/:/etc/nats
     ports:

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -22,7 +22,7 @@ type publisher struct {
 
 // NewPublisher returns NATS message Publisher.
 func NewPublisher(url string) (messaging.Publisher, error) {
-	conn, err := broker.Connect(url)
+	conn, err := broker.Connect(url, broker.MaxReconnects(-1))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -11,6 +11,11 @@ import (
 	broker "github.com/nats-io/nats.go"
 )
 
+// A maximum number of reconnect attempts before NATS connection closes permanently.
+// Value -1 represents an unlimited number of reconnect retries, i.e. the client
+// will never give up on retrying to re-establish connection to NATS server.
+const maxReconnects = -1
+
 var _ messaging.Publisher = (*publisher)(nil)
 
 type publisher struct {
@@ -22,7 +27,7 @@ type publisher struct {
 
 // NewPublisher returns NATS message Publisher.
 func NewPublisher(url string) (messaging.Publisher, error) {
-	conn, err := broker.Connect(url, broker.MaxReconnects(-1))
+	conn, err := broker.Connect(url, broker.MaxReconnects(maxReconnects))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -48,7 +48,7 @@ type pubsub struct {
 // here: https://docs.nats.io/developing-with-nats/receiving/queues.
 // If the queue is empty, Subscribe will be used.
 func NewPubSub(url, queue string, logger log.Logger) (messaging.PubSub, error) {
-	conn, err := broker.Connect(url)
+	conn, err := broker.Connect(url, broker.MaxReconnects(-1))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -17,12 +17,11 @@ import (
 
 const chansPrefix = "channels"
 
+// Publisher and Subscriber errors.
 var (
-	ErrAlreadySubscribed = errors.New("already subscribed to topic")
-	ErrNotSubscribed     = errors.New("not subscribed")
-	ErrEmptyTopic        = errors.New("empty topic")
-	ErrEmptyID           = errors.New("empty id")
-	ErrFailed            = errors.New("failed")
+	ErrNotSubscribed = errors.New("not subscribed")
+	ErrEmptyTopic    = errors.New("empty topic")
+	ErrEmptyID       = errors.New("empty id")
 )
 
 var _ messaging.PubSub = (*pubsub)(nil)
@@ -48,7 +47,7 @@ type pubsub struct {
 // here: https://docs.nats.io/developing-with-nats/receiving/queues.
 // If the queue is empty, Subscribe will be used.
 func NewPubSub(url, queue string, logger log.Logger) (messaging.PubSub, error) {
-	conn, err := broker.Connect(url, broker.MaxReconnects(-1))
+	conn, err := broker.Connect(url, broker.MaxReconnects(maxReconnects))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/messaging/nats/pubsub_test.go
+++ b/pkg/messaging/nats/pubsub_test.go
@@ -4,6 +4,7 @@
 package nats_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -22,8 +23,9 @@ const (
 )
 
 var (
-	msgChan = make(chan messaging.Message)
-	data    = []byte("payload")
+	msgChan   = make(chan messaging.Message)
+	data      = []byte("payload")
+	errFailed = errors.New("failed")
 )
 
 func TestPublisher(t *testing.T) {
@@ -230,7 +232,7 @@ func TestPubsub(t *testing.T) {
 			desc:         "Subscribe to another already subscribed topic with an ID with Unsubscribe failing",
 			topic:        fmt.Sprintf("%s.%s", chansPrefix, topic+"1"),
 			clientID:     "clientid3",
-			errorMessage: nats.ErrFailed,
+			errorMessage: errFailed,
 			pubsub:       true,
 			handler:      handler{true},
 		},
@@ -246,7 +248,7 @@ func TestPubsub(t *testing.T) {
 			desc:         "Unsubscribe from a topic with an ID with failing handler",
 			topic:        fmt.Sprintf("%s.%s", chansPrefix, topic+"2"),
 			clientID:     "clientid4",
-			errorMessage: nats.ErrFailed,
+			errorMessage: errFailed,
 			pubsub:       false,
 			handler:      handler{true},
 		},
@@ -282,7 +284,7 @@ func (h handler) Handle(msg messaging.Message) error {
 
 func (h handler) Cancel() error {
 	if h.fail {
-		return nats.ErrFailed
+		return errFailed
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: dusanb94 <dusan.borovcanin@mainflux.com>

### What does this do?
Currently, connection to NATS defaults to a max of 60 reconnect attempts before giving up and leaving the connection permanently closed. This approach causes the problem in case the service has been disconnected from the NATS server for whatever reasons.
This pull request makes a connection to NATS to never give up on trying to reconnect.

### Which issue(s) does this PR fix/relate to?
This pull request fixes #1681.

### List any changes that modify/break current functionality
There are no such changes.

### Have you included tests for your changes?
N/A

### Did you document any new/modified functionality?
N/A

### Notes
N/A