### PR TITLE
NOISSUE - Fix List Policies Based on Role

### DIFF
--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -345,13 +345,15 @@ func TestListPolicies(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		repoCall := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: tc.response}), tc.err)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: tc.response}), tc.err)
 		pp, err := policySDK.ListPolicies(tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, pp.Policies, fmt.Sprintf("%s: expected %v, got %v", tc.desc, tc.response, pp))
 		ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
 		assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }
 

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -355,14 +355,16 @@ func TestListClients(t *testing.T) {
 			Tag:      tc.tag,
 		}
 
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
 		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
-			ok := repoCall.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
+			ok := repoCall1.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("RetrieveAll was not called on %s", tc.desc))
 		}
+		repoCall1.Unset()
 		repoCall.Unset()
 	}
 }
@@ -1081,12 +1083,14 @@ func TestEnableClient(t *testing.T) {
 			Status: tc.status,
 		}
 
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
 		clientsPage, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(clientsPage.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }
 
@@ -1205,11 +1209,13 @@ func TestDisableClient(t *testing.T) {
 			Limit:  100,
 			Status: tc.status,
 		}
-		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
 		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(page.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
 		repoCall.Unset()
+		repoCall1.Unset()
 	}
 }

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -124,7 +124,7 @@ func (svc service) ListPolicy(ctx context.Context, token string, pm Page) (Polic
 		return svc.policies.Retrieve(ctx, pm)
 	}
 
-	// If the user is not admin, return only the policies that he owns
+	// If the user is not admin, return only the policies that they are in
 	pm.Subject = id
 	pm.Object = id
 

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -112,19 +112,23 @@ func (svc service) DeletePolicy(ctx context.Context, token string, p Policy) err
 }
 
 func (svc service) ListPolicy(ctx context.Context, token string, pm Page) (PolicyPage, error) {
-	if _, err := svc.identify(ctx, token); err != nil {
+	id, err := svc.identify(ctx, token)
+	if err != nil {
 		return PolicyPage{}, err
 	}
 	if err := pm.Validate(); err != nil {
 		return PolicyPage{}, err
 	}
-
-	page, err := svc.policies.Retrieve(ctx, pm)
-	if err != nil {
-		return PolicyPage{}, err
+	// If the user is admin, return all policies
+	if err := svc.policies.CheckAdmin(ctx, id); err == nil {
+		return svc.policies.Retrieve(ctx, pm)
 	}
 
-	return page, err
+	// If the user is not admin, return only the policies that he owns
+	pm.Subject = id
+	pm.Object = id
+
+	return svc.policies.Retrieve(ctx, pm)
 }
 
 // checkActionRank check if an action is in the provide list of actions

--- a/users/policies/service_test.go
+++ b/users/policies/service_test.go
@@ -338,7 +338,8 @@ func TestListPolicies(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		repoCall := pRepo.On("Retrieve", context.Background(), tc.page).Return(tc.response, tc.err)
+		repoCall := pRepo.On("CheckAdmin", context.Background(), mock.Anything).Return(nil)
+		repoCall1 := pRepo.On("Retrieve", context.Background(), tc.page).Return(tc.response, tc.err)
 		page, err := svc.ListPolicy(context.Background(), tc.token, tc.page)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page, fmt.Sprintf("%s: expected size %v got %v\n", tc.desc, tc.response, page))
@@ -346,6 +347,7 @@ func TestListPolicies(t *testing.T) {
 			ok := repoCall.Parent.AssertCalled(t, "Retrieve", context.Background(), tc.page)
 			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 		}
+		repoCall1.Unset()
 		repoCall.Unset()
 	}
 


### PR DESCRIPTION
### What does this do?
If the user is `admin`, they can list all policies. If they aren't `admin`, they can list only polices they are in

### Which issue(s) does this PR fix/relate to?
Noissue

### List any changes that modify/break current functionality
No

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A