### PR TITLE
MF-1787 - Incorrect response code for CoAP POST messages

### DIFF
--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -96,6 +96,7 @@ func handler(w mux.ResponseWriter, m *mux.Message) {
 	case codes.GET:
 		err = handleGet(m, w.Client(), msg, key)
 	case codes.POST:
+		resp.Code = codes.Created
 		err = service.Publish(context.Background(), key, msg)
 	default:
 		err = errors.ErrNotFound


### PR DESCRIPTION
### What does this do?
This pull request fixes status code for the POST requests sent to CoAP adapter from 2.05-Content to 2.01-Created.

### Which issue(s) does this PR fix/relate to?
This pull request fixes #1787.

### List any changes that modify/break current functionality
There are no breaking changes except this change in the response status code.

### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?
No.

### Notes
N/A