### PR TITLE
NOISSUE - Fix Event Sourcing and Authorization Cache

### DIFF
--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -9,25 +9,25 @@ package bootstrap
 // MFKey is key of corresponding Mainflux Thing.
 // MFChannels is a list of Mainflux Channels corresponding Mainflux Thing connects to.
 type Config struct {
-	MFThing     string
-	Owner       string
-	Name        string
-	ClientCert  string
-	ClientKey   string
-	CACert      string
-	MFKey       string
-	MFChannels  []Channel
-	ExternalID  string
-	ExternalKey string
-	Content     string
-	State       State
+	MFThing     string    `json:"mainflux_thing"`
+	Owner       string    `json:"owner,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	ClientCert  string    `json:"client_cert,omitempty"`
+	ClientKey   string    `json:"client_key,omitempty"`
+	CACert      string    `json:"ca_cert,omitempty"`
+	MFKey       string    `json:"mainflux_key"`
+	MFChannels  []Channel `json:"mainflux_channels,omitempty"`
+	ExternalID  string    `json:"external_id"`
+	ExternalKey string    `json:"external_key"`
+	Content     string    `json:"content,omitempty"`
+	State       State     `json:"state"`
 }
 
 // Channel represents Mainflux channel corresponding Mainflux Thing is connected to.
 type Channel struct {
-	ID       string
-	Name     string
-	Metadata map[string]interface{}
+	ID       string                 `json:"id"`
+	Name     string                 `json:"name,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Filter is used for the search filters.
@@ -39,10 +39,10 @@ type Filter struct {
 // ConfigsPage contains page related metadata as well as list of Configs that
 // belong to this page.
 type ConfigsPage struct {
-	Total   uint64
-	Offset  uint64
-	Limit   uint64
-	Configs []Config
+	Total   uint64   `json:"total"`
+	Offset  uint64   `json:"offset"`
+	Limit   uint64   `json:"limit"`
+	Configs []Config `json:"configs"`
 }
 
 // ConfigRepository specifies a Config persistence API.

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -3,6 +3,12 @@
 
 package bootstrap
 
+import (
+	"time"
+
+	"github.com/mainflux/mainflux/pkg/clients"
+)
+
 // Config represents Configuration entity. It wraps information about external entity
 // as well as info about corresponding Mainflux entities.
 // MFThing represents corresponding Mainflux Thing ID.
@@ -25,9 +31,16 @@ type Config struct {
 
 // Channel represents Mainflux channel corresponding Mainflux Thing is connected to.
 type Channel struct {
-	ID       string                 `json:"id"`
-	Name     string                 `json:"name,omitempty"`
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Owner       string                 `json:"owner_id"`
+	Parent      string                 `json:"parent_id,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at,omitempty"`
+	UpdatedBy   string                 `json:"updated_by,omitempty"`
+	Status      clients.Status         `json:"status"`
 }
 
 // Filter is used for the search filters.

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -558,7 +558,7 @@ func nullString(s string) sql.NullString {
 }
 
 func nullTime(t time.Time) sql.NullTime {
-	if t == (time.Time{}) {
+	if t.IsZero() {
 		return sql.NullTime{}
 	}
 

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgtype"
@@ -15,6 +16,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/mainflux/mainflux/bootstrap"
 	mflog "github.com/mainflux/mainflux/logger"
+	"github.com/mainflux/mainflux/pkg/clients"
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
@@ -391,7 +393,8 @@ func (cr configRepository) UpdateChannel(c bootstrap.Channel) error {
 		return errors.Wrap(errors.ErrUpdateEntity, err)
 	}
 
-	q := `UPDATE channels SET name = :name, metadata = :metadata WHERE mainflux_channel = :mainflux_channel`
+	q := `UPDATE channels SET name = :name, metadata = :metadata, updated_at = :updated_at, updated_by = :updated_by 
+			WHERE mainflux_channel = :mainflux_channel`
 	if _, err = cr.db.NamedExec(q, dbch); err != nil {
 		return errors.Wrap(errUpdateChannels, err)
 	}
@@ -457,9 +460,8 @@ func insertChannels(owner string, channels []bootstrap.Channel, tx *sqlx.Tx) err
 		}
 		chans = append(chans, dbch)
 	}
-
-	q := `INSERT INTO channels (mainflux_channel, owner, name, metadata)
-		  VALUES (:mainflux_channel, :owner, :name, :metadata)`
+	q := `INSERT INTO channels (mainflux_channel, owner, name, metadata, parent_id, description, created_at, updated_at, updated_by, status)
+		  VALUES (:mainflux_channel, :owner, :name, :metadata, :parent_id, :description, :created_at, :updated_at, :updated_by, :status)`
 	if _, err := tx.NamedExec(q, chans); err != nil {
 		e := err
 		if pqErr, ok := err.(*pgconn.PgError); ok && pqErr.Code == pgerrcode.UniqueViolation {
@@ -555,6 +557,17 @@ func nullString(s string) sql.NullString {
 	}
 }
 
+func nullTime(t time.Time) sql.NullTime {
+	if t == (time.Time{}) {
+		return sql.NullTime{}
+	}
+
+	return sql.NullTime{
+		Time:  t,
+		Valid: true,
+	}
+}
+
 type dbConfig struct {
 	MFThing     string          `db:"mainflux_thing"`
 	Owner       string          `db:"owner"`
@@ -618,17 +631,29 @@ func toConfig(dbcfg dbConfig) bootstrap.Config {
 }
 
 type dbChannel struct {
-	ID       string         `db:"mainflux_channel"`
-	Name     sql.NullString `db:"name"`
-	Owner    sql.NullString `db:"owner"`
-	Metadata string         `db:"metadata"`
+	ID          string         `db:"mainflux_channel"`
+	Name        sql.NullString `db:"name"`
+	Owner       sql.NullString `db:"owner"`
+	Metadata    string         `db:"metadata"`
+	Parent      sql.NullString `db:"parent_id,omitempty"`
+	Description string         `db:"description,omitempty"`
+	CreatedAt   time.Time      `db:"created_at"`
+	UpdatedAt   sql.NullTime   `db:"updated_at,omitempty"`
+	UpdatedBy   sql.NullString `db:"updated_by,omitempty"`
+	Status      clients.Status `db:"status"`
 }
 
 func toDBChannel(owner string, ch bootstrap.Channel) (dbChannel, error) {
 	dbch := dbChannel{
-		ID:    ch.ID,
-		Name:  nullString(ch.Name),
-		Owner: nullString(owner),
+		ID:          ch.ID,
+		Name:        nullString(ch.Name),
+		Owner:       nullString(owner),
+		Parent:      nullString(ch.Parent),
+		Description: ch.Description,
+		CreatedAt:   ch.CreatedAt,
+		UpdatedAt:   nullTime(ch.UpdatedAt),
+		UpdatedBy:   nullString(ch.UpdatedBy),
+		Status:      ch.Status,
 	}
 
 	metadata, err := json.Marshal(ch.Metadata)
@@ -642,11 +667,26 @@ func toDBChannel(owner string, ch bootstrap.Channel) (dbChannel, error) {
 
 func toChannel(dbch dbChannel) (bootstrap.Channel, error) {
 	ch := bootstrap.Channel{
-		ID: dbch.ID,
+		ID:          dbch.ID,
+		Description: dbch.Description,
+		CreatedAt:   dbch.CreatedAt,
+		Status:      dbch.Status,
 	}
 
 	if dbch.Name.Valid {
 		ch.Name = dbch.Name.String
+	}
+	if dbch.Owner.Valid {
+		ch.Owner = dbch.Owner.String
+	}
+	if dbch.Parent.Valid {
+		ch.Parent = dbch.Parent.String
+	}
+	if dbch.UpdatedBy.Valid {
+		ch.UpdatedBy = dbch.UpdatedBy.String
+	}
+	if dbch.UpdatedAt.Valid {
+		ch.UpdatedAt = dbch.UpdatedAt.Time
 	}
 
 	if err := json.Unmarshal([]byte(dbch.Metadata), &ch.Metadata); err != nil {

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -636,7 +636,7 @@ func TestUpdateChannel(t *testing.T) {
 			break
 		}
 	}
-
+	update.Owner = retreved.Owner
 	assert.Equal(t, update, retreved, fmt.Sprintf("expected %s, go %s", update, retreved))
 }
 

--- a/bootstrap/postgres/init.go
+++ b/bootstrap/postgres/init.go
@@ -64,6 +64,17 @@ func Migration() *migrate.MemoryMigrationSource {
 					"CREATE TABLE IF NOT EXISTS unknown_configs",
 				},
 			},
+			{
+				Id: "configs_3",
+				Up: []string{
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS parent_id VARCHAR(36)`,
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS description VARCHAR(1024)`,
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS created_at TIMESTAMP`,
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP`,
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS updated_by VARCHAR(254)`,
+					`ALTER TABLE IF EXISTS channels ADD COLUMN IF NOT EXISTS status SMALLINT NOT NULL DEFAULT 0 CHECK (status >= 0)`,
+				},
+			},
 		},
 	}
 }

--- a/bootstrap/redis/consumer/events.go
+++ b/bootstrap/redis/consumer/events.go
@@ -3,14 +3,18 @@
 
 package consumer
 
+import "time"
+
 type removeEvent struct {
 	id string
 }
 
 type updateChannelEvent struct {
-	id       string
-	name     string
-	metadata map[string]interface{}
+	id        string
+	name      string
+	metadata  map[string]interface{}
+	updatedAt time.Time
+	updatedBy string
 }
 
 // Connection event is either connect or disconnect event.

--- a/bootstrap/redis/consumer/streams.go
+++ b/bootstrap/redis/consumer/streams.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
 	"github.com/mainflux/mainflux/logger"
+	"github.com/mainflux/mainflux/pkg/clients"
 )
 
 const (
@@ -96,8 +97,20 @@ func (es eventStore) Subscribe(ctx context.Context, subject string) error {
 }
 
 func decodeRemoveThing(event map[string]interface{}) removeEvent {
-	return removeEvent{
-		id: read(event, "id", ""),
+	status := read(event, "status", "")
+	st, err := clients.ToStatus(status)
+	if err != nil {
+		return removeEvent{}
+	}
+	switch st {
+	case clients.EnabledStatus:
+		return removeEvent{}
+	case clients.DisabledStatus:
+		return removeEvent{
+			id: read(event, "id", ""),
+		}
+	default:
+		return removeEvent{}
 	}
 }
 
@@ -118,8 +131,20 @@ func decodeUpdateChannel(event map[string]interface{}) updateChannelEvent {
 }
 
 func decodeRemoveChannel(event map[string]interface{}) removeEvent {
-	return removeEvent{
-		id: read(event, "id", ""),
+	status := read(event, "status", "")
+	st, err := clients.ToStatus(status)
+	if err != nil {
+		return removeEvent{}
+	}
+	switch st {
+	case clients.EnabledStatus:
+		return removeEvent{}
+	case clients.DisabledStatus:
+		return removeEvent{
+			id: read(event, "id", ""),
+		}
+	default:
+		return removeEvent{}
 	}
 }
 

--- a/bootstrap/redis/consumer/streams.go
+++ b/bootstrap/redis/consumer/streams.go
@@ -31,7 +31,7 @@ const (
 // Subscriber represents event source for things and channels provisioning.
 type Subscriber interface {
 	// Subscribes to given subject and receives events.
-	Subscribe(context.Context, string) error
+	Subscribe(ctx context.Context, subject string) error
 }
 
 type eventStore struct {

--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -17,15 +17,17 @@ const (
 	configUpdate        = configPrefix + "update"
 	configRemove        = configPrefix + "remove"
 	configList          = configPrefix + "list"
-	configHandlerRemove = configPrefix + "handler_remove"
+	configHandlerRemove = configPrefix + "remove_handler"
 
 	thingPrefix            = "thing."
 	thingBootstrap         = thingPrefix + "bootstrap"
-	thingStateChange       = thingPrefix + "state_change"
+	thingStateChange       = thingPrefix + "change_state"
 	thingUpdateConnections = thingPrefix + "update_connections"
-	channelHandlerRemove   = thingPrefix + "channel_handler_remove"
-	channelUpdateHandler   = thingPrefix + "update_channel_handler"
 	thingDisconnect        = thingPrefix + "disconnect"
+
+	channelPrefix        = "channel."
+	channelHandlerRemove = channelPrefix + "remove_handler"
+	channelUpdateHandler = channelPrefix + "update_handler"
 
 	certUpdate = "cert.update"
 )

--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -4,22 +4,30 @@
 package producer
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
-	"time"
 
 	"github.com/mainflux/mainflux/bootstrap"
 )
 
 const (
-	configPrefix = "config."
-	configCreate = configPrefix + "create"
-	configUpdate = configPrefix + "update"
-	configRemove = configPrefix + "remove"
+	configPrefix        = "config."
+	configCreate        = configPrefix + "create"
+	configUpdate        = configPrefix + "update"
+	configRemove        = configPrefix + "remove"
+	configList          = configPrefix + "list"
+	configHandlerRemove = configPrefix + "handler_remove"
 
 	thingPrefix            = "thing."
 	thingBootstrap         = thingPrefix + "bootstrap"
 	thingStateChange       = thingPrefix + "state_change"
 	thingUpdateConnections = thingPrefix + "update_connections"
+	channelHandlerRemove   = thingPrefix + "channel_handler_remove"
+	channelUpdateHandler   = thingPrefix + "update_channel_handler"
+	thingDisconnect        = thingPrefix + "disconnect"
+
+	certUpdate = "cert.update"
 )
 
 type event interface {
@@ -27,93 +35,166 @@ type event interface {
 }
 
 var (
-	_ event = (*createConfigEvent)(nil)
-	_ event = (*updateConfigEvent)(nil)
+	_ event = (*configEvent)(nil)
 	_ event = (*removeConfigEvent)(nil)
 	_ event = (*bootstrapEvent)(nil)
 	_ event = (*changeStateEvent)(nil)
 	_ event = (*updateConnectionsEvent)(nil)
+	_ event = (*updateCertEvent)(nil)
+	_ event = (*listConfigsEvent)(nil)
+	_ event = (*removeHandlerEvent)(nil)
 )
 
-type createConfigEvent struct {
-	mfThing    string
-	owner      string
-	name       string
-	mfChannels []string
-	externalID string
-	content    string
-	timestamp  time.Time
+type configEvent struct {
+	bootstrap.Config
 }
 
-func (cce createConfigEvent) encode() map[string]interface{} {
-	return map[string]interface{}{
-		"thing_id":    cce.mfThing,
-		"owner":       cce.owner,
-		"name":        cce.name,
-		"channels":    strings.Join(cce.mfChannels, ", "),
-		"external_id": cce.externalID,
-		"content":     cce.content,
-		"timestamp":   cce.timestamp.Unix(),
-		"operation":   configCreate,
+func (ce configEvent) encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"state":     ce.State.String(),
+		"operation": configCreate,
 	}
-}
-
-type updateConfigEvent struct {
-	mfThing   string
-	name      string
-	content   string
-	timestamp time.Time
-}
-
-func (uce updateConfigEvent) encode() map[string]interface{} {
-	return map[string]interface{}{
-		"thing_id":  uce.mfThing,
-		"name":      uce.name,
-		"content":   uce.content,
-		"timestamp": uce.timestamp.Unix(),
-		"operation": configUpdate,
+	if ce.MFThing != "" {
+		val["mainflux_thing"] = ce.MFThing
 	}
+	if ce.Content != "" {
+		val["content"] = ce.Content
+	}
+	if ce.Owner != "" {
+		val["owner"] = ce.Owner
+	}
+	if ce.Name != "" {
+		val["name"] = ce.Name
+	}
+	if ce.ExternalID != "" {
+		val["external_id"] = ce.ExternalID
+	}
+	if len(ce.MFChannels) > 0 {
+		channels := make([]string, len(ce.MFChannels))
+		for i, ch := range ce.MFChannels {
+			channels[i] = ch.ID
+		}
+		val["channels"] = fmt.Sprintf("[%s]", strings.Join(channels, ", "))
+	}
+	if ce.ClientCert != "" {
+		val["client_cert"] = ce.ClientCert
+	}
+	if ce.ClientKey != "" {
+		val["client_key"] = ce.ClientKey
+	}
+	if ce.CACert != "" {
+		val["ca_cert"] = ce.CACert
+	}
+	if ce.Content != "" {
+		val["content"] = ce.Content
+	}
+
+	return val
 }
 
 type removeConfigEvent struct {
-	mfThing   string
-	timestamp time.Time
+	mfThing string
 }
 
 func (rce removeConfigEvent) encode() map[string]interface{} {
 	return map[string]interface{}{
 		"thing_id":  rce.mfThing,
-		"timestamp": rce.timestamp.Unix(),
 		"operation": configRemove,
 	}
 }
 
+type listConfigsEvent struct {
+	offset       uint64
+	limit        uint64
+	fullMatch    map[string]string
+	partialMatch map[string]string
+}
+
+func (rce listConfigsEvent) encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"offset":    rce.offset,
+		"limit":     rce.limit,
+		"operation": configList,
+	}
+	if len(rce.fullMatch) > 0 {
+		data, err := json.Marshal(rce.fullMatch)
+		if err != nil {
+			return val
+		}
+
+		val["full_match"] = data
+	}
+
+	if len(rce.partialMatch) > 0 {
+		data, err := json.Marshal(rce.partialMatch)
+		if err != nil {
+			return val
+		}
+
+		val["full_match"] = data
+	}
+	return val
+}
+
 type bootstrapEvent struct {
+	bootstrap.Config
 	externalID string
 	success    bool
-	timestamp  time.Time
 }
 
 func (be bootstrapEvent) encode() map[string]interface{} {
-	return map[string]interface{}{
+	val := map[string]interface{}{
 		"external_id": be.externalID,
 		"success":     be.success,
-		"timestamp":   be.timestamp.Unix(),
 		"operation":   thingBootstrap,
 	}
+
+	if be.MFThing != "" {
+		val["mainflux_thing"] = be.MFThing
+	}
+	if be.Content != "" {
+		val["content"] = be.Content
+	}
+	if be.Owner != "" {
+		val["owner"] = be.Owner
+	}
+	if be.Name != "" {
+		val["name"] = be.Name
+	}
+	if be.ExternalID != "" {
+		val["external_id"] = be.ExternalID
+	}
+	if len(be.MFChannels) > 0 {
+		channels := make([]string, len(be.MFChannels))
+		for i, ch := range be.MFChannels {
+			channels[i] = ch.ID
+		}
+		val["channels"] = fmt.Sprintf("[%s]", strings.Join(channels, ", "))
+	}
+	if be.ClientCert != "" {
+		val["client_cert"] = be.ClientCert
+	}
+	if be.ClientKey != "" {
+		val["client_key"] = be.ClientKey
+	}
+	if be.CACert != "" {
+		val["ca_cert"] = be.CACert
+	}
+	if be.Content != "" {
+		val["content"] = be.Content
+	}
+	return val
 }
 
 type changeStateEvent struct {
-	mfThing   string
-	state     bootstrap.State
-	timestamp time.Time
+	mfThing string
+	state   bootstrap.State
 }
 
 func (cse changeStateEvent) encode() map[string]interface{} {
 	return map[string]interface{}{
 		"thing_id":  cse.mfThing,
 		"state":     cse.state.String(),
-		"timestamp": cse.timestamp.Unix(),
 		"operation": thingStateChange,
 	}
 }
@@ -121,14 +202,77 @@ func (cse changeStateEvent) encode() map[string]interface{} {
 type updateConnectionsEvent struct {
 	mfThing    string
 	mfChannels []string
-	timestamp  time.Time
 }
 
 func (uce updateConnectionsEvent) encode() map[string]interface{} {
 	return map[string]interface{}{
 		"thing_id":  uce.mfThing,
-		"channels":  strings.Join(uce.mfChannels, ", "),
-		"timestamp": uce.timestamp.Unix(),
+		"channels":  fmt.Sprintf("[%s]", strings.Join(uce.mfChannels, ", ")),
 		"operation": thingUpdateConnections,
+	}
+}
+
+type updateCertEvent struct {
+	thingKey, clientCert, clientKey, caCert string
+}
+
+func (uce updateCertEvent) encode() map[string]interface{} {
+	return map[string]interface{}{
+		"thing_key":   uce.thingKey,
+		"client_cert": uce.clientCert,
+		"client_key":  uce.clientKey,
+		"ca_cert":     uce.caCert,
+		"operation":   certUpdate,
+	}
+}
+
+type removeHandlerEvent struct {
+	id        string
+	operation string
+}
+
+func (rhe removeHandlerEvent) encode() map[string]interface{} {
+	return map[string]interface{}{
+		"config_id": rhe.id,
+		"operation": rhe.operation,
+	}
+}
+
+type updateChannelHandlerEvent struct {
+	bootstrap.Channel
+}
+
+func (uche updateChannelHandlerEvent) encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": channelUpdateHandler,
+	}
+
+	if uche.ID != "" {
+		val["channel_id"] = uche.ID
+	}
+	if uche.Name != "" {
+		val["name"] = uche.Name
+	}
+	if uche.Metadata != nil {
+		metadata, err := json.Marshal(uche.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	return val
+}
+
+type disconnectThingEvent struct {
+	thingID   string
+	channelID string
+}
+
+func (dte disconnectThingEvent) encode() map[string]interface{} {
+	return map[string]interface{}{
+		"thing_id":   dte.thingID,
+		"channel_id": dte.channelID,
+		"operation":  thingDisconnect,
 	}
 }

--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -33,7 +33,7 @@ const (
 )
 
 type event interface {
-	encode() map[string]interface{}
+	encode() (map[string]interface{}, error)
 }
 
 var (
@@ -52,7 +52,7 @@ type configEvent struct {
 	operation string
 }
 
-func (ce configEvent) encode() map[string]interface{} {
+func (ce configEvent) encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"state":     ce.State.String(),
 		"operation": ce.operation,
@@ -92,18 +92,18 @@ func (ce configEvent) encode() map[string]interface{} {
 		val["content"] = ce.Content
 	}
 
-	return val
+	return val, nil
 }
 
 type removeConfigEvent struct {
 	mfThing string
 }
 
-func (rce removeConfigEvent) encode() map[string]interface{} {
+func (rce removeConfigEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  rce.mfThing,
 		"operation": configRemove,
-	}
+	}, nil
 }
 
 type listConfigsEvent struct {
@@ -113,7 +113,7 @@ type listConfigsEvent struct {
 	partialMatch map[string]string
 }
 
-func (rce listConfigsEvent) encode() map[string]interface{} {
+func (rce listConfigsEvent) encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"offset":    rce.offset,
 		"limit":     rce.limit,
@@ -122,7 +122,7 @@ func (rce listConfigsEvent) encode() map[string]interface{} {
 	if len(rce.fullMatch) > 0 {
 		data, err := json.Marshal(rce.fullMatch)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["full_match"] = data
@@ -131,12 +131,12 @@ func (rce listConfigsEvent) encode() map[string]interface{} {
 	if len(rce.partialMatch) > 0 {
 		data, err := json.Marshal(rce.partialMatch)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["full_match"] = data
 	}
-	return val
+	return val, nil
 }
 
 type bootstrapEvent struct {
@@ -145,7 +145,7 @@ type bootstrapEvent struct {
 	success    bool
 }
 
-func (be bootstrapEvent) encode() map[string]interface{} {
+func (be bootstrapEvent) encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"external_id": be.externalID,
 		"success":     be.success,
@@ -186,7 +186,7 @@ func (be bootstrapEvent) encode() map[string]interface{} {
 	if be.Content != "" {
 		val["content"] = be.Content
 	}
-	return val
+	return val, nil
 }
 
 type changeStateEvent struct {
@@ -194,12 +194,12 @@ type changeStateEvent struct {
 	state   bootstrap.State
 }
 
-func (cse changeStateEvent) encode() map[string]interface{} {
+func (cse changeStateEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  cse.mfThing,
 		"state":     cse.state.String(),
 		"operation": thingStateChange,
-	}
+	}, nil
 }
 
 type updateConnectionsEvent struct {
@@ -207,26 +207,26 @@ type updateConnectionsEvent struct {
 	mfChannels []string
 }
 
-func (uce updateConnectionsEvent) encode() map[string]interface{} {
+func (uce updateConnectionsEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  uce.mfThing,
 		"channels":  fmt.Sprintf("[%s]", strings.Join(uce.mfChannels, ", ")),
 		"operation": thingUpdateConnections,
-	}
+	}, nil
 }
 
 type updateCertEvent struct {
 	thingKey, clientCert, clientKey, caCert string
 }
 
-func (uce updateCertEvent) encode() map[string]interface{} {
+func (uce updateCertEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_key":   uce.thingKey,
 		"client_cert": uce.clientCert,
 		"client_key":  uce.clientKey,
 		"ca_cert":     uce.caCert,
 		"operation":   certUpdate,
-	}
+	}, nil
 }
 
 type removeHandlerEvent struct {
@@ -234,18 +234,18 @@ type removeHandlerEvent struct {
 	operation string
 }
 
-func (rhe removeHandlerEvent) encode() map[string]interface{} {
+func (rhe removeHandlerEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"config_id": rhe.id,
 		"operation": rhe.operation,
-	}
+	}, nil
 }
 
 type updateChannelHandlerEvent struct {
 	bootstrap.Channel
 }
 
-func (uche updateChannelHandlerEvent) encode() map[string]interface{} {
+func (uche updateChannelHandlerEvent) encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": channelUpdateHandler,
 	}
@@ -259,12 +259,12 @@ func (uche updateChannelHandlerEvent) encode() map[string]interface{} {
 	if uche.Metadata != nil {
 		metadata, err := json.Marshal(uche.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
 	}
-	return val
+	return val, nil
 }
 
 type disconnectThingEvent struct {
@@ -272,10 +272,10 @@ type disconnectThingEvent struct {
 	channelID string
 }
 
-func (dte disconnectThingEvent) encode() map[string]interface{} {
+func (dte disconnectThingEvent) encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":   dte.thingID,
 		"channel_id": dte.channelID,
 		"operation":  thingDisconnect,
-	}
+	}, nil
 }

--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -49,12 +49,13 @@ var (
 
 type configEvent struct {
 	bootstrap.Config
+	operation string
 }
 
 func (ce configEvent) encode() map[string]interface{} {
 	val := map[string]interface{}{
 		"state":     ce.State.String(),
-		"operation": configCreate,
+		"operation": ce.operation,
 	}
 	if ce.MFThing != "" {
 		val["mainflux_thing"] = ce.MFThing

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -5,7 +5,6 @@ package producer
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
@@ -38,28 +37,31 @@ func (es eventStore) Add(ctx context.Context, token string, cfg bootstrap.Config
 		return saved, err
 	}
 
-	var channels []string
-	for _, ch := range saved.MFChannels {
-		channels = append(channels, ch.ID)
+	ev := configEvent{
+		saved,
 	}
 
-	ev := createConfigEvent{
-		mfThing:    saved.MFThing,
-		owner:      saved.Owner,
-		name:       saved.Name,
-		mfChannels: channels,
-		externalID: saved.ExternalID,
-		content:    saved.Content,
-		timestamp:  time.Now(),
+	if err = es.add(ctx, ev); err != nil {
+		return saved, err
 	}
-
-	err = es.add(ctx, ev)
 
 	return saved, err
 }
 
 func (es eventStore) View(ctx context.Context, token, id string) (bootstrap.Config, error) {
-	return es.svc.View(ctx, token, id)
+	cfg, err := es.svc.View(ctx, token, id)
+	if err != nil {
+		return cfg, err
+	}
+	ev := configEvent{
+		cfg,
+	}
+
+	if err = es.add(ctx, ev); err != nil {
+		return cfg, err
+	}
+
+	return cfg, err
 }
 
 func (es eventStore) Update(ctx context.Context, token string, cfg bootstrap.Config) error {
@@ -67,18 +69,26 @@ func (es eventStore) Update(ctx context.Context, token string, cfg bootstrap.Con
 		return err
 	}
 
-	ev := updateConfigEvent{
-		mfThing:   cfg.MFThing,
-		name:      cfg.Name,
-		content:   cfg.Content,
-		timestamp: time.Now(),
+	ev := configEvent{
+		cfg,
 	}
 
 	return es.add(ctx, ev)
 }
 
 func (es eventStore) UpdateCert(ctx context.Context, token, thingKey, clientCert, clientKey, caCert string) error {
-	return es.svc.UpdateCert(ctx, token, thingKey, clientCert, clientKey, caCert)
+	if err := es.svc.UpdateCert(ctx, token, thingKey, clientCert, clientKey, caCert); err != nil {
+		return err
+	}
+
+	ev := updateCertEvent{
+		thingKey:   thingKey,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+		caCert:     caCert,
+	}
+
+	return es.add(ctx, ev)
 }
 
 func (es eventStore) UpdateConnections(ctx context.Context, token, id string, connections []string) error {
@@ -89,14 +99,29 @@ func (es eventStore) UpdateConnections(ctx context.Context, token, id string, co
 	ev := updateConnectionsEvent{
 		mfThing:    id,
 		mfChannels: connections,
-		timestamp:  time.Now(),
 	}
 
 	return es.add(ctx, ev)
 }
 
 func (es eventStore) List(ctx context.Context, token string, filter bootstrap.Filter, offset, limit uint64) (bootstrap.ConfigsPage, error) {
-	return es.svc.List(ctx, token, filter, offset, limit)
+	bp, err := es.svc.List(ctx, token, filter, offset, limit)
+	if err != nil {
+		return bp, err
+	}
+
+	ev := listConfigsEvent{
+		offset:       offset,
+		limit:        limit,
+		fullMatch:    filter.FullMatch,
+		partialMatch: filter.PartialMatch,
+	}
+
+	if err = es.add(ctx, ev); err != nil {
+		return bp, err
+	}
+
+	return bp, nil
 }
 
 func (es eventStore) Remove(ctx context.Context, token, id string) error {
@@ -105,8 +130,7 @@ func (es eventStore) Remove(ctx context.Context, token, id string) error {
 	}
 
 	ev := removeConfigEvent{
-		mfThing:   id,
-		timestamp: time.Now(),
+		mfThing: id,
 	}
 
 	return es.add(ctx, ev)
@@ -116,15 +140,18 @@ func (es eventStore) Bootstrap(ctx context.Context, externalKey, externalID stri
 	cfg, err := es.svc.Bootstrap(ctx, externalKey, externalID, secure)
 
 	ev := bootstrapEvent{
-		externalID: externalID,
-		timestamp:  time.Now(),
-		success:    true,
+		cfg,
+		externalID,
+		true,
 	}
 
 	if err != nil {
 		ev.success = false
 	}
-	_ = es.add(ctx, ev)
+
+	if err = es.add(ctx, ev); err != nil {
+		return cfg, err
+	}
 
 	return cfg, err
 }
@@ -135,28 +162,62 @@ func (es eventStore) ChangeState(ctx context.Context, token, id string, state bo
 	}
 
 	ev := changeStateEvent{
-		mfThing:   id,
-		state:     state,
-		timestamp: time.Now(),
+		mfThing: id,
+		state:   state,
 	}
 
 	return es.add(ctx, ev)
 }
 
 func (es eventStore) RemoveConfigHandler(ctx context.Context, id string) error {
-	return es.svc.RemoveConfigHandler(ctx, id)
+	if err := es.svc.RemoveConfigHandler(ctx, id); err != nil {
+		return err
+	}
+
+	ev := removeHandlerEvent{
+		id:        id,
+		operation: configHandlerRemove,
+	}
+
+	return es.add(ctx, ev)
 }
 
 func (es eventStore) RemoveChannelHandler(ctx context.Context, id string) error {
-	return es.svc.RemoveChannelHandler(ctx, id)
+	if err := es.svc.RemoveChannelHandler(ctx, id); err != nil {
+		return err
+	}
+
+	ev := removeHandlerEvent{
+		id:        id,
+		operation: channelHandlerRemove,
+	}
+
+	return es.add(ctx, ev)
 }
 
 func (es eventStore) UpdateChannelHandler(ctx context.Context, channel bootstrap.Channel) error {
-	return es.svc.UpdateChannelHandler(ctx, channel)
+	if err := es.svc.UpdateChannelHandler(ctx, channel); err != nil {
+		return err
+	}
+
+	ev := updateChannelHandlerEvent{
+		channel,
+	}
+
+	return es.add(ctx, ev)
 }
 
 func (es eventStore) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
-	return es.svc.DisconnectThingHandler(ctx, channelID, thingID)
+	if err := es.svc.DisconnectThingHandler(ctx, channelID, thingID); err != nil {
+		return err
+	}
+
+	ev := disconnectThingEvent{
+		channelID,
+		thingID,
+	}
+
+	return es.add(ctx, ev)
 }
 
 func (es eventStore) add(ctx context.Context, ev event) error {

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -222,10 +222,15 @@ func (es eventStore) DisconnectThingHandler(ctx context.Context, channelID, thin
 }
 
 func (es eventStore) add(ctx context.Context, ev event) error {
+	values, err := ev.encode()
+	if err != nil {
+		return err
+	}
+
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       ev.encode(),
+		Values:       values,
 	}
 
 	return es.client.XAdd(ctx, record).Err()

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
+	"github.com/mainflux/mainflux/pkg/errors"
 )
 
 const (
@@ -38,11 +39,11 @@ func (es eventStore) Add(ctx context.Context, token string, cfg bootstrap.Config
 	}
 
 	ev := configEvent{
-		saved,
+		saved, configCreate,
 	}
 
-	if err = es.add(ctx, ev); err != nil {
-		return saved, err
+	if err1 := es.add(ctx, ev); err1 != nil {
+		return saved, errors.Wrap(err, err1)
 	}
 
 	return saved, err
@@ -54,11 +55,11 @@ func (es eventStore) View(ctx context.Context, token, id string) (bootstrap.Conf
 		return cfg, err
 	}
 	ev := configEvent{
-		cfg,
+		cfg, configList,
 	}
 
-	if err = es.add(ctx, ev); err != nil {
-		return cfg, err
+	if err1 := es.add(ctx, ev); err1 != nil {
+		return cfg, errors.Wrap(err, err1)
 	}
 
 	return cfg, err
@@ -70,7 +71,7 @@ func (es eventStore) Update(ctx context.Context, token string, cfg bootstrap.Con
 	}
 
 	ev := configEvent{
-		cfg,
+		cfg, configUpdate,
 	}
 
 	return es.add(ctx, ev)
@@ -117,8 +118,8 @@ func (es eventStore) List(ctx context.Context, token string, filter bootstrap.Fi
 		partialMatch: filter.PartialMatch,
 	}
 
-	if err = es.add(ctx, ev); err != nil {
-		return bp, err
+	if err1 := es.add(ctx, ev); err1 != nil {
+		return bp, errors.Wrap(err, err1)
 	}
 
 	return bp, nil
@@ -149,8 +150,8 @@ func (es eventStore) Bootstrap(ctx context.Context, externalKey, externalID stri
 		ev.success = false
 	}
 
-	if err = es.add(ctx, ev); err != nil {
-		return cfg, err
+	if err1 := es.add(ctx, ev); err1 != nil {
+		return cfg, err1
 	}
 
 	return cfg, err

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 volumes:
   mainflux-users-db-volume:
   mainflux-things-db-volume:
-  mainflux-users-redis-volume:
+  mainflux-things-redis-volume:
   mainflux-es-redis-volume:
   mainflux-mqtt-broker-volume:
 
@@ -82,7 +82,7 @@ services:
       MF_THINGS_DB_USER: ${MF_THINGS_DB_USER}
       MF_THINGS_DB_PASS: ${MF_THINGS_DB_PASS}
       MF_THINGS_DB: ${MF_THINGS_DB}
-      MF_THINGS_CACHE_URL: users-redis:${MF_REDIS_TCP_PORT}
+      MF_THINGS_CACHE_URL: things-redis:${MF_REDIS_TCP_PORT}
       MF_THINGS_ES_URL: es-redis:${MF_REDIS_TCP_PORT}
       MF_THINGS_HTTP_PORT: ${MF_THINGS_HTTP_PORT}
       MF_JAEGER_URL: ${MF_JAEGER_URL}
@@ -112,14 +112,14 @@ services:
     volumes:
       - mainflux-users-db-volume:/var/lib/postgresql/data
 
-  users-redis:
+  things-redis:
     image: redis:6.2.2-alpine
-    container_name: mainflux-users-redis
+    container_name: mainflux-things-redis
     restart: on-failure
     networks:
       - mainflux-base-net
     volumes:
-      - mainflux-users-redis-volume:/data
+      - mainflux-things-redis-volume:/data
 
   users:
     image: mainflux/users:${MF_RELEASE_TAG}
@@ -205,7 +205,7 @@ services:
       MF_JAEGER_URL: ${MF_JAEGER_URL}
       MF_THINGS_AUTH_GRPC_URL: ${MF_THINGS_AUTH_GRPC_URL}
       MF_THINGS_AUTH_GRPC_TIMEOUT: ${MF_THINGS_AUTH_GRPC_TIMEOUT}
-      MF_AUTH_CACHE_URL: users-redis:${MF_REDIS_TCP_PORT}
+      MF_AUTH_CACHE_URL: things-redis:${MF_REDIS_TCP_PORT}
     networks:
       - mainflux-base-net
 

--- a/mqtt/redis/events.go
+++ b/mqtt/redis/events.go
@@ -13,7 +13,6 @@ var (
 
 type mqttEvent struct {
 	clientID  string
-	timestamp string
 	eventType string
 	instance  string
 }
@@ -21,7 +20,6 @@ type mqttEvent struct {
 func (me mqttEvent) Encode() map[string]interface{} {
 	return map[string]interface{}{
 		"thing_id":   me.clientID,
-		"timestamp":  me.timestamp,
 		"event_type": me.eventType,
 		"instance":   me.instance,
 	}

--- a/mqtt/redis/streams.go
+++ b/mqtt/redis/streams.go
@@ -5,8 +5,6 @@ package redis
 
 import (
 	"context"
-	"strconv"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 )
@@ -37,11 +35,8 @@ func NewEventStore(client *redis.Client, instance string) EventStore {
 }
 
 func (es eventStore) storeEvent(clientID, eventType string) error {
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-
 	event := mqttEvent{
 		clientID:  clientID,
-		timestamp: timestamp,
 		eventType: eventType,
 		instance:  es.instance,
 	}

--- a/pkg/clients/page.go
+++ b/pkg/clients/page.go
@@ -9,13 +9,13 @@ type Page struct {
 	Order        string   `json:"order,omitempty"`
 	Dir          string   `json:"dir,omitempty"`
 	Metadata     Metadata `json:"metadata,omitempty"`
-	Disconnected bool     // Used for connected or disconnected lists
-	Owner        string
-	Tag          string
-	SharedBy     string
-	Status       Status
-	Action       string
-	Subject      string
-	IDs          []string
-	Identity     string
+	Disconnected bool     `json:"disconnected,omitempty"` // Used for connected or disconnected lists
+	Owner        string   `json:"owner,omitempty"`
+	Tag          string   `json:"tag,omitempty"`
+	SharedBy     string   `json:"shared_by,omitempty"`
+	Status       Status   `json:"status,omitempty"`
+	Action       string   `json:"action,omitempty"`
+	Subject      string   `json:"subject,omitempty"`
+	IDs          []string `json:"ids,omitempty"`
+	Identity     string   `json:"identity,omitempty"`
 }

--- a/pkg/groups/groups.go
+++ b/pkg/groups/groups.go
@@ -29,8 +29,8 @@ type Group struct {
 	Path        string           `json:"path,omitempty"`
 	Children    []*Group         `json:"children,omitempty"`
 	CreatedAt   time.Time        `json:"created_at"`
-	UpdatedAt   time.Time        `json:"updated_at"`
-	UpdatedBy   string           `json:"updated_by"`
+	UpdatedAt   time.Time        `json:"updated_at,omitempty"`
+	UpdatedBy   string           `json:"updated_by,omitempty"`
 	Status      clients.Status   `json:"status"`
 }
 

--- a/pkg/groups/page.go
+++ b/pkg/groups/page.go
@@ -4,16 +4,16 @@ import "github.com/mainflux/mainflux/pkg/clients"
 
 // Page contains page metadata that helps navigation.
 type Page struct {
-	Total        uint64
-	Offset       uint64 `json:"offset,omitempty"`
-	Limit        uint64 `json:"limit,omitempty"`
-	Name         string `json:"name,omitempty"`
-	OwnerID      string
-	Tag          string
+	Total        uint64           `json:"total"`
+	Offset       uint64           `json:"offset"`
+	Limit        uint64           `json:"limit"`
+	Name         string           `json:"name,omitempty"`
+	OwnerID      string           `json:"identity,omitempty"`
+	Tag          string           `json:"tag,omitempty"`
 	Metadata     clients.Metadata `json:"metadata,omitempty"`
-	SharedBy     string
-	Status       clients.Status
-	Subject      string
-	Action       string
-	Disconnected bool // Used for connected or disconnected lists
+	SharedBy     string           `json:"shared_by,omitempty"`
+	Status       clients.Status   `json:"status,omitempty"`
+	Subject      string           `json:"subject,omitempty"`
+	Action       string           `json:"action,omitempty"`
+	Disconnected bool             `json:"disconnected,omitempty"` // Used for connected or disconnected lists
 }

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -364,7 +364,6 @@ func TestListClients(t *testing.T) {
 			ok := repoCall1.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("RetrieveAll was not called on %s", tc.desc))
 		}
-		repoCall1.Unset()
 		repoCall.Unset()
 	}
 }

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -355,16 +355,15 @@ func TestListClients(t *testing.T) {
 			Tag:      tc.tag,
 		}
 
-		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
+		repoCall := pRepo.On("Evaluate", mock.Anything, mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
+		repoCall1 := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
+		repoCall2 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
 		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
-		if tc.err == nil {
-			ok := repoCall1.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
-			assert.True(t, ok, fmt.Sprintf("RetrieveAll was not called on %s", tc.desc))
-		}
 		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
 	}
 }
 

--- a/things/clients/clients.go
+++ b/things/clients/clients.go
@@ -53,12 +53,12 @@ type Service interface {
 
 // ClientCache contains thing caching interface.
 type ClientCache interface {
-	// Save stores pair thing key, thing id.
-	Save(context.Context, string, string) error
+	// Save stores pair thing secret, thing id.
+	Save(ctx context.Context, thingSecret, thingID string) error
 
-	// ID returns thing ID for given key.
-	ID(context.Context, string) (string, error)
+	// ID returns thing ID for given thing secret.
+	ID(ctx context.Context, thingSecret string) (string, error)
 
 	// Removes thing from cache.
-	Remove(context.Context, string) error
+	Remove(ctx context.Context, thingID string) error
 }

--- a/things/clients/postgres/clients.go
+++ b/things/clients/postgres/clients.go
@@ -333,7 +333,7 @@ func toDBClient(c mfclients.Client) (dbClient, error) {
 		updatedBy = &c.UpdatedBy
 	}
 	var updatedAt sql.NullTime
-	if c.UpdatedAt != (time.Time{}) {
+	if !c.UpdatedAt.IsZero() {
 		updatedAt = sql.NullTime{Time: c.UpdatedAt, Valid: true}
 	}
 

--- a/things/clients/redis/events.go
+++ b/things/clients/redis/events.go
@@ -106,7 +106,7 @@ func (uce updateClientEvent) Encode() map[string]interface{} {
 
 		val["metadata"] = metadata
 	}
-	if uce.CreatedAt != (time.Time{}) {
+	if !uce.CreatedAt.IsZero() {
 		val["created_at"] = uce.CreatedAt
 	}
 	if uce.Status.String() != "" {
@@ -179,10 +179,10 @@ func (vce viewClientEvent) Encode() map[string]interface{} {
 
 		val["metadata"] = metadata
 	}
-	if vce.CreatedAt != (time.Time{}) {
+	if !vce.CreatedAt.IsZero() {
 		val["created_at"] = vce.CreatedAt
 	}
-	if vce.UpdatedAt != (time.Time{}) {
+	if !vce.UpdatedAt.IsZero() {
 		val["updated_at"] = vce.UpdatedAt
 	}
 	if vce.UpdatedBy != "" {

--- a/things/clients/redis/events.go
+++ b/things/clients/redis/events.go
@@ -22,7 +22,7 @@ const (
 )
 
 type event interface {
-	Encode() map[string]interface{}
+	Encode() (map[string]interface{}, error)
 }
 
 var (
@@ -40,7 +40,7 @@ type createClientEvent struct {
 	mfclients.Client
 }
 
-func (cce createClientEvent) Encode() map[string]interface{} {
+func (cce createClientEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  clientCreate,
 		"id":         cce.ID,
@@ -61,7 +61,7 @@ func (cce createClientEvent) Encode() map[string]interface{} {
 	if cce.Metadata != nil {
 		metadata, err := json.Marshal(cce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -70,7 +70,7 @@ func (cce createClientEvent) Encode() map[string]interface{} {
 		val["identity"] = cce.Credentials.Identity
 	}
 
-	return val
+	return val, nil
 }
 
 type updateClientEvent struct {
@@ -78,7 +78,7 @@ type updateClientEvent struct {
 	operation string
 }
 
-func (uce updateClientEvent) Encode() map[string]interface{} {
+func (uce updateClientEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  clientUpdate + "." + uce.operation,
 		"updated_at": uce.UpdatedAt,
@@ -101,7 +101,7 @@ func (uce updateClientEvent) Encode() map[string]interface{} {
 	if uce.Metadata != nil {
 		metadata, err := json.Marshal(uce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -113,7 +113,7 @@ func (uce updateClientEvent) Encode() map[string]interface{} {
 		val["status"] = uce.Status.String()
 	}
 
-	return val
+	return val, nil
 }
 
 type removeClientEvent struct {
@@ -123,14 +123,14 @@ type removeClientEvent struct {
 	updatedBy string
 }
 
-func (rce removeClientEvent) Encode() map[string]interface{} {
+func (rce removeClientEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"operation":  clientRemove,
 		"id":         rce.id,
 		"status":     rce.status,
 		"updated_at": rce.updatedAt,
 		"updated_by": rce.updatedBy,
-	}
+	}, nil
 }
 
 type shareClientEvent struct {
@@ -139,20 +139,20 @@ type shareClientEvent struct {
 	userIDs string
 }
 
-func (sce shareClientEvent) Encode() map[string]interface{} {
+func (sce shareClientEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"operation": clientShare,
 		"thing_id":  sce.thingID,
 		"actions":   sce.actions,
 		"user_ids":  sce.userIDs,
-	}
+	}, nil
 }
 
 type viewClientEvent struct {
 	mfclients.Client
 }
 
-func (vce viewClientEvent) Encode() map[string]interface{} {
+func (vce viewClientEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": clientView,
 		"id":        vce.ID,
@@ -174,7 +174,7 @@ func (vce viewClientEvent) Encode() map[string]interface{} {
 	if vce.Metadata != nil {
 		metadata, err := json.Marshal(vce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -192,14 +192,14 @@ func (vce viewClientEvent) Encode() map[string]interface{} {
 		val["status"] = vce.Status.String()
 	}
 
-	return val
+	return val, nil
 }
 
 type listClientEvent struct {
 	mfclients.Page
 }
 
-func (lce listClientEvent) Encode() map[string]interface{} {
+func (lce listClientEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": clientList,
 		"total":     lce.Total,
@@ -219,7 +219,7 @@ func (lce listClientEvent) Encode() map[string]interface{} {
 	if lce.Metadata != nil {
 		metadata, err := json.Marshal(lce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -246,7 +246,7 @@ func (lce listClientEvent) Encode() map[string]interface{} {
 		val["identity"] = lce.Identity
 	}
 
-	return val
+	return val, nil
 }
 
 type listClientByGroupEvent struct {
@@ -254,7 +254,7 @@ type listClientByGroupEvent struct {
 	channelID string
 }
 
-func (lcge listClientByGroupEvent) Encode() map[string]interface{} {
+func (lcge listClientByGroupEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  clientListByGroup,
 		"total":      lcge.Total,
@@ -275,7 +275,7 @@ func (lcge listClientByGroupEvent) Encode() map[string]interface{} {
 	if lcge.Metadata != nil {
 		metadata, err := json.Marshal(lcge.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -302,16 +302,16 @@ func (lcge listClientByGroupEvent) Encode() map[string]interface{} {
 		val["identity"] = lcge.Identity
 	}
 
-	return val
+	return val, nil
 }
 
 type identifyClientEvent struct {
 	thingID string
 }
 
-func (ice identifyClientEvent) Encode() map[string]interface{} {
+func (ice identifyClientEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"operation": clientIdentify,
 		"thing_id":  ice.thingID,
-	}
+	}, nil
 }

--- a/things/clients/redis/events.go
+++ b/things/clients/redis/events.go
@@ -1,12 +1,24 @@
 package redis
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	mfclients "github.com/mainflux/mainflux/pkg/clients"
+)
 
 const (
-	thingPrefix = "thing."
-	thingCreate = thingPrefix + "create"
-	thingUpdate = thingPrefix + "update"
-	thingRemove = thingPrefix + "remove"
+	clientPrefix      = "thing."
+	clientCreate      = clientPrefix + "create"
+	clientUpdate      = clientPrefix + "update"
+	clientRemove      = clientPrefix + "remove"
+	clientShare       = clientPrefix + "share"
+	clientView        = clientPrefix + "view"
+	clientList        = clientPrefix + "list"
+	clientListByGroup = clientPrefix + "list_by_group"
+	clientIdentify    = clientPrefix + "identify"
 )
 
 type event interface {
@@ -17,75 +29,289 @@ var (
 	_ event = (*createClientEvent)(nil)
 	_ event = (*updateClientEvent)(nil)
 	_ event = (*removeClientEvent)(nil)
+	_ event = (*shareClientEvent)(nil)
+	_ event = (*viewClientEvent)(nil)
+	_ event = (*listClientEvent)(nil)
+	_ event = (*listClientByGroupEvent)(nil)
+	_ event = (*identifyClientEvent)(nil)
 )
 
 type createClientEvent struct {
-	id       string
-	owner    string
-	name     string
-	metadata map[string]interface{}
+	mfclients.Client
 }
 
-func (cte createClientEvent) Encode() map[string]interface{} {
+func (cce createClientEvent) Encode() map[string]interface{} {
 	val := map[string]interface{}{
-		"id":        cte.id,
-		"owner":     cte.owner,
-		"operation": thingCreate,
+		"operation":  clientCreate,
+		"id":         cce.ID,
+		"status":     cce.Status.String(),
+		"created_at": cce.CreatedAt,
 	}
 
-	if cte.name != "" {
-		val["name"] = cte.name
+	if cce.Name != "" {
+		val["name"] = cce.Name
 	}
-
-	if cte.metadata != nil {
-		metadata, err := json.Marshal(cte.metadata)
+	if len(cce.Tags) > 0 {
+		tags := fmt.Sprintf("[%s]", strings.Join(cce.Tags, ","))
+		val["tags"] = tags
+	}
+	if cce.Owner != "" {
+		val["owner"] = cce.Owner
+	}
+	if cce.Metadata != nil {
+		metadata, err := json.Marshal(cce.Metadata)
 		if err != nil {
 			return val
 		}
 
-		val["metadata"] = string(metadata)
+		val["metadata"] = metadata
+	}
+	if cce.Credentials.Identity != "" {
+		val["identity"] = cce.Credentials.Identity
 	}
 
 	return val
 }
 
 type updateClientEvent struct {
-	id       string
-	name     string
-	owner    string
-	tags     []string
-	metadata map[string]interface{}
+	mfclients.Client
+	operation string
 }
 
-func (ute updateClientEvent) Encode() map[string]interface{} {
+func (uce updateClientEvent) Encode() map[string]interface{} {
 	val := map[string]interface{}{
-		"id":        ute.id,
-		"operation": thingUpdate,
+		"operation":  clientUpdate + "." + uce.operation,
+		"updated_at": uce.UpdatedAt,
+		"updated_by": uce.UpdatedBy,
 	}
 
-	if ute.name != "" {
-		val["name"] = ute.name
+	if uce.ID != "" {
+		val["id"] = uce.ID
 	}
-
-	if ute.metadata != nil {
-		metadata, err := json.Marshal(ute.metadata)
+	if uce.Name != "" {
+		val["name"] = uce.Name
+	}
+	if len(uce.Tags) > 0 {
+		tags := fmt.Sprintf("[%s]", strings.Join(uce.Tags, ","))
+		val["tags"] = tags
+	}
+	if uce.Credentials.Identity != "" {
+		val["identity"] = uce.Credentials.Identity
+	}
+	if uce.Metadata != nil {
+		metadata, err := json.Marshal(uce.Metadata)
 		if err != nil {
 			return val
 		}
 
-		val["metadata"] = string(metadata)
+		val["metadata"] = metadata
+	}
+	if uce.CreatedAt != (time.Time{}) {
+		val["created_at"] = uce.CreatedAt
+	}
+	if uce.Status.String() != "" {
+		val["status"] = uce.Status.String()
 	}
 
 	return val
 }
 
 type removeClientEvent struct {
-	id string
+	id        string
+	status    string
+	updatedAt time.Time
+	updatedBy string
 }
 
-func (rte removeClientEvent) Encode() map[string]interface{} {
+func (rce removeClientEvent) Encode() map[string]interface{} {
 	return map[string]interface{}{
-		"id":        rte.id,
-		"operation": thingRemove,
+		"operation":  clientRemove,
+		"id":         rce.id,
+		"status":     rce.status,
+		"updated_at": rce.updatedAt,
+		"updated_by": rce.updatedBy,
+	}
+}
+
+type shareClientEvent struct {
+	thingID string
+	actions string
+	userIDs string
+}
+
+func (sce shareClientEvent) Encode() map[string]interface{} {
+	return map[string]interface{}{
+		"operation": clientShare,
+		"thing_id":  sce.thingID,
+		"actions":   sce.actions,
+		"user_ids":  sce.userIDs,
+	}
+}
+
+type viewClientEvent struct {
+	mfclients.Client
+}
+
+func (vce viewClientEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": clientView,
+		"id":        vce.ID,
+	}
+
+	if vce.Name != "" {
+		val["name"] = vce.Name
+	}
+	if len(vce.Tags) > 0 {
+		tags := fmt.Sprintf("[%s]", strings.Join(vce.Tags, ","))
+		val["tags"] = tags
+	}
+	if vce.Owner != "" {
+		val["owner"] = vce.Owner
+	}
+	if vce.Credentials.Identity != "" {
+		val["identity"] = vce.Credentials.Identity
+	}
+	if vce.Metadata != nil {
+		metadata, err := json.Marshal(vce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if vce.CreatedAt != (time.Time{}) {
+		val["created_at"] = vce.CreatedAt
+	}
+	if vce.UpdatedAt != (time.Time{}) {
+		val["updated_at"] = vce.UpdatedAt
+	}
+	if vce.UpdatedBy != "" {
+		val["updated_by"] = vce.UpdatedBy
+	}
+	if vce.Status.String() != "" {
+		val["status"] = vce.Status.String()
+	}
+
+	return val
+}
+
+type listClientEvent struct {
+	mfclients.Page
+}
+
+func (lce listClientEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": clientList,
+		"total":     lce.Total,
+		"offset":    lce.Offset,
+		"limit":     lce.Limit,
+	}
+
+	if lce.Name != "" {
+		val["name"] = lce.Name
+	}
+	if lce.Order != "" {
+		val["order"] = lce.Order
+	}
+	if lce.Dir != "" {
+		val["dir"] = lce.Dir
+	}
+	if lce.Metadata != nil {
+		metadata, err := json.Marshal(lce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if lce.Owner != "" {
+		val["owner"] = lce.Owner
+	}
+	if lce.Tag != "" {
+		val["tag"] = lce.Tag
+	}
+	if lce.SharedBy != "" {
+		val["sharedBy"] = lce.SharedBy
+	}
+	if lce.Status.String() != "" {
+		val["status"] = lce.Status.String()
+	}
+	if lce.Action != "" {
+		val["action"] = lce.Action
+	}
+	if lce.Subject != "" {
+		val["subject"] = lce.Subject
+	}
+	if lce.Identity != "" {
+		val["identity"] = lce.Identity
+	}
+
+	return val
+}
+
+type listClientByGroupEvent struct {
+	mfclients.Page
+	channelID string
+}
+
+func (lcge listClientByGroupEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation":  clientListByGroup,
+		"total":      lcge.Total,
+		"offset":     lcge.Offset,
+		"limit":      lcge.Limit,
+		"channel_id": lcge.channelID,
+	}
+
+	if lcge.Name != "" {
+		val["name"] = lcge.Name
+	}
+	if lcge.Order != "" {
+		val["order"] = lcge.Order
+	}
+	if lcge.Dir != "" {
+		val["dir"] = lcge.Dir
+	}
+	if lcge.Metadata != nil {
+		metadata, err := json.Marshal(lcge.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if lcge.Owner != "" {
+		val["owner"] = lcge.Owner
+	}
+	if lcge.Tag != "" {
+		val["tag"] = lcge.Tag
+	}
+	if lcge.SharedBy != "" {
+		val["sharedBy"] = lcge.SharedBy
+	}
+	if lcge.Status.String() != "" {
+		val["status"] = lcge.Status.String()
+	}
+	if lcge.Action != "" {
+		val["action"] = lcge.Action
+	}
+	if lcge.Subject != "" {
+		val["subject"] = lcge.Subject
+	}
+	if lcge.Identity != "" {
+		val["identity"] = lcge.Identity
+	}
+
+	return val
+}
+
+type identifyClientEvent struct {
+	thingID string
+}
+
+func (ice identifyClientEvent) Encode() map[string]interface{} {
+	return map[string]interface{}{
+		"operation": clientIdentify,
+		"thing_id":  ice.thingID,
 	}
 }

--- a/things/clients/redis/streams.go
+++ b/things/clients/redis/streams.go
@@ -5,6 +5,8 @@ package redis
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/go-redis/redis/v8"
 	mfclients "github.com/mainflux/mainflux/pkg/clients"
@@ -37,17 +39,15 @@ func (es eventStore) CreateThings(ctx context.Context, token string, thing ...mf
 	if err != nil {
 		return sths, err
 	}
+
 	for _, th := range sths {
 		event := createClientEvent{
-			id:       th.ID,
-			owner:    th.Owner,
-			name:     th.Name,
-			metadata: th.Metadata,
+			th,
 		}
 		record := &redis.XAddArgs{
-			Stream:       streamID,
-			MaxLenApprox: streamLen,
-			Values:       event.Encode(),
+			Stream: streamID,
+			MaxLen: streamLen,
+			Values: event.Encode(),
 		}
 		if err := es.client.XAdd(ctx, record).Err(); err != nil {
 			return sths, err
@@ -62,21 +62,7 @@ func (es eventStore) UpdateClient(ctx context.Context, token string, thing mfcli
 		return mfclients.Client{}, err
 	}
 
-	event := updateClientEvent{
-		id:       cli.ID,
-		name:     cli.Name,
-		metadata: cli.Metadata,
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return mfclients.Client{}, err
-	}
-
-	return cli, nil
+	return es.update(ctx, "", cli)
 }
 
 func (es eventStore) UpdateClientOwner(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
@@ -85,19 +71,7 @@ func (es eventStore) UpdateClientOwner(ctx context.Context, token string, thing 
 		return mfclients.Client{}, err
 	}
 
-	event := updateClientEvent{
-		owner: cli.Owner,
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return mfclients.Client{}, err
-	}
-
-	return cli, nil
+	return es.update(ctx, "owner", cli)
 }
 
 func (es eventStore) UpdateClientTags(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
@@ -106,8 +80,21 @@ func (es eventStore) UpdateClientTags(ctx context.Context, token string, thing m
 		return mfclients.Client{}, err
 	}
 
+	return es.update(ctx, "tags", cli)
+}
+
+func (es eventStore) UpdateClientSecret(ctx context.Context, token, id, key string) (mfclients.Client, error) {
+	cli, err := es.svc.UpdateClientSecret(ctx, token, id, key)
+	if err != nil {
+		return mfclients.Client{}, err
+	}
+
+	return es.update(ctx, "secret", cli)
+}
+
+func (es eventStore) update(ctx context.Context, operation string, cli mfclients.Client) (mfclients.Client, error) {
 	event := updateClientEvent{
-		tags: cli.Tags,
+		cli, operation,
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
@@ -121,27 +108,86 @@ func (es eventStore) UpdateClientTags(ctx context.Context, token string, thing m
 	return cli, nil
 }
 
-// UpdateClientSecret doesn't send event because key shouldn't be sent over stream.
-// Maybe we can start publishing this event at some point, without key value
-// in order to notify adapters to disconnect connected things after key update.
-func (es eventStore) UpdateClientSecret(ctx context.Context, token, id, key string) (mfclients.Client, error) {
-	return es.svc.UpdateClientSecret(ctx, token, id, key)
-}
-
 func (es eventStore) ShareClient(ctx context.Context, token, thingID string, actions, userIDs []string) error {
-	return es.svc.ShareClient(ctx, token, thingID, actions, userIDs)
+	if err := es.svc.ShareClient(ctx, token, thingID, actions, userIDs); err != nil {
+		return err
+	}
+	event := shareClientEvent{
+		thingID: thingID,
+		actions: fmt.Sprintf("[%s]", strings.Join(actions, ",")),
+		userIDs: fmt.Sprintf("[%s]", strings.Join(userIDs, ",")),
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (es eventStore) ViewClient(ctx context.Context, token, id string) (mfclients.Client, error) {
-	return es.svc.ViewClient(ctx, token, id)
+	cli, err := es.svc.ViewClient(ctx, token, id)
+	if err != nil {
+		return mfclients.Client{}, err
+	}
+	event := viewClientEvent{
+		cli,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return mfclients.Client{}, err
+	}
+
+	return cli, nil
 }
 
 func (es eventStore) ListClients(ctx context.Context, token string, pm mfclients.Page) (mfclients.ClientsPage, error) {
-	return es.svc.ListClients(ctx, token, pm)
+	cp, err := es.svc.ListClients(ctx, token, pm)
+	if err != nil {
+		return mfclients.ClientsPage{}, err
+	}
+	event := listClientEvent{
+		pm,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return mfclients.ClientsPage{}, err
+	}
+
+	return cp, nil
 }
 
 func (es eventStore) ListClientsByGroup(ctx context.Context, token, chID string, pm mfclients.Page) (mfclients.MembersPage, error) {
-	return es.svc.ListClientsByGroup(ctx, token, chID, pm)
+	cp, err := es.svc.ListClientsByGroup(ctx, token, chID, pm)
+	if err != nil {
+		return mfclients.MembersPage{}, err
+	}
+	event := listClientByGroupEvent{
+		pm, chID,
+	}
+
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return mfclients.MembersPage{}, err
+	}
+
+	return cp, nil
 }
 
 func (es eventStore) EnableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
@@ -150,19 +196,7 @@ func (es eventStore) EnableClient(ctx context.Context, token, id string) (mfclie
 		return mfclients.Client{}, err
 	}
 
-	event := removeClientEvent{
-		id: id,
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return mfclients.Client{}, err
-	}
-
-	return cli, nil
+	return es.delete(ctx, cli)
 }
 
 func (es eventStore) DisableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
@@ -171,8 +205,15 @@ func (es eventStore) DisableClient(ctx context.Context, token, id string) (mfcli
 		return mfclients.Client{}, err
 	}
 
+	return es.delete(ctx, cli)
+}
+
+func (es eventStore) delete(ctx context.Context, cli mfclients.Client) (mfclients.Client, error) {
 	event := removeClientEvent{
-		id: id,
+		id:        cli.ID,
+		updatedAt: cli.UpdatedAt,
+		updatedBy: cli.UpdatedBy,
+		status:    cli.Status.String(),
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
@@ -187,5 +228,21 @@ func (es eventStore) DisableClient(ctx context.Context, token, id string) (mfcli
 }
 
 func (es eventStore) Identify(ctx context.Context, key string) (string, error) {
-	return es.svc.Identify(ctx, key)
+	thingID, err := es.svc.Identify(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	event := identifyClientEvent{
+		thingID: thingID,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return "", err
+	}
+
+	return thingID, nil
 }

--- a/things/clients/redis/things.go
+++ b/things/clients/redis/things.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	keyPrefix = "thing_key"
-	idPrefix  = "thing"
+	idPrefix  = "thing_id"
 )
 
 var _ clients.ClientCache = (*thingCache)(nil)

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -218,6 +218,10 @@ func (svc service) DisableClient(ctx context.Context, token, id string) (mfclien
 		return mfclients.Client{}, errors.Wrap(mfclients.ErrDisableClient, err)
 	}
 
+	if err := svc.clientCache.Remove(ctx, client.ID); err != nil {
+		return client, err
+	}
+
 	return client, nil
 }
 

--- a/things/groups/postgres/groups.go
+++ b/things/groups/postgres/groups.go
@@ -317,7 +317,7 @@ func toDBGroup(g mfgroups.Group) (dbGroup, error) {
 		data = b
 	}
 	var updatedAt sql.NullTime
-	if g.UpdatedAt != (time.Time{}) {
+	if !g.UpdatedAt.IsZero() {
 		updatedAt = sql.NullTime{Time: g.UpdatedAt, Valid: true}
 	}
 	var updatedBy *string

--- a/things/groups/redis/doc.go
+++ b/things/groups/redis/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+// Package redis contains cache implementations using Redis as
+// the underlying database.
+package redis

--- a/things/groups/redis/events.go
+++ b/things/groups/redis/events.go
@@ -18,7 +18,7 @@ const (
 )
 
 type event interface {
-	Encode() map[string]interface{}
+	Encode() (map[string]interface{}, error)
 }
 
 var (
@@ -34,7 +34,7 @@ type createGroupEvent struct {
 	mfgroups.Group
 }
 
-func (cce createGroupEvent) Encode() map[string]interface{} {
+func (cce createGroupEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  groupCreate,
 		"id":         cce.ID,
@@ -57,7 +57,7 @@ func (cce createGroupEvent) Encode() map[string]interface{} {
 	if cce.Metadata != nil {
 		metadata, err := json.Marshal(cce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -68,14 +68,14 @@ func (cce createGroupEvent) Encode() map[string]interface{} {
 	if !cce.CreatedAt.IsZero() {
 		val["created_at"] = cce.CreatedAt
 	}
-	return val
+	return val, nil
 }
 
 type updateGroupEvent struct {
 	mfgroups.Group
 }
 
-func (uce updateGroupEvent) Encode() map[string]interface{} {
+func (uce updateGroupEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  groupUpdate,
 		"updated_at": uce.UpdatedAt,
@@ -100,7 +100,7 @@ func (uce updateGroupEvent) Encode() map[string]interface{} {
 	if uce.Metadata != nil {
 		metadata, err := json.Marshal(uce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -115,7 +115,7 @@ func (uce updateGroupEvent) Encode() map[string]interface{} {
 		val["status"] = uce.Status.String()
 	}
 
-	return val
+	return val, nil
 }
 
 type removeGroupEvent struct {
@@ -125,21 +125,21 @@ type removeGroupEvent struct {
 	updatedBy string
 }
 
-func (rce removeGroupEvent) Encode() map[string]interface{} {
+func (rce removeGroupEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"operation":  groupRemove,
 		"id":         rce.id,
 		"status":     rce.status,
 		"updated_at": rce.updatedAt,
 		"updated_by": rce.updatedBy,
-	}
+	}, nil
 }
 
 type viewGroupEvent struct {
 	mfgroups.Group
 }
 
-func (vce viewGroupEvent) Encode() map[string]interface{} {
+func (vce viewGroupEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": groupView,
 		"id":        vce.ID,
@@ -160,7 +160,7 @@ func (vce viewGroupEvent) Encode() map[string]interface{} {
 	if vce.Metadata != nil {
 		metadata, err := json.Marshal(vce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -178,14 +178,14 @@ func (vce viewGroupEvent) Encode() map[string]interface{} {
 		val["status"] = vce.Status.String()
 	}
 
-	return val
+	return val, nil
 }
 
 type listGroupEvent struct {
 	mfgroups.GroupsPage
 }
 
-func (lce listGroupEvent) Encode() map[string]interface{} {
+func (lce listGroupEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": groupList,
 		"total":     lce.Total,
@@ -205,7 +205,7 @@ func (lce listGroupEvent) Encode() map[string]interface{} {
 	if lce.Metadata != nil {
 		metadata, err := json.Marshal(lce.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -223,7 +223,7 @@ func (lce listGroupEvent) Encode() map[string]interface{} {
 		val["subject"] = lce.Subject
 	}
 
-	return val
+	return val, nil
 }
 
 type listGroupMembershipEvent struct {
@@ -231,7 +231,7 @@ type listGroupMembershipEvent struct {
 	channelID string
 }
 
-func (lcge listGroupMembershipEvent) Encode() map[string]interface{} {
+func (lcge listGroupMembershipEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  groupListMemberships,
 		"total":      lcge.Total,
@@ -252,7 +252,7 @@ func (lcge listGroupMembershipEvent) Encode() map[string]interface{} {
 	if lcge.Metadata != nil {
 		metadata, err := json.Marshal(lcge.Metadata)
 		if err != nil {
-			return val
+			return map[string]interface{}{}, err
 		}
 
 		val["metadata"] = metadata
@@ -270,5 +270,5 @@ func (lcge listGroupMembershipEvent) Encode() map[string]interface{} {
 		val["subject"] = lcge.Subject
 	}
 
-	return val
+	return val, nil
 }

--- a/things/groups/redis/events.go
+++ b/things/groups/redis/events.go
@@ -1,0 +1,274 @@
+package redis
+
+import (
+	"encoding/json"
+	"time"
+
+	mfgroups "github.com/mainflux/mainflux/pkg/groups"
+)
+
+const (
+	groupPrefix          = "channels."
+	groupCreate          = groupPrefix + "create"
+	groupUpdate          = groupPrefix + "update"
+	groupRemove          = groupPrefix + "remove"
+	groupView            = groupPrefix + "view"
+	groupList            = groupPrefix + "list"
+	groupListMemberships = groupPrefix + "list_by_group"
+)
+
+type event interface {
+	Encode() map[string]interface{}
+}
+
+var (
+	_ event = (*createGroupEvent)(nil)
+	_ event = (*updateGroupEvent)(nil)
+	_ event = (*removeGroupEvent)(nil)
+	_ event = (*viewGroupEvent)(nil)
+	_ event = (*listGroupEvent)(nil)
+	_ event = (*listGroupMembershipEvent)(nil)
+)
+
+type createGroupEvent struct {
+	mfgroups.Group
+}
+
+func (cce createGroupEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation":  groupCreate,
+		"id":         cce.ID,
+		"status":     cce.Status.String(),
+		"created_at": cce.CreatedAt,
+	}
+
+	if cce.Owner != "" {
+		val["owner"] = cce.Owner
+	}
+	if cce.Parent != "" {
+		val["parent"] = cce.Parent
+	}
+	if cce.Name != "" {
+		val["name"] = cce.Name
+	}
+	if cce.Description != "" {
+		val["description"] = cce.Description
+	}
+	if cce.Metadata != nil {
+		metadata, err := json.Marshal(cce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if cce.Status.String() != "" {
+		val["status"] = cce.Status.String()
+	}
+	if cce.CreatedAt != (time.Time{}) {
+		val["created_at"] = cce.CreatedAt
+	}
+	return val
+}
+
+type updateGroupEvent struct {
+	mfgroups.Group
+}
+
+func (uce updateGroupEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation":  groupUpdate,
+		"updated_at": uce.UpdatedAt,
+		"updated_by": uce.UpdatedBy,
+	}
+
+	if uce.ID != "" {
+		val["id"] = uce.ID
+	}
+	if uce.Owner != "" {
+		val["owner"] = uce.Owner
+	}
+	if uce.Parent != "" {
+		val["parent"] = uce.Parent
+	}
+	if uce.Name != "" {
+		val["name"] = uce.Name
+	}
+	if uce.Description != "" {
+		val["description"] = uce.Description
+	}
+	if uce.Metadata != nil {
+		metadata, err := json.Marshal(uce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if uce.CreatedAt != (time.Time{}) {
+		val["created_at"] = uce.CreatedAt
+	}
+	if uce.UpdatedAt != (time.Time{}) {
+		val["updated_at"] = uce.UpdatedAt
+	}
+	if uce.Status.String() != "" {
+		val["status"] = uce.Status.String()
+	}
+
+	return val
+}
+
+type removeGroupEvent struct {
+	id        string
+	status    string
+	updatedAt time.Time
+	updatedBy string
+}
+
+func (rce removeGroupEvent) Encode() map[string]interface{} {
+	return map[string]interface{}{
+		"operation":  groupRemove,
+		"id":         rce.id,
+		"status":     rce.status,
+		"updated_at": rce.updatedAt,
+		"updated_by": rce.updatedBy,
+	}
+}
+
+type viewGroupEvent struct {
+	mfgroups.Group
+}
+
+func (vce viewGroupEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": groupView,
+		"id":        vce.ID,
+	}
+
+	if vce.Owner != "" {
+		val["owner"] = vce.Owner
+	}
+	if vce.Parent != "" {
+		val["parent"] = vce.Parent
+	}
+	if vce.Name != "" {
+		val["name"] = vce.Name
+	}
+	if vce.Description != "" {
+		val["description"] = vce.Description
+	}
+	if vce.Metadata != nil {
+		metadata, err := json.Marshal(vce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if vce.CreatedAt != (time.Time{}) {
+		val["created_at"] = vce.CreatedAt
+	}
+	if vce.UpdatedAt != (time.Time{}) {
+		val["updated_at"] = vce.UpdatedAt
+	}
+	if vce.UpdatedBy != "" {
+		val["updated_by"] = vce.UpdatedBy
+	}
+	if vce.Status.String() != "" {
+		val["status"] = vce.Status.String()
+	}
+
+	return val
+}
+
+type listGroupEvent struct {
+	mfgroups.GroupsPage
+}
+
+func (lce listGroupEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": groupList,
+		"total":     lce.Total,
+		"offset":    lce.Offset,
+		"limit":     lce.Limit,
+	}
+
+	if lce.Name != "" {
+		val["name"] = lce.Name
+	}
+	if lce.OwnerID != "" {
+		val["owner_id"] = lce.OwnerID
+	}
+	if lce.Tag != "" {
+		val["tag"] = lce.Tag
+	}
+	if lce.Metadata != nil {
+		metadata, err := json.Marshal(lce.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if lce.SharedBy != "" {
+		val["sharedBy"] = lce.SharedBy
+	}
+	if lce.Status.String() != "" {
+		val["status"] = lce.Status.String()
+	}
+	if lce.Action != "" {
+		val["action"] = lce.Action
+	}
+	if lce.Subject != "" {
+		val["subject"] = lce.Subject
+	}
+
+	return val
+}
+
+type listGroupMembershipEvent struct {
+	mfgroups.GroupsPage
+	channelID string
+}
+
+func (lcge listGroupMembershipEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation":  groupListMemberships,
+		"total":      lcge.Total,
+		"offset":     lcge.Offset,
+		"limit":      lcge.Limit,
+		"channel_id": lcge.channelID,
+	}
+
+	if lcge.Name != "" {
+		val["name"] = lcge.Name
+	}
+	if lcge.OwnerID != "" {
+		val["owner_id"] = lcge.OwnerID
+	}
+	if lcge.Tag != "" {
+		val["tag"] = lcge.Tag
+	}
+	if lcge.Metadata != nil {
+		metadata, err := json.Marshal(lcge.Metadata)
+		if err != nil {
+			return val
+		}
+
+		val["metadata"] = metadata
+	}
+	if lcge.SharedBy != "" {
+		val["shared_by"] = lcge.SharedBy
+	}
+	if lcge.Status.String() != "" {
+		val["status"] = lcge.Status.String()
+	}
+	if lcge.Action != "" {
+		val["action"] = lcge.Action
+	}
+	if lcge.Subject != "" {
+		val["subject"] = lcge.Subject
+	}
+
+	return val
+}

--- a/things/groups/redis/events.go
+++ b/things/groups/redis/events.go
@@ -65,7 +65,7 @@ func (cce createGroupEvent) Encode() map[string]interface{} {
 	if cce.Status.String() != "" {
 		val["status"] = cce.Status.String()
 	}
-	if cce.CreatedAt != (time.Time{}) {
+	if !cce.CreatedAt.IsZero() {
 		val["created_at"] = cce.CreatedAt
 	}
 	return val
@@ -105,10 +105,10 @@ func (uce updateGroupEvent) Encode() map[string]interface{} {
 
 		val["metadata"] = metadata
 	}
-	if uce.CreatedAt != (time.Time{}) {
+	if !uce.CreatedAt.IsZero() {
 		val["created_at"] = uce.CreatedAt
 	}
-	if uce.UpdatedAt != (time.Time{}) {
+	if !uce.UpdatedAt.IsZero() {
 		val["updated_at"] = uce.UpdatedAt
 	}
 	if uce.Status.String() != "" {
@@ -165,10 +165,10 @@ func (vce viewGroupEvent) Encode() map[string]interface{} {
 
 		val["metadata"] = metadata
 	}
-	if vce.CreatedAt != (time.Time{}) {
+	if !vce.CreatedAt.IsZero() {
 		val["created_at"] = vce.CreatedAt
 	}
-	if vce.UpdatedAt != (time.Time{}) {
+	if !vce.UpdatedAt.IsZero() {
 		val["updated_at"] = vce.UpdatedAt
 	}
 	if vce.UpdatedBy != "" {

--- a/things/groups/redis/events.go
+++ b/things/groups/redis/events.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	groupPrefix          = "channels."
+	groupPrefix          = "channel."
 	groupCreate          = groupPrefix + "create"
 	groupUpdate          = groupPrefix + "update"
 	groupRemove          = groupPrefix + "remove"

--- a/things/groups/redis/streams.go
+++ b/things/groups/redis/streams.go
@@ -42,10 +42,14 @@ func (es eventStore) CreateGroups(ctx context.Context, token string, groups ...m
 		event := createGroupEvent{
 			group,
 		}
+		values, err := event.Encode()
+		if err != nil {
+			return gs, err
+		}
 		record := &redis.XAddArgs{
 			Stream: streamID,
 			MaxLen: streamLen,
-			Values: event.Encode(),
+			Values: values,
 		}
 		if err := es.client.XAdd(ctx, record).Err(); err != nil {
 			return gs, err
@@ -63,10 +67,14 @@ func (es eventStore) UpdateGroup(ctx context.Context, token string, group mfgrou
 	event := updateGroupEvent{
 		group,
 	}
+	values, err := event.Encode()
+	if err != nil {
+		return group, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return group, err
@@ -83,10 +91,14 @@ func (es eventStore) ViewGroup(ctx context.Context, token, id string) (mfgroups.
 	event := viewGroupEvent{
 		group,
 	}
+	values, err := event.Encode()
+	if err != nil {
+		return group, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return group, err
@@ -103,10 +115,14 @@ func (es eventStore) ListGroups(ctx context.Context, token string, pm mfgroups.G
 	event := listGroupEvent{
 		pm,
 	}
+	values, err := event.Encode()
+	if err != nil {
+		return gp, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return gp, err
@@ -123,11 +139,14 @@ func (es eventStore) ListMemberships(ctx context.Context, token, clientID string
 	event := listGroupMembershipEvent{
 		pm, clientID,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return mp, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return mp, err
@@ -161,10 +180,14 @@ func (es eventStore) delete(ctx context.Context, group mfgroups.Group) (mfgroups
 		updatedBy: group.UpdatedBy,
 		status:    group.Status.String(),
 	}
+	values, err := event.Encode()
+	if err != nil {
+		return group, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return group, err

--- a/things/groups/redis/streams.go
+++ b/things/groups/redis/streams.go
@@ -1,0 +1,174 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package redis
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v8"
+	mfgroups "github.com/mainflux/mainflux/pkg/groups"
+	"github.com/mainflux/mainflux/things/groups"
+)
+
+const (
+	streamID  = "mainflux.channels"
+	streamLen = 1000
+)
+
+var _ groups.Service = (*eventStore)(nil)
+
+type eventStore struct {
+	svc    groups.Service
+	client *redis.Client
+}
+
+// NewEventStoreMiddleware returns wrapper around things service that sends
+// events to event store.
+func NewEventStoreMiddleware(svc groups.Service, client *redis.Client) groups.Service {
+	return eventStore{
+		svc:    svc,
+		client: client,
+	}
+}
+
+func (es eventStore) CreateGroups(ctx context.Context, token string, groups ...mfgroups.Group) ([]mfgroups.Group, error) {
+	gs, err := es.svc.CreateGroups(ctx, token, groups...)
+	if err != nil {
+		return gs, err
+	}
+
+	for _, group := range gs {
+		event := createGroupEvent{
+			group,
+		}
+		record := &redis.XAddArgs{
+			Stream: streamID,
+			MaxLen: streamLen,
+			Values: event.Encode(),
+		}
+		if err := es.client.XAdd(ctx, record).Err(); err != nil {
+			return gs, err
+		}
+	}
+	return gs, nil
+}
+
+func (es eventStore) UpdateGroup(ctx context.Context, token string, group mfgroups.Group) (mfgroups.Group, error) {
+	group, err := es.svc.UpdateGroup(ctx, token, group)
+	if err != nil {
+		return mfgroups.Group{}, err
+	}
+
+	event := updateGroupEvent{
+		group,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return group, err
+	}
+
+	return group, nil
+}
+
+func (es eventStore) ViewGroup(ctx context.Context, token, id string) (mfgroups.Group, error) {
+	group, err := es.svc.ViewGroup(ctx, token, id)
+	if err != nil {
+		return mfgroups.Group{}, err
+	}
+	event := viewGroupEvent{
+		group,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return group, err
+	}
+
+	return group, nil
+}
+
+func (es eventStore) ListGroups(ctx context.Context, token string, pm mfgroups.GroupsPage) (mfgroups.GroupsPage, error) {
+	gp, err := es.svc.ListGroups(ctx, token, pm)
+	if err != nil {
+		return mfgroups.GroupsPage{}, err
+	}
+	event := listGroupEvent{
+		pm,
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return gp, err
+	}
+
+	return gp, nil
+}
+
+func (es eventStore) ListMemberships(ctx context.Context, token, clientID string, pm mfgroups.GroupsPage) (mfgroups.MembershipsPage, error) {
+	mp, err := es.svc.ListMemberships(ctx, token, clientID, pm)
+	if err != nil {
+		return mfgroups.MembershipsPage{}, err
+	}
+	event := listGroupMembershipEvent{
+		pm, clientID,
+	}
+
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return mp, err
+	}
+
+	return mp, nil
+}
+
+func (es eventStore) EnableGroup(ctx context.Context, token, id string) (mfgroups.Group, error) {
+	cli, err := es.svc.EnableGroup(ctx, token, id)
+	if err != nil {
+		return mfgroups.Group{}, err
+	}
+
+	return es.delete(ctx, cli)
+}
+
+func (es eventStore) DisableGroup(ctx context.Context, token, id string) (mfgroups.Group, error) {
+	cli, err := es.svc.DisableGroup(ctx, token, id)
+	if err != nil {
+		return mfgroups.Group{}, err
+	}
+
+	return es.delete(ctx, cli)
+}
+
+func (es eventStore) delete(ctx context.Context, group mfgroups.Group) (mfgroups.Group, error) {
+	event := removeGroupEvent{
+		id:        group.ID,
+		updatedAt: group.UpdatedAt,
+		updatedBy: group.UpdatedBy,
+		status:    group.Status.String(),
+	}
+	record := &redis.XAddArgs{
+		Stream:       streamID,
+		MaxLenApprox: streamLen,
+		Values:       event.Encode(),
+	}
+	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		return group, err
+	}
+
+	return group, nil
+}

--- a/things/groups/redis/streams.go
+++ b/things/groups/redis/streams.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	streamID  = "mainflux.channels"
+	streamID  = "mainflux.things"
 	streamLen = 1000
 )
 

--- a/things/policies/redis/events.go
+++ b/things/policies/redis/events.go
@@ -1,35 +1,109 @@
 package redis
 
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mainflux/mainflux/things/policies"
+)
+
 const (
-	policyPrefix   = "policy."
-	authorize      = policyPrefix + "authorize"
-	authorizeByKey = policyPrefix + "authorizebykey"
-	addPolicy      = policyPrefix + "add"
-	updatePolicy   = policyPrefix + "update"
-	listPolicy     = policyPrefix + "list"
-	deletePolicy   = policyPrefix + "delete"
+	policyPrefix = "policies."
+	authorize    = policyPrefix + "authorize"
+	policyAdd    = policyPrefix + "add"
+	policyUpdate = policyPrefix + "update"
+	policyList   = policyPrefix + "list"
+	policyDelete = policyPrefix + "delete"
 )
 
 type event interface {
-	Encode(operation string) map[string]interface{}
+	Encode() map[string]interface{}
 }
 
 var (
 	_ event = (*policyEvent)(nil)
+	_ event = (*authorizeEvent)(nil)
+	_ event = (*listPoliciesEvent)(nil)
 )
 
 type policyEvent struct {
-	entityType string
-	clientID   string
-	groupID    string
-	actions    []string
+	policies.Policy
+	operation string
 }
 
-func (cte policyEvent) Encode(operation string) map[string]interface{} {
-	return map[string]interface{}{
-		"group_id":  cte.groupID,
-		"client_id": cte.clientID,
-		"actions":   cte.actions,
-		"operation": operation,
+func (pe policyEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": pe.operation,
 	}
+	if pe.OwnerID != "" {
+		val["owner_id"] = pe.OwnerID
+	}
+	if pe.Subject != "" {
+		val["subject"] = pe.Subject
+	}
+	if pe.Object != "" {
+		val["object"] = pe.Object
+	}
+	if len(pe.Actions) > 0 {
+		actions := fmt.Sprintf("[%s]", strings.Join(pe.Actions, ","))
+		val["actions"] = actions
+	}
+	if pe.CreatedAt != (time.Time{}) {
+		val["created_at"] = pe.CreatedAt
+	}
+	if pe.UpdatedAt != (time.Time{}) {
+		val["updated_at"] = pe.UpdatedAt
+	}
+	if pe.UpdatedBy != "" {
+		val["updated_by"] = pe.UpdatedBy
+	}
+	return val
+}
+
+type authorizeEvent struct {
+	policies.AccessRequest
+	entityType string
+}
+
+func (ae authorizeEvent) Encode() map[string]interface{} {
+	// We don't want to send the key over the stream, so we don't send the subject.
+	val := map[string]interface{}{
+		"operation":   authorize,
+		"entity_type": ae.entityType,
+	}
+
+	if ae.Object != "" {
+		val["object"] = ae.Object
+	}
+	if ae.Action != "" {
+		val["actions"] = ae.Action
+	}
+	return val
+}
+
+type listPoliciesEvent struct {
+	policies.Page
+}
+
+func (ae listPoliciesEvent) Encode() map[string]interface{} {
+	val := map[string]interface{}{
+		"operation": policyList,
+		"total":     ae.Total,
+		"limit":     ae.Limit,
+		"offset":    ae.Offset,
+	}
+	if ae.OwnerID != "" {
+		val["owner_id"] = ae.OwnerID
+	}
+	if ae.Subject != "" {
+		val["subject"] = ae.Subject
+	}
+	if ae.Object != "" {
+		val["object"] = ae.Object
+	}
+	if ae.Action != "" {
+		val["action"] = ae.Action
+	}
+	return val
 }

--- a/things/policies/redis/events.go
+++ b/things/policies/redis/events.go
@@ -17,7 +17,7 @@ const (
 )
 
 type event interface {
-	Encode() map[string]interface{}
+	Encode() (map[string]interface{}, error)
 }
 
 var (
@@ -31,7 +31,7 @@ type policyEvent struct {
 	operation string
 }
 
-func (pe policyEvent) Encode() map[string]interface{} {
+func (pe policyEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": pe.operation,
 	}
@@ -57,7 +57,7 @@ func (pe policyEvent) Encode() map[string]interface{} {
 	if pe.UpdatedBy != "" {
 		val["updated_by"] = pe.UpdatedBy
 	}
-	return val
+	return val, nil
 }
 
 type authorizeEvent struct {
@@ -65,7 +65,7 @@ type authorizeEvent struct {
 	entityType string
 }
 
-func (ae authorizeEvent) Encode() map[string]interface{} {
+func (ae authorizeEvent) Encode() (map[string]interface{}, error) {
 	// We don't want to send the key over the stream, so we don't send the subject.
 	val := map[string]interface{}{
 		"operation":   authorize,
@@ -78,14 +78,14 @@ func (ae authorizeEvent) Encode() map[string]interface{} {
 	if ae.Action != "" {
 		val["actions"] = ae.Action
 	}
-	return val
+	return val, nil
 }
 
 type listPoliciesEvent struct {
 	policies.Page
 }
 
-func (ae listPoliciesEvent) Encode() map[string]interface{} {
+func (ae listPoliciesEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": policyList,
 		"total":     ae.Total,
@@ -104,5 +104,5 @@ func (ae listPoliciesEvent) Encode() map[string]interface{} {
 	if ae.Action != "" {
 		val["action"] = ae.Action
 	}
-	return val
+	return val, nil
 }

--- a/things/policies/redis/events.go
+++ b/things/policies/redis/events.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/mainflux/mainflux/things/policies"
 )
@@ -49,10 +48,10 @@ func (pe policyEvent) Encode() map[string]interface{} {
 		actions := fmt.Sprintf("[%s]", strings.Join(pe.Actions, ","))
 		val["actions"] = actions
 	}
-	if pe.CreatedAt != (time.Time{}) {
+	if !pe.CreatedAt.IsZero() {
 		val["created_at"] = pe.CreatedAt
 	}
-	if pe.UpdatedAt != (time.Time{}) {
+	if !pe.UpdatedAt.IsZero() {
 		val["updated_at"] = pe.UpdatedAt
 	}
 	if pe.UpdatedBy != "" {

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	streamID  = "mainflux.things.policies"
+	streamID  = "mainflux.things"
 	streamLen = 1000
 )
 

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -40,11 +40,14 @@ func (es eventStore) Authorize(ctx context.Context, ar policies.AccessRequest, e
 	event := authorizeEvent{
 		ar, entity,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return id, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return id, err
@@ -62,14 +65,17 @@ func (es eventStore) AddPolicy(ctx context.Context, token string, policy policie
 	event := policyEvent{
 		policy, policyAdd,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return policy, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return policies.Policy{}, err
+		return policy, err
 	}
 
 	return policy, nil
@@ -84,14 +90,17 @@ func (es eventStore) UpdatePolicy(ctx context.Context, token string, policy poli
 	event := policyEvent{
 		policy, policyUpdate,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return policy, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return policies.Policy{}, err
+		return policy, err
 	}
 
 	return policy, nil
@@ -106,14 +115,17 @@ func (es eventStore) ListPolicies(ctx context.Context, token string, page polici
 	event := listPoliciesEvent{
 		page,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return policypage, err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return policies.PolicyPage{}, err
+		return policypage, err
 	}
 
 	return policypage, nil
@@ -127,11 +139,14 @@ func (es eventStore) DeletePolicy(ctx context.Context, token string, policy poli
 	event := policyEvent{
 		policy, policyDelete,
 	}
-
+	values, err := event.Encode()
+	if err != nil {
+		return err
+	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
-		Values:       event.Encode(),
+		Values:       values,
 	}
 	if err := es.client.XAdd(ctx, record).Err(); err != nil {
 		return err

--- a/users/clients/postgres/clients.go
+++ b/users/clients/postgres/clients.go
@@ -346,7 +346,7 @@ func toDBClient(c mfclients.Client) (dbClient, error) {
 		updatedBy = &c.UpdatedBy
 	}
 	var updatedAt sql.NullTime
-	if c.UpdatedAt != (time.Time{}) {
+	if !c.UpdatedAt.IsZero() {
 		updatedAt = sql.NullTime{Time: c.UpdatedAt, Valid: true}
 	}
 

--- a/users/groups/postgres/groups.go
+++ b/users/groups/postgres/groups.go
@@ -334,7 +334,7 @@ func toDBGroup(g mfgroups.Group) (dbGroup, error) {
 		parentID = &g.Parent
 	}
 	var updatedAt sql.NullTime
-	if g.UpdatedAt != (time.Time{}) {
+	if !g.UpdatedAt.IsZero() {
 		updatedAt = sql.NullTime{Time: g.UpdatedAt, Valid: true}
 	}
 	var updatedBy *string

--- a/users/policies/postgres/policies.go
+++ b/users/policies/postgres/policies.go
@@ -221,7 +221,7 @@ func toDBPolicy(p policies.Policy) (dbPolicy, error) {
 		return dbPolicy{}, err
 	}
 	var updatedAt sql.NullTime
-	if p.UpdatedAt != (time.Time{}) {
+	if !p.UpdatedAt.IsZero() {
 		updatedAt = sql.NullTime{Time: p.UpdatedAt, Valid: true}
 	}
 	var updatedBy *string


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?
1. It enables event sourcing for things service. This for all service operations in the clients, groups and policies domain

![image](https://github.com/mainflux/mainflux/assets/28790446/e96bd449-3f3d-4572-9fe3-57dad64e0634)

2. It fixes error on Authorization when publishing message on HTTP adapter endpoint

![image](https://github.com/mainflux/mainflux/assets/28790446/dcceef77-c0fd-4e61-816f-e446e6716ffd)

3. It removed timestamp on mqtt events as the timestamps are generated automatically and they can be referenced using the `id` field

![image](https://github.com/mainflux/mainflux/assets/28790446/51fc1964-b266-4730-8c4b-1d04c4160bf6)

4. Enabled event sourcing for changing things secret but we don't send the secret over the wire.

### Which issue(s) does this PR fix/relate to?
Noissue

### List any changes that modify/break current functionality
Listed above.

### Have you included tests for your changes?
Manually tested with the attached screenshots

### Did you document any new/modified functionality?
No

### Notes
N/A