### PR TITLE
NOISSUE - Seperate Identify and Authorize

### DIFF
--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -355,15 +355,17 @@ func TestListClients(t *testing.T) {
 			Tag:      tc.tag,
 		}
 
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
 		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
-			ok := repoCall.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
+			ok := repoCall1.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("RetrieveAll was not called on %s", tc.desc))
 		}
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }
 
@@ -1081,12 +1083,14 @@ func TestEnableClient(t *testing.T) {
 			Status: tc.status,
 		}
 
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
 		clientsPage, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(clientsPage.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }
 
@@ -1205,11 +1209,13 @@ func TestDisableClient(t *testing.T) {
 			Limit:  100,
 			Status: tc.status,
 		}
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
 		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(page.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -39,7 +39,7 @@ var (
 
 func newService(tokens map[string]string) (clients.Service, *mocks.ClientRepository) {
 	adminPolicy := mocks.MockSubjectSet{Object: ID, Relation: clients.AdminRelationKey}
-	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{token: {adminPolicy}})
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	thingCache := mocks.NewClientCache()
 	idProvider := uuid.NewMock()
 	cRepo := new(mocks.ClientRepository)

--- a/things/groups/service_test.go
+++ b/things/groups/service_test.go
@@ -40,7 +40,7 @@ var (
 
 func newService(tokens map[string]string) (groups.Service, *gmocks.GroupRepository) {
 	adminPolicy := mocks.MockSubjectSet{Object: ID, Relation: []string{"g_add", "g_update", "g_list", "g_delete"}}
-	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{token: {adminPolicy}})
+	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	idProvider := uuid.NewMock()
 	gRepo := new(gmocks.GroupRepository)
 

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -39,14 +39,9 @@ func (svc service) Authorize(ctx context.Context, entityType string, p Policy) e
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	id, err := svc.identify(ctx, p.Subject)
-	if err != nil {
-		return err
-	}
-	if err = svc.policies.CheckAdmin(ctx, id); err == nil {
+	if err := svc.policies.CheckAdmin(ctx, p.Subject); err == nil {
 		return nil
 	}
-	p.Subject = id
 
 	return svc.policies.Evaluate(ctx, entityType, p)
 }


### PR DESCRIPTION
### What does this do?
Seperate Identify and Authorize

### Which issue(s) does this PR fix/relate to?
Noissue

### List any changes that modify/break current functionality
Instead of passing in token as subject when doing authorize, we passing in clientID after doing identify

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A