### PR TITLE
NOISSUE - Fix Add Policy If Policy Exists

### DIFF
--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -84,8 +84,6 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) (Polic
 
 	p.OwnerID = res.GetId()
 	p.CreatedAt = time.Now()
-	p.UpdatedAt = p.CreatedAt
-	p.UpdatedBy = res.GetId()
 
 	if err := svc.policyCache.AddPolicy(ctx, p); err != nil {
 		return Policy{}, err

--- a/things/postgres/init.go
+++ b/things/postgres/init.go
@@ -50,7 +50,7 @@ func Migration() *migrate.MemoryMigrationSource {
 						updated_at	TIMESTAMP,
 						updated_by  VARCHAR(254),
 						FOREIGN KEY	(object) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
-						PRIMARY KEY (subject, object, actions)
+						PRIMARY KEY (subject, object)
 					)`,
 				},
 				Down: []string{

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -83,20 +83,8 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) error 
 		return err
 	}
 
-	// If the policy already exists, update it appending the new actions
+	// If the policy already exists, replace the actions
 	if len(page.Policies) == 1 {
-		p.Actions = append(p.Actions, page.Policies[0].Actions...)
-
-		isUnique := make(map[string]bool)
-		var uniqueActions []string
-		for _, action := range p.Actions {
-			if _, ok := isUnique[action]; !ok {
-				isUnique[action] = true
-				uniqueActions = append(uniqueActions, action)
-			}
-		}
-
-		p.Actions = uniqueActions
 		p.UpdatedAt = time.Now()
 		p.UpdatedBy = id
 		return svc.policies.Update(ctx, p)

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -50,6 +50,7 @@ func (svc service) Authorize(ctx context.Context, entityType string, p Policy) e
 
 	return svc.policies.Evaluate(ctx, entityType, p)
 }
+
 func (svc service) UpdatePolicy(ctx context.Context, token string, p Policy) error {
 	id, err := svc.identify(ctx, token)
 	if err != nil {
@@ -72,31 +73,35 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) error 
 	if err != nil {
 		return err
 	}
-	p.UpdatedBy = id
 	if err := p.Validate(); err != nil {
 		return err
 	}
 
-	page, err := svc.policies.Retrieve(ctx, Page{Subject: p.Subject, Object: p.Object})
+	pm := Page{Subject: p.Subject, Object: p.Object, Offset: 0, Limit: 1}
+	page, err := svc.policies.Retrieve(ctx, pm)
 	if err != nil {
 		return err
 	}
+
+	// If the policy already exists, update it appending the new actions
 	if len(page.Policies) == 1 {
-		// Update policy, add the new actions
-		for _, ra := range page.Policies[0].Actions {
-			var found = false
-			for _, na := range p.Actions {
-				if ra == na {
-					found = true
-					break
-				}
-			}
-			if !found {
-				p.Actions = append(p.Actions, ra)
+		p.Actions = append(p.Actions, page.Policies[0].Actions...)
+
+		isUnique := make(map[string]bool)
+		var uniqueActions []string
+		for _, action := range p.Actions {
+			if _, ok := isUnique[action]; !ok {
+				isUnique[action] = true
+				uniqueActions = append(uniqueActions, action)
 			}
 		}
+
+		p.Actions = uniqueActions
+		p.UpdatedAt = time.Now()
+		p.UpdatedBy = id
 		return svc.policies.Update(ctx, p)
 	}
+
 	if err := svc.checkActionRank(ctx, id, p); err != nil {
 		return err
 	}

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -52,7 +52,7 @@ func Migration() *migrate.MemoryMigrationSource {
 						updated_at  TIMESTAMP,
 						updated_by  VARCHAR(254),
 						FOREIGN KEY (subject) REFERENCES clients (id) ON DELETE CASCADE ON UPDATE CASCADE,
-						PRIMARY KEY (subject, object, actions)
+						PRIMARY KEY (subject, object)
 					)`,
 				},
 				Down: []string{


### PR DESCRIPTION
### What does this do?
If policy exists in the database we need to update it with only the new fields.

### Which issue(s) does this PR fix/relate to?
Noissue

### List any changes that modify/break current functionality
When policy exist we update it rather than creating another one

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
Changed the primary key constain to be only on `subject` `object` rather than having it on `subject` `object` `action`