### PR TITLE
NOISSUE - Update Read Messages CLI

### DIFF
--- a/cli/message.go
+++ b/cli/message.go
@@ -25,7 +25,7 @@ var cmdMessages = []cobra.Command{
 		},
 	},
 	{
-		Use:   "read <channel_id.subtopic> <thing_key>",
+		Use:   "read <channel_id.subtopic> <user_token>",
 		Short: "Read messages",
 		Long:  `Reads all channel messages`,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: rodneyosodo <socials@rodneyosodo.com>

### What does this do?
Changes CLI documentation for reading messages to use `<user_token>` rather than `<thing_key>`

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
N/A

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
https://github.com/mainflux/docs/pull/134

### Notes
N/A