### PR TITLE
MF-1771 - Add Quantiles to Latency Summary Metrics

### DIFF
--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -16,10 +16,11 @@ func MakeMetrics(namespace, subsystem string) (*kitprometheus.Counter, *kitprome
 		Help:      "Number of requests received.",
 	}, []string{"method"})
 	latency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: namespace,
-		Subsystem: subsystem,
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Namespace:  namespace,
+		Subsystem:  subsystem,
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		Name:       "request_latency_microseconds",
+		Help:       "Total duration of requests in microseconds.",
 	}, []string{"method"})
 
 	return counter, latency


### PR DESCRIPTION
Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?

Configures Summary metrics created to track latency in Prometheus, so that they report latencies by quantiles (using the 50th, 90th and 99th quantiles)

This is just done by passing the quantiles in under the `Objectives` property when instantiating the Summary metric in Prometheus

### Which issue(s) does this PR fix/relate to?

Resolves #1771 

### List any changes that modify/break current functionality

No changes to current functionality, this change adds new metrics outputs from prometheus but makes no change to existing outputs

### Have you included tests for your changes?

No functional changes included, only metrics reporting changes, which have been tested operationally with a local build

### Did you document any new/modified functionality?

N/A

### Notes
