### PR TITLE
MF-1707 - Make Certs TTL Configurable

### DIFF
--- a/api/openapi/certs.yml
+++ b/api/openapi/certs.yml
@@ -204,6 +204,7 @@ components:
                  format: uuid
                ttl:
                  type: string
+                 example: "10h"
 
   responses:
     ServiceError:

--- a/certs/api/requests.go
+++ b/certs/api/requests.go
@@ -3,7 +3,11 @@
 
 package api
 
-import "github.com/mainflux/mainflux/internal/apiutil"
+import (
+	"time"
+
+	"github.com/mainflux/mainflux/internal/apiutil"
+)
 
 const maxLimitSize = 100
 
@@ -24,6 +28,10 @@ func (req addCertsReq) validate() error {
 
 	if req.TTL == "" {
 		return apiutil.ErrMissingCertData
+	}
+
+	if _, err := time.ParseDuration(req.TTL); err != nil {
+		return apiutil.ErrInvalidCertData
 	}
 
 	return nil

--- a/certs/api/transport.go
+++ b/certs/api/transport.go
@@ -146,6 +146,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 	case errors.Contains(err, errors.ErrMalformedEntity),
 		err == apiutil.ErrMissingID,
 		err == apiutil.ErrMissingCertData,
+		err == apiutil.ErrInvalidCertData,
 		err == apiutil.ErrLimitSize:
 		w.WriteHeader(http.StatusBadRequest)
 	case errors.Contains(err, errors.ErrConflict):

--- a/certs/pki/vault.go
+++ b/certs/pki/vault.go
@@ -6,7 +6,6 @@ package pki
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -101,7 +100,7 @@ func NewVaultClient(token, host, path, role string) (Agent, error) {
 func (p *pkiAgent) IssueCert(cn, ttl string) (Cert, error) {
 	cReq := certReq{
 		CommonName: cn,
-		TTL:        fmt.Sprintf("%sh", ttl),
+		TTL:        ttl,
 	}
 
 	var certIssueReq map[string]interface{}

--- a/cli/certs.go
+++ b/cli/certs.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"strconv"
-
 	"github.com/spf13/cobra"
 )
 
@@ -45,10 +43,10 @@ var cmdCerts = []cobra.Command{
 
 // NewCertsCmd returns certificate command.
 func NewCertsCmd() *cobra.Command {
-	var ttl uint32
+	var ttl string
 
 	issueCmd := cobra.Command{
-		Use:   "issue <thing_id> <user_auth_token> [--ttl=8760]",
+		Use:   "issue <thing_id> <user_auth_token> [--ttl=8760h]",
 		Short: "Issue certificate",
 		Long:  `Issues new certificate for a thing`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -58,9 +56,8 @@ func NewCertsCmd() *cobra.Command {
 			}
 
 			thingID := args[0]
-			valid := strconv.FormatUint(uint64(ttl), 10)
 
-			c, err := sdk.IssueCert(thingID, valid, args[1])
+			c, err := sdk.IssueCert(thingID, ttl, args[1])
 			if err != nil {
 				logError(err)
 				return
@@ -69,7 +66,7 @@ func NewCertsCmd() *cobra.Command {
 		},
 	}
 
-	issueCmd.Flags().Uint32Var(&ttl, "ttl", 8760, "certificate time to live in hours")
+	issueCmd.Flags().StringVar(&ttl, "ttl", "8760h", "certificate time to live in duration")
 
 	cmd := cobra.Command{
 		Use:   "certs [issue | get | revoke ]",

--- a/internal/apiutil/errors.go
+++ b/internal/apiutil/errors.go
@@ -63,6 +63,9 @@ var (
 	// ErrMissingCertData indicates missing cert data (ttl).
 	ErrMissingCertData = errors.New("missing certificate data")
 
+	// ErrInvalidCertData indicates invalid cert data (ttl).
+	ErrInvalidCertData = errors.New("invalid certificate data")
+
 	// ErrInvalidTopic indicates an invalid subscription topic.
 	ErrInvalidTopic = errors.New("invalid Subscription topic")
 


### PR DESCRIPTION
Signed-off-by: rodneyosodo <socials@rodneyosodo.com>

### What does this do?
Makes the certs TTL configurable to a time duration i.e `h`, `m`, `d` rather than having it being set to hours by default.

### Which issue(s) does this PR fix/relate to?
Resolves #1707 

### List any changes that modify/break current functionality
N/A

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
Yes

### Notes
N/A