### PR TITLE
NOISSUE - Fix Send Response for Publishing Message

### DIFF
--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -79,19 +79,17 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 		Context: m.Context,
 		Options: make(message.Options, 0, 16),
 	}
-
+	defer sendResp(w, &resp)
 	msg, err := decodeMessage(m)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Error decoding message: %s", err))
 		resp.Code = codes.BadRequest
-		sendResp(w, &resp)
 		return
 	}
 	key, err := parseKey(m)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Error parsing auth: %s", err))
 		resp.Code = codes.Unauthorized
-		sendResp(w, &resp)
 		return
 	}
 	switch m.Code {
@@ -115,7 +113,6 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 			resp.Code = codes.InternalServerError
 		}
 	}
-	sendResp(w, &resp)
 }
 
 func handleGet(m *mux.Message, c mux.Client, msg *messaging.Message, key string) error {

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -114,8 +114,8 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 		default:
 			resp.Code = codes.InternalServerError
 		}
-		sendResp(w, &resp)
 	}
+	sendResp(w, &resp)
 }
 
 func handleGet(m *mux.Message, c mux.Client, msg *messaging.Message, key string) error {


### PR DESCRIPTION
### What does this do?
Adds functionality to send response for successfully publishing messages.

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
Previously, we only sent response when we encountered an error. This meant when you try ab publish message using coap-cli it would not automatically close after successfully publishing the message. It would close after the timeout has reached. This was because we were not returning a response upon successful publishing of message

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
How to reproduce the problem would be to try and publish message using coap-cli

```bash
coap-cli post channels/<channel_id>/messages -auth <thing_key> -d 'message'
```
