### PR TITLE
MF-1783 - Improve HTTP / gRPC codes when attempting to publish with nonexistent thing key / channel id

### DIFF
--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -78,7 +78,7 @@ func parseSubtopic(subtopic string) (string, error) {
 	if err != nil {
 		return "", errMalformedSubtopic
 	}
-	subtopic = strings.Replace(subtopic, "/", ".", -1)
+	subtopic = strings.ReplaceAll(subtopic, "/", ".")
 
 	elems := strings.Split(subtopic, ".")
 	filteredElems := []string{}

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -16,7 +16,6 @@ import (
 	kitot "github.com/go-kit/kit/tracing/opentracing"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/go-zoo/bone"
-	"github.com/hashicorp/go-uuid"
 	"github.com/mainflux/mainflux"
 	adapter "github.com/mainflux/mainflux/http"
 	"github.com/mainflux/mainflux/internal/apiutil"
@@ -122,10 +121,6 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	case !ok:
 		token = apiutil.ExtractThingKey(r)
 	}
-	_, err = uuid.ParseUUID(token)
-	if err != nil {
-		return nil, errors.ErrMalformedEntity
-	}
 
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -133,16 +128,10 @@ func decodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	}
 	defer r.Body.Close()
 
-	channel := bone.GetValue(r, "chanID")
-	_, err = uuid.ParseUUID(channel)
-	if err != nil {
-		return nil, errors.ErrMalformedEntity
-	}
-
 	req := publishReq{
 		msg: &messaging.Message{
 			Protocol: protocol,
-			Channel:  channel,
+			Channel:  bone.GetValue(r, "chanID"),
 			Subtopic: subtopic,
 			Payload:  payload,
 			Created:  time.Now().UnixNano(),

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -171,6 +171,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 				w.WriteHeader(http.StatusForbidden)
 			case codes.Internal:
 				w.WriteHeader(http.StatusInternalServerError)
+			case codes.NotFound:
+				w.WriteHeader(http.StatusNotFound)
 			default:
 				w.WriteHeader(http.StatusInternalServerError)
 			}

--- a/things/api/auth/grpc/server.go
+++ b/things/api/auth/grpc/server.go
@@ -137,6 +137,9 @@ func encodeError(err error) error {
 	case errors.ErrNotFound:
 		return status.Error(codes.NotFound, "entity does not exist")
 	default:
+		if errors.Contains(err, errors.ErrNotFound) || errors.Contains(err, errors.ErrViewEntity) {
+			return status.Error(codes.NotFound, "entity does not exist")
+		}
 		return status.Error(codes.Internal, "internal server error")
 	}
 }


### PR DESCRIPTION
### What does this do?
Improves error reports for invalid channels and things.

### Which issue(s) does this PR fix/relate to?
Resolves #1783 

### List any changes that modify/break current functionality
Non-existent channel id and thing key returned 500 internal error which is now switched to 404 not found.

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
