### PR TITLE
NOISSUE - Add UsersURL to SDK on Provision SVC

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -100,6 +100,7 @@ func main() {
 	}
 
 	SDKCfg := mfSDK.Config{
+		UsersURL:        cfg.Server.UsersURL,
 		ThingsURL:       cfg.Server.ThingsURL,
 		BootstrapURL:    cfg.Server.MfBSURL,
 		CertsURL:        cfg.Server.MfCertsURL,


### PR DESCRIPTION
Signed-off-by: rodneyosodo <socials@rodneyosodo.com>

### What does this do?
Add UsersURL to SDK config for provision service

### Which issue(s) does this PR fix/relate to?
Noissue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
The error was

```bash
{"level":"warn","message":"Method mapping for token: xxxx took 1.776552ms to complete with error: unauthorized access : Status: : Get \"/users?limit=10&metadata=%7B%7D\": unsupported protocol scheme \"\"","ts":"2023-04-17T11:29:52.387288469Z"}
```