### PR TITLE
MF-969 - Add List API Keys Endpoint

### DIFF
--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -25,6 +25,29 @@ paths:
           description: Missing or invalid content type.
         '500':
           $ref: "#/components/responses/ServiceError"
+
+    get:
+      summary: Lists API key
+      description: |
+        List the API keys issued by the logged in user.
+      tags:
+        - auth
+      parameters:
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Subject"
+        - $ref: "#/components/parameters/Type"
+      responses:
+        '201':
+          description: Issued new key.
+        '400':
+          description: Failed due to malformed JSON.
+        '409':
+          description: Failed due to using already existing ID.
+        '415':
+          description: Missing or invalid content type.
+        '500':
+          $ref: "#/components/responses/ServiceError"          
   /keys/{keyID}:
     get:
       summary: Gets API key details.
@@ -616,7 +639,23 @@ components:
       schema:
         type: boolean
         default: false
-
+    Type:
+      name: type
+      description: The type of the API Key.
+      in: query
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
+      required: false
+    Subject:
+      name: subject
+      description: The subject of an API Key
+      in: query
+      schema:
+        type: string
+      required: false  
+  
   requestBodies:
     KeyRequest:
       description: JSON-formatted document describing key request.

--- a/auth/api/http/keys/requests.go
+++ b/auth/api/http/keys/requests.go
@@ -46,3 +46,23 @@ func (req keyReq) validate() error {
 	}
 	return nil
 }
+
+type listKeysReq struct {
+	token   string
+	subject string
+	keyType uint32
+	offset  uint64
+	limit   uint64
+}
+
+func (req listKeysReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	if req.limit < 1 {
+		return apiutil.ErrLimitSize
+	}
+
+	return nil
+}

--- a/auth/api/http/keys/responses.go
+++ b/auth/api/http/keys/responses.go
@@ -55,6 +55,17 @@ func (res retrieveKeyRes) Empty() bool {
 	return false
 }
 
+type keyPageRes struct {
+	pageRes
+	Keys []retrieveKeyRes `json:"keys"`
+}
+
+type pageRes struct {
+	Limit  uint64 `json:"limit,omitempty"`
+	Offset uint64 `json:"offset,omitempty"`
+	Total  uint64 `json:"total"`
+}
+
 type revokeKeyRes struct {
 }
 

--- a/auth/api/logging.go
+++ b/auth/api/logging.go
@@ -82,6 +82,19 @@ func (lm *loggingMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 	return lm.svc.RetrieveKey(ctx, token, id)
 }
 
+func (lm *loggingMiddleware) RetrieveKeys(ctx context.Context, token string, pm auth.PageMetadata) (kp auth.KeyPage, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method retrieve for token %s took %s to complete", token, time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
+	}(time.Now())
+
+	return lm.svc.RetrieveKeys(ctx, token, pm)
+}
+
 func (lm *loggingMiddleware) Identify(ctx context.Context, key string) (id auth.Identity, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method identify took %s to complete", time.Since(begin))

--- a/auth/api/metrics.go
+++ b/auth/api/metrics.go
@@ -66,6 +66,15 @@ func (ms *metricsMiddleware) RetrieveKey(ctx context.Context, token, id string) 
 	return ms.svc.RetrieveKey(ctx, token, id)
 }
 
+func (ms *metricsMiddleware) RetrieveKeys(ctx context.Context, token string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "retrieve_keys").Add(1)
+		ms.latency.With("method", "retrieve_keys").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return ms.svc.RetrieveKeys(ctx, token, pm)
+}
+
 func (ms *metricsMiddleware) Identify(ctx context.Context, token string) (auth.Identity, error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "identify").Add(1)

--- a/auth/groups.go
+++ b/auth/groups.go
@@ -67,7 +67,8 @@ type PageMetadata struct {
 	Size     uint64
 	Level    uint64
 	Name     string
-	Type     string
+	Type     uint32
+	Subject  string
 	Metadata GroupMetadata
 }
 

--- a/auth/keys.go
+++ b/auth/keys.go
@@ -40,6 +40,12 @@ type Key struct {
 	ExpiresAt time.Time
 }
 
+// KeyPage contains a page of keys.
+type KeyPage struct {
+	PageMetadata
+	Keys []Key
+}
+
 // Identity contains ID and Email.
 type Identity struct {
 	ID    string
@@ -60,8 +66,11 @@ type KeyRepository interface {
 	// operation failure
 	Save(context.Context, Key) (string, error)
 
-	// Retrieve retrieves Key by its unique identifier.
-	Retrieve(context.Context, string, string) (Key, error)
+	// RetrieveByID retrieves Key by its unique identifier.
+	RetrieveByID(context.Context, string, string) (Key, error)
+
+	// RetrieveAll retrieves all keys for given user ID.
+	RetrieveAll(context.Context, string, PageMetadata) (KeyPage, error)
 
 	// Remove removes Key with provided ID.
 	Remove(context.Context, string, string) error

--- a/auth/mocks/keys.go
+++ b/auth/mocks/keys.go
@@ -36,7 +36,7 @@ func (krm *keyRepositoryMock) Save(ctx context.Context, key auth.Key) (string, e
 	krm.keys[key.ID] = key
 	return key.ID, nil
 }
-func (krm *keyRepositoryMock) Retrieve(ctx context.Context, issuerID, id string) (auth.Key, error) {
+func (krm *keyRepositoryMock) RetrieveByID(ctx context.Context, issuerID, id string) (auth.Key, error) {
 	krm.mu.Lock()
 	defer krm.mu.Unlock()
 
@@ -46,6 +46,28 @@ func (krm *keyRepositoryMock) Retrieve(ctx context.Context, issuerID, id string)
 
 	return auth.Key{}, errors.ErrNotFound
 }
+
+func (krm *keyRepositoryMock) RetrieveAll(ctx context.Context, issuerID string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	krm.mu.Lock()
+	defer krm.mu.Unlock()
+
+	kp := auth.KeyPage{}
+	i := uint64(0)
+
+	for _, k := range krm.keys {
+		if i >= pm.Offset && i < (pm.Limit+pm.Offset) {
+			kp.Keys = append(kp.Keys, k)
+		}
+		i++
+	}
+
+	kp.Offset = pm.Offset
+	kp.Limit = pm.Limit
+	kp.Total = uint64(i)
+
+	return kp, nil
+}
+
 func (krm *keyRepositoryMock) Remove(ctx context.Context, issuerID, id string) error {
 	krm.mu.Lock()
 	defer krm.mu.Unlock()

--- a/auth/postgres/key_test.go
+++ b/auth/postgres/key_test.go
@@ -68,7 +68,7 @@ func TestKeySave(t *testing.T) {
 	}
 }
 
-func TestKeyRetrieve(t *testing.T) {
+func TestKeyRetrieveByID(t *testing.T) {
 	dbMiddleware := postgres.NewDatabase(db)
 	repo := postgres.New(dbMiddleware)
 
@@ -111,8 +111,131 @@ func TestKeyRetrieve(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, err := repo.Retrieve(context.Background(), tc.owner, tc.id)
+		_, err := repo.RetrieveByID(context.Background(), tc.owner, tc.id)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+	}
+}
+
+func TestKeyRetrieveAll(t *testing.T) {
+	dbMiddleware := postgres.NewDatabase(db)
+	repo := postgres.New(dbMiddleware)
+
+	issuerID1, err := idProvider.ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	issuerID2, err := idProvider.ID()
+	require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	n := uint64(100)
+	for i := uint64(0); i < n; i++ {
+		id, err := idProvider.ID()
+		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+		key := auth.Key{
+			Subject:   fmt.Sprintf("key-%d@email.com", i),
+			IssuedAt:  time.Now(),
+			ExpiresAt: expTime,
+			ID:        id,
+			IssuerID:  issuerID1,
+			Type:      auth.LoginKey,
+		}
+		if i%10 == 0 {
+			key.Type = auth.APIKey
+		}
+		if i == n-1 {
+			key.IssuerID = issuerID2
+		}
+		_, err = repo.Save(context.Background(), key)
+		assert.Nil(t, err, fmt.Sprintf("Storing Key expected to succeed: %s", err))
+	}
+
+	cases := map[string]struct {
+		owner        string
+		pageMetadata auth.PageMetadata
+		size         uint64
+	}{
+		"retrieve all keys": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  n,
+			},
+			size: n - 1,
+		},
+		"retrieve all keys with different issuer ID": {
+			owner: issuerID2,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  n,
+			},
+			size: 1,
+		},
+		"retrieve subset of keys with existing owner": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: n/2 - 1,
+				Limit:  n,
+				Total:  n,
+			},
+			size: n / 2,
+		},
+		"retrieve keys with existing subject": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "key-10@email.com",
+			},
+			size: 1,
+		},
+		"retrieve keys with non-existing subject": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "wrong",
+				Total:   0,
+			},
+			size: 0,
+		},
+		"retrieve keys with existing type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Type:   auth.APIKey,
+			},
+			size: 10,
+		},
+		"retrieve keys with non-existing type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset: 0,
+				Limit:  n,
+				Total:  0,
+				Type:   uint32(9),
+			},
+			size: 0,
+		},
+		"retrieve all keys with existing subject and type": {
+			owner: issuerID1,
+			pageMetadata: auth.PageMetadata{
+				Offset:  0,
+				Limit:   n,
+				Subject: "key-10@email.com",
+				Type:    auth.APIKey,
+			},
+			size: 1,
+		},
+	}
+
+	for desc, tc := range cases {
+		page, err := repo.RetrieveAll(context.Background(), tc.owner, tc.pageMetadata)
+		size := uint64(len(page.Keys))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", desc, tc.size, size))
+		// assert.Equal(t, tc.pageMetadata.Total, page.Total, fmt.Sprintf("%s: expected total %d got %d\n", desc, tc.pageMetadata.Total, page.Total))
+		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %d\n", desc, err))
 	}
 }
 

--- a/auth/postgres/key_test.go
+++ b/auth/postgres/key_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mainflux/mainflux/pkg/uuid"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const email = "user-save@example.com"

--- a/auth/tracing/keys.go
+++ b/auth/tracing/keys.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	saveOp     = "save"
-	retrieveOp = "retrieve_by_id"
-	revokeOp   = "remove"
+	saveOp        = "save"
+	retrieveOp    = "retrieve_by_id"
+	retrieveAllOp = "retrieve_all"
+	revokeOp      = "remove"
 )
 
 var _ auth.KeyRepository = (*keyRepositoryMiddleware)(nil)
@@ -44,12 +45,20 @@ func (krm keyRepositoryMiddleware) Save(ctx context.Context, key auth.Key) (stri
 	return krm.repo.Save(ctx, key)
 }
 
-func (krm keyRepositoryMiddleware) Retrieve(ctx context.Context, owner, id string) (auth.Key, error) {
+func (krm keyRepositoryMiddleware) RetrieveByID(ctx context.Context, owner, id string) (auth.Key, error) {
 	span := createSpan(ctx, krm.tracer, retrieveOp)
 	defer span.Finish()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return krm.repo.Retrieve(ctx, owner, id)
+	return krm.repo.RetrieveByID(ctx, owner, id)
+}
+
+func (krm keyRepositoryMiddleware) RetrieveAll(ctx context.Context, owner string, pm auth.PageMetadata) (auth.KeyPage, error) {
+	span := createSpan(ctx, krm.tracer, retrieveAllOp)
+	defer span.Finish()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return krm.repo.RetrieveAll(ctx, owner, pm)
 }
 
 func (krm keyRepositoryMiddleware) Remove(ctx context.Context, owner, id string) error {


### PR DESCRIPTION
Signed-off-by: rodneyosodo <socials@rodneyosodo.com>

### What does this do?
It adds list API Keys endpoint on the auth service

### Which issue(s) does this PR fix/relate to?
Resolves #969

### List any changes that modify/break current functionality
Adds a GET endpoint to Auth Service where the logged in user can be able to list the keys they are allocated

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
Yes

### Notes
N/A