### PR TITLE
NOISSUE - Add More Functions to SDK

### DIFF
--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -5,6 +5,7 @@ package producer_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"strconv"
@@ -576,6 +577,23 @@ func test(t *testing.T, expected, actual map[string]interface{}, description str
 
 		delete(expected, "timestamp")
 		delete(actual, "timestamp")
+
+		ech := expected["channels"]
+		ach := actual["channels"]
+
+		che := []int{}
+		err = json.Unmarshal([]byte(ech.(string)), &che)
+		require.Nil(t, err, fmt.Sprintf("%s: expected to get a valid channels, got %s", description, err))
+
+		cha := []int{}
+		err = json.Unmarshal([]byte(ach.(string)), &cha)
+		require.Nil(t, err, fmt.Sprintf("%s: expected to get a valid channels, got %s", description, err))
+
+		if assert.ElementsMatchf(t, che, cha, "%s: got incorrect channels\n", description) {
+			delete(expected, "channels")
+			delete(actual, "channels")
+		}
+
 		assert.Equal(t, expected, actual, fmt.Sprintf("%s: got incorrect event\n", description))
 	}
 }

--- a/cli/channels.go
+++ b/cli/channels.go
@@ -118,7 +118,6 @@ var cmdChannels = []cobra.Command{
 			pm := mfxsdk.PageMetadata{
 				Offset:       uint64(Offset),
 				Limit:        uint64(Limit),
-				Disconnected: false,
 			}
 			cl, err := sdk.ThingsByChannel(args[0], pm, args[1])
 			if err != nil {

--- a/cli/groups.go
+++ b/cli/groups.go
@@ -167,21 +167,15 @@ var cmdGroups = []cobra.Command{
 		},
 	},
 	{
-		Use:   "unassign <member_type> <group_id> <member_id> <user_auth_token>",
+		Use:   "unassign <member_id> <group_id> <user_auth_token>",
 		Short: "Unassign member",
-		Long: `Unassign members from a group
-				member_ids - '["member_id",...]`,
+		Long:  `Unassign members from a group`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 4 {
 				logUsage(cmd.Use)
 				return
 			}
-			var types []string
-			if err := json.Unmarshal([]byte(args[0]), &types); err != nil {
-				logError(err)
-				return
-			}
-			if err := sdk.Unassign(types, args[1], args[2], args[3]); err != nil {
+			if err := sdk.Unassign(args[0], args[1], args[2]); err != nil {
 				logError(err)
 				return
 			}

--- a/cli/groups.go
+++ b/cli/groups.go
@@ -15,16 +15,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "create <JSON_group> <user_auth_token>",
 		Short: "Create group",
-		Long: `Creates new group:
-		{
-			"Name":<group_name>,
-			"Description":<description>,
-			"ParentID":<parent_id>,
-			"Metadata":<metadata>,
-		}
-		Name - is unique group name
-		ParentID - ID of a group that is a parent to the creating group
-		Metadata - JSON structured string`,
+		Long: "Creates new group\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups create '{\"name\":\"new group\", \"description\":\"new group description\", \"metadata\":{\"key\": \"value\"}}' $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -47,7 +40,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "update <JSON_group> <user_auth_token>",
 		Short: "Update group",
-		Long:  `Updates group record`,
+		Long: "Updates group\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups update '{\"id\":\"<group_id>\", \"name\":\"new group\", \"description\":\"new group description\", \"metadata\":{\"key\": \"value\"}}' $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -60,22 +55,24 @@ var cmdGroups = []cobra.Command{
 				return
 			}
 
-			if _, err := sdk.UpdateGroup(group, args[1]); err != nil {
+			group, err := sdk.UpdateGroup(group, args[1])
+			if err != nil {
 				logError(err)
 				return
 			}
 
-			logOK()
+			logJSON(group)
 		},
 	},
 	{
 		Use:   "get [all | children <group_id> | parents <group_id> | members <group_id> | <group_id>] <user_auth_token>",
 		Short: "Get group",
-		Long: `Get all users groups, group children or group by id.
-		all - lists all groups
-		children <group_id> - lists all children groups of <group_id>
-		members <group_id> - shows members of the provided group ID
-		<group_id> - shows group with provided group ID`,
+		Long: "Get all users groups, group children or group by id.\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups get all $USERTOKEN - lists all groups\n" +
+			"\tmainflux-cli groups get children <group_id> $USERTOKEN - lists all children groups of <group_id>\n" +
+			"\tmainflux-cli groups get parents <group_id> $USERTOKEN - lists all parent groups of <group_id>\n" +
+			"\tmainflux-cli groups get <group_id> $USERTOKEN - shows group with provided group ID\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 2 {
 				logUsage(cmd.Use)
@@ -145,21 +142,22 @@ var cmdGroups = []cobra.Command{
 		},
 	},
 	{
-		Use:   "assign <member_type> <member_id> <group_id> <user_auth_token>",
+		Use:   "assign <allowed_actions> <member_id> <group_id> <user_auth_token>",
 		Short: "Assign member",
-		Long: `Assign members to a group.
-				member_ids - '["member_id",...]`,
+		Long: "Assign members to a group\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups assign '[\"<allowed_action>\", \"<allowed_action>\"]' <member_id> <group_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 4 {
 				logUsage(cmd.Use)
 				return
 			}
-			var types []string
-			if err := json.Unmarshal([]byte(args[0]), &types); err != nil {
+			var actions []string
+			if err := json.Unmarshal([]byte(args[0]), &actions); err != nil {
 				logError(err)
 				return
 			}
-			if err := sdk.Assign(types, args[1], args[2], args[3]); err != nil {
+			if err := sdk.Assign(actions, args[1], args[2], args[3]); err != nil {
 				logError(err)
 				return
 			}
@@ -169,7 +167,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "unassign <member_id> <group_id> <user_auth_token>",
 		Short: "Unassign member",
-		Long:  `Unassign members from a group`,
+		Long: "Unassign member from a group\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups unassign <member_id> <group_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 4 {
 				logUsage(cmd.Use)
@@ -185,7 +185,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "members <group_id> <user_auth_token>",
 		Short: "Members list",
-		Long:  `Lists all members of a group.`,
+		Long: "List group's members\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups members <group_id> $USERTOKEN",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -207,7 +209,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "membership <member_id> <user_auth_token>",
 		Short: "Membership list",
-		Long:  `List member group's membership`,
+		Long: "List memberships of a member\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups membership <member_id> $USERTOKEN",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -228,7 +232,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "enable <group_id> <user_auth_token>",
 		Short: "Change group status to enabled",
-		Long:  `Change group status to enabled`,
+		Long: "Change group status to enabled\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups enable <group_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -247,7 +253,9 @@ var cmdGroups = []cobra.Command{
 	{
 		Use:   "disable <group_id> <user_auth_token>",
 		Short: "Change group status to disabled",
-		Long:  `Change group status to disabled`,
+		Long: "Change group status to disabled\n" +
+			"Usage:\n" +
+			"\tmainflux-cli groups disable <group_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)

--- a/cli/policies.go
+++ b/cli/policies.go
@@ -14,12 +14,9 @@ var cmdPolicies = []cobra.Command{
 	{
 		Use:   "create <JSON_policy> <user_auth_token>",
 		Short: "Create policy",
-		Long: `Create new policy:
-				{
-					"Object":<object>,
-					"Subjects":[<subject1>, ...],
-					"Policies":[<policy1>, ...],
-				}`,
+		Long: "Create a new policy\n" +
+			"Usage:\n" +
+			"\tmainflux-cli policies create '{\"object\":\"<group_id>\", \"subject\":\"<user_id>\",\"actions\":[\"c_list\"]}' $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -40,14 +37,80 @@ var cmdPolicies = []cobra.Command{
 		},
 	},
 	{
+		Use:   "update [ <JSON_policy> | things <JSON_policy> ] <user_auth_token>",
+		Short: "Update policy",
+		Long: "Update policy\n" +
+			"Usage:\n" +
+			"\tmainflux-cli policies update '{\"object\":\"<group_id>\", \"subject\":\"<user_id>\",\"actions\":[\"c_list\"]}' $USERTOKEN\n" +
+			"\tmainflux-cli policies update things '{\"object\":\"<channel_id>\", \"subject\":\"<thing_id>\",\"actions\":[\"m_write\"]}' $USERTOKEN\n",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 2 && len(args) != 3 {
+				logUsage(cmd.Use)
+				return
+			}
+
+			var policy mfxsdk.Policy
+			if err := json.Unmarshal([]byte(args[0]), &policy); err != nil {
+				logError(err)
+				return
+			}
+			if args[0] == "things" {
+				if err := sdk.UpdateThingsPolicy(policy, args[2]); err != nil {
+					logError(err)
+					return
+				}
+			}
+			if err := sdk.UpdatePolicy(policy, args[1]); err != nil {
+				logError(err)
+				return
+			}
+
+			logOK()
+		},
+	},
+	{
+		Use:   "list [ users | things ] <user_auth_token>",
+		Short: "List policies",
+		Long: "List policies\n" +
+			"Usage:\n" +
+			"\tmainflux-cli policies list users $USERTOKEN\n" +
+			"\tmainflux-cli policies list things $USERTOKEN\n",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 2 {
+				logUsage(cmd.Use)
+				return
+			}
+			pm := mfxsdk.PageMetadata{
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
+			}
+			if args[0] == "things" {
+				policies, err := sdk.ListThingsPolicies(pm, args[1])
+				if err != nil {
+					logError(err)
+					return
+				}
+				logJSON(policies)
+				return
+			}
+			if args[0] == "users" {
+				policies, err := sdk.ListPolicies(pm, args[0])
+				if err != nil {
+					logError(err)
+					return
+				}
+
+				logJSON(policies)
+				return
+			}
+		},
+	},
+	{
 		Use:   "remove <JSON_policy> <user_auth_token>",
 		Short: "Remove policy",
-		Long: `Removes removes a policy with the provided object and subject
-				{
-					"Object":<object>,
-					"Subjects":[<subject1>, ...],
-					"Policies":[<policy1>, ...],
-				}`,
+		Long: "Removes a policy with the provided object and subject\n" +
+			"Usage:\n" +
+			"\tmainflux-cli policies remove '{\"object\":\"<group_id>\", \"subject\":\"<user_id>\"}' $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -72,9 +135,9 @@ var cmdPolicies = []cobra.Command{
 // NewPolicyCmd returns policies command.
 func NewPolicyCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "policies [create | remove ]",
+		Use:   "policies [create | update | list | remove ]",
 		Short: "Policies management",
-		Long:  `Policies management: create or delete policies`,
+		Long:  `Policies management: create or update or list or delete policies`,
 	}
 
 	for i := range cmdPolicies {

--- a/cli/things.go
+++ b/cli/things.go
@@ -302,7 +302,6 @@ var cmdThings = []cobra.Command{
 			pm := mfxsdk.PageMetadata{
 				Offset:       uint64(Offset),
 				Limit:        uint64(Limit),
-				Disconnected: false,
 			}
 			cl, err := sdk.ChannelsByThing(args[0], pm, args[1])
 			if err != nil {

--- a/cli/things.go
+++ b/cli/things.go
@@ -15,7 +15,9 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "create <JSON_thing> <user_auth_token>",
 		Short: "Create thing",
-		Long:  `Create new thing, generate his UUID and store it`,
+		Long: "Creates new thing with provided name and metadata\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things create '{\"name\":\"new thing\", \"metadata\":{\"key\": \"value\"}}' $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -40,9 +42,11 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "get [all | <thing_id>] <user_auth_token>",
 		Short: "Get things",
-		Long: `Get all things or get thing by id. Things can be filtered by name or metadata
-		all - lists all things
-		<thing_id> - shows thing with provided <thing_id>`,
+		Long: "Get all things or get thing by id. Things can be filtered by name or metadata\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things get all $USERTOKEN - lists all things\n" +
+			"\tmainflux-cli things get all $USERTOKEN --offset=10 --limit=10 - lists all things with offset and limit\n" +
+			"\tmainflux-cli things get <thing_id> $USERTOKEN - shows thing with provided <thing_id>\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -80,7 +84,9 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "identify <thing_key>",
 		Short: "Identify thing",
-		Long:  "Validates thing's key and returns its ID",
+		Long: "Validates thing's key and returns its ID\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things identify <thing_key>\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				logUsage(cmd.Use)
@@ -97,16 +103,61 @@ var cmdThings = []cobra.Command{
 		},
 	},
 	{
-		Use:   "update [<JSON_string> | key <thing_id> <thing_key>] <user_auth_token>",
+		Use:   "update [<thing_id> <JSON_string> | tags <thing_id> <tags> | secret <thing_id> <secret> | owner <thing_id> <owner> ] <user_auth_token>",
 		Short: "Update thing",
-		Long:  `Update thing record`,
+		Long: "Updates thing with provided id, name and metadata, or updates thing tags, secret or owner\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things update <thing_id> '{\"name\":\"new name\", \"metadata\":{\"key\": \"value\"}}' $USERTOKEN\n" +
+			"\tmainflux-cli things update tags <thing_id> '{\"tag1\":\"value1\", \"tag2\":\"value2\"}' $USERTOKEN\n" +
+			"\tmainflux-cli things update secret <thing_id> newsecret $USERTOKEN\n" +
+			"\tmainflux-cli things update owner <thing_id> <owner_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
+			if len(args) != 4 && len(args) != 3 {
 				logUsage(cmd.Use)
 				return
 			}
 
 			var thing mfxsdk.Thing
+			if args[0] == "tags" {
+				if err := json.Unmarshal([]byte(args[2]), &thing.Tags); err != nil {
+					logError(err)
+					return
+				}
+				thing.ID = args[1]
+				thing, err := sdk.UpdateThingTags(thing, args[3])
+				if err != nil {
+					logError(err)
+					return
+				}
+
+				logJSON(thing)
+				return
+			}
+
+			if args[0] == "secret" {
+				thing, err := sdk.UpdateThingSecret(args[1], args[2], args[3])
+				if err != nil {
+					logError(err)
+					return
+				}
+
+				logJSON(thing)
+				return
+			}
+
+			if args[0] == "owner" {
+				thing.ID = args[1]
+				thing.Owner = args[2]
+				thing, err := sdk.UpdateThingOwner(thing, args[3])
+				if err != nil {
+					logError(err)
+					return
+				}
+
+				logJSON(thing)
+				return
+			}
+
 			if err := json.Unmarshal([]byte(args[1]), &thing); err != nil {
 				logError(err)
 				return
@@ -122,78 +173,11 @@ var cmdThings = []cobra.Command{
 		},
 	},
 	{
-		Use:   "update tags <thing_id> <tags> <user_auth_token>",
-		Short: "Update thing tags",
-		Long:  `Update thing record`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
-				logUsage(cmd.Use)
-				return
-			}
-
-			var thing mfxsdk.Thing
-			if err := json.Unmarshal([]byte(args[1]), &thing.Tags); err != nil {
-				logError(err)
-				return
-			}
-			thing.ID = args[0]
-			thing, err := sdk.UpdateThingTags(thing, args[2])
-			if err != nil {
-				logError(err)
-				return
-			}
-
-			logJSON(thing)
-		},
-	},
-	{
-		Use:   "update secret <thing_id> <secret> <user_auth_token>",
-		Short: "Update thing tags",
-		Long:  `Update thing record`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
-				logUsage(cmd.Use)
-				return
-			}
-
-			thing, err := sdk.UpdateThingSecret(args[0], args[1], args[2])
-			if err != nil {
-				logError(err)
-				return
-			}
-
-			logJSON(thing)
-		},
-	},
-	{
-		Use:   "update owner <thing_id> <tags> <user_auth_token>",
-		Short: "Update thing owner",
-		Long:  `Update thing record`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 3 {
-				logUsage(cmd.Use)
-				return
-			}
-
-			var thing mfxsdk.Thing
-			if err := json.Unmarshal([]byte(args[1]), &thing.Owner); err != nil {
-				logError(err)
-				return
-			}
-			thing.ID = args[0]
-			thing, err := sdk.UpdateThingOwner(thing, args[2])
-			if err != nil {
-				logError(err)
-				return
-			}
-
-			logJSON(thing)
-		},
-	},
-	{
 		Use:   "enable <thing_id> <user_auth_token>",
 		Short: "Change thing status to enabled",
-		Long:  `Change thing status to enabled`,
+		Long: "Change thing status to enabled\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things enable <thing_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -212,7 +196,9 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "disable <thing_id> <user_auth_token>",
 		Short: "Change thing status to disabled",
-		Long:  `Change thing status to disabled`,
+		Long: "Change thing status to disabled\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things disable <thing_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -229,9 +215,37 @@ var cmdThings = []cobra.Command{
 		},
 	},
 	{
+		Use:   "share <thing_id> <group_id> <user_id> <allowed_actions> <user_auth_token>",
+		Short: "Share thing with a user",
+		Long: "Share thing with a user\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things share <thing_id> <group_id> <user_id> '[\"c_list\", \"c_delete\"]' $USERTOKEN\n",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 5 {
+				logUsage(cmd.Use)
+				return
+			}
+			var actions []string
+			if err := json.Unmarshal([]byte(args[3]), &actions); err != nil {
+				logError(err)
+				return
+			}
+
+			err := sdk.ShareThing(args[0], args[1], args[2], actions, args[4])
+			if err != nil {
+				logError(err)
+				return
+			}
+
+			logOK()
+		},
+	},
+	{
 		Use:   "connect <thing_id> <channel_id> <user_auth_token>",
 		Short: "Connect thing",
-		Long:  `Connect thing to the channel`,
+		Long: "Connect thing to the channel\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things connect <thing_id> <channel_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 3 {
 				logUsage(cmd.Use)
@@ -253,7 +267,9 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "disconnect <thing_id> <channel_id> <user_auth_token>",
 		Short: "Disconnect thing",
-		Long:  `Disconnect thing to the channel`,
+		Long: "Disconnect thing to the channel\n" +
+			"Usage:\n" +
+			"\tmainflux-cli things disconnect <thing_id> <channel_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 3 {
 				logUsage(cmd.Use)
@@ -275,7 +291,9 @@ var cmdThings = []cobra.Command{
 	{
 		Use:   "connections <thing_id> <user_auth_token>",
 		Short: "Connected list",
-		Long:  `List of Channels connected to Thing`,
+		Long: "List of Channels connected to Thing\n" +
+			"Usage:\n" +
+			"\tmainflux-cli connections <thing_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
 				logUsage(cmd.Use)
@@ -300,9 +318,9 @@ var cmdThings = []cobra.Command{
 // NewThingsCmd returns things command.
 func NewThingsCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "things [create | get | update | delete | connect | disconnect | connections | not-connected]",
+		Use:   "things [create | get | update | delete | share | connect | disconnect | connections | not-connected]",
 		Short: "Things management",
-		Long:  `Things management: create, get, update or delete Thing, connect or disconnect Thing from Channel and get the list of Channels connected or disconnected from a Thing`,
+		Long:  `Things management: create, get, update, delete or share Thing, connect or disconnect Thing from Channel and get the list of Channels connected or disconnected from a Thing`,
 	}
 
 	for i := range cmdThings {

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -134,9 +134,9 @@ func main() {
 		logger.Fatal(fmt.Sprintf("failed to load %s gRPC server configuration : %s", svcName, err))
 	}
 	mux := bone.New()
+	hsp := httpserver.New(ctx, cancel, "things-policies", httpServerConfig, papi.MakePolicyHandler(csvc, psvc, mux, logger), logger)
 	hsc := httpserver.New(ctx, cancel, "things-clients", httpServerConfig, capi.MakeHandler(csvc, mux, logger), logger)
 	hsg := httpserver.New(ctx, cancel, "things-groups", httpServerConfig, gapi.MakeHandler(gsvc, mux, logger), logger)
-	hsp := httpserver.New(ctx, cancel, "things-policies", httpServerConfig, papi.MakePolicyHandler(csvc, psvc, mux, logger), logger)
 
 	registerThingsServiceServer := func(srv *grpc.Server) {
 		reflection.Register(srv)

--- a/docker/nginx/nginx-key.conf
+++ b/docker/nginx/nginx-key.conf
@@ -51,50 +51,25 @@ http {
         server_name localhost;
 
         # Proxy pass to users service
-        location ~ ^/(users|tokens|password) {
+        location ~ ^/(users|groups|password|policies|authorize) {
             include snippets/proxy-headers.conf;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT};
-        }
-
-        location ~ ^/(policies) {
-            include snippets/proxy-headers.conf;
+            add_header Access-Control-Expose-Headers Location;
             proxy_pass http://users:${MF_USERS_HTTP_PORT};
         }
 
         # Proxy pass to things service
-        location ~ ^/(things|channels|connect|disconnect) {
+        location ~ ^/(things|channels|connect|disconnect|identify) {
             include snippets/proxy-headers.conf;
             add_header Access-Control-Expose-Headers Location;
             proxy_pass http://things:${MF_THINGS_HTTP_PORT};
-        }
-
-        location ~ ^/(identify){
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://things:${MF_THINGS_HTTP_PORT};
-        }
-
-        # Proxy pass for groups to things service
-        location ^~ /groups/things/ {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://things:${MF_THINGS_HTTP_PORT}/groups/;
-        }
-
-        # Proxy pass for groups to users service
-        location ^~ /groups/users/ {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT}/groups/;
-        }
-
-        location ~ ^/(groups|members|keys) {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT};
         }
         
         location /health {
+            include snippets/proxy-headers.conf;
+            proxy_pass http://things:${MF_THINGS_HTTP_PORT};
+        }
+
+        location /metrics {
             include snippets/proxy-headers.conf;
             proxy_pass http://things:${MF_THINGS_HTTP_PORT};
         }

--- a/docker/nginx/nginx-x509.conf
+++ b/docker/nginx/nginx-x509.conf
@@ -59,54 +59,29 @@ http {
         server_name localhost;
 
         # Proxy pass to users service
-        location ~ ^/(users|tokens|password) {
+        location ~ ^/(users|groups|password|policies|authorize) {
             include snippets/proxy-headers.conf;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT};
-        }
-
-        location ~ ^/(policies) {
-            include snippets/proxy-headers.conf;
+            add_header Access-Control-Expose-Headers Location;
             proxy_pass http://users:${MF_USERS_HTTP_PORT};
         }
 
         # Proxy pass to things service
-        location ~ ^/(things|channels|connect|disconnect) {
+        location ~ ^/(things|channels|connect|disconnect|identify) {
             include snippets/proxy-headers.conf;
             add_header Access-Control-Expose-Headers Location;
             proxy_pass http://things:${MF_THINGS_HTTP_PORT};
         }
-
-        location ~ ^/(identify){
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://things:${MF_THINGS_HTTP_PORT};
-        }
-
-        # Proxy pass for groups to things service
-        location ^~ /groups/things/ {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://things:${MF_THINGS_HTTP_PORT}/groups/;
-        }
-
-        # Proxy pass for groups to users service
-        location ^~ /groups/users/ {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT}/groups/;
-        }
-
-        location ~ ^/(groups|members|keys) {
-            include snippets/proxy-headers.conf;
-            add_header Access-Control-Expose-Headers Location;
-            proxy_pass http://users:${MF_USERS_HTTP_PORT};
-        }
-
+        
         location /health {
             include snippets/proxy-headers.conf;
             proxy_pass http://things:${MF_THINGS_HTTP_PORT};
         }
 
+        location /metrics {
+            include snippets/proxy-headers.conf;
+            proxy_pass http://things:${MF_THINGS_HTTP_PORT};
+        }
+        
         # Proxy pass to mainflux-http-adapter
         location /http/ {
             include snippets/verify-ssl-client.conf;

--- a/pkg/sdk/go/bootstrap.go
+++ b/pkg/sdk/go/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mainflux/mainflux/internal/apiutil"
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
@@ -166,7 +165,7 @@ func (sdk mfSDK) RemoveBootstrap(id, token string) errors.SDKError {
 
 func (sdk mfSDK) Bootstrap(externalID, externalKey string) (BootstrapConfig, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.bootstrapURL, bootstrapEndpoint, externalID)
-	_, body, err := sdk.processRequest(http.MethodGet, url, apiutil.ThingPrefix+externalKey, string(CTJSON), nil, http.StatusOK)
+	_, body, err := sdk.processRequest(http.MethodGet, url, ThingPrefix+externalKey, string(CTJSON), nil, http.StatusOK)
 	if err != nil {
 		return BootstrapConfig{}, err
 	}
@@ -181,7 +180,7 @@ func (sdk mfSDK) Bootstrap(externalID, externalKey string) (BootstrapConfig, err
 
 func (sdk mfSDK) BootstrapSecure(externalID, externalKey string) (BootstrapConfig, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.bootstrapURL, bootstrapEndpoint, secureEndpoint, externalID)
-	_, body, err := sdk.processRequest(http.MethodGet, url, apiutil.ThingPrefix+externalKey, string(CTJSON), nil, http.StatusOK)
+	_, body, err := sdk.processRequest(http.MethodGet, url, ThingPrefix+externalKey, string(CTJSON), nil, http.StatusOK)
 	if err != nil {
 		return BootstrapConfig{}, err
 	}

--- a/pkg/sdk/go/bootstrap.go
+++ b/pkg/sdk/go/bootstrap.go
@@ -62,6 +62,7 @@ func (sdk mfSDK) AddBootstrap(cfg BootstrapConfig, token string) (string, errors
 	}
 
 	id := strings.TrimPrefix(headers.Get("Location"), "/things/configs/")
+
 	return id, nil
 }
 
@@ -97,6 +98,7 @@ func (sdk mfSDK) Whitelist(cfg BootstrapConfig, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s", sdk.bootstrapURL, whitelistEndpoint, cfg.MFThing)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodPut, url, token, string(CTJSON), data, http.StatusCreated, http.StatusOK)
+
 	return sdkerr
 }
 
@@ -123,6 +125,7 @@ func (sdk mfSDK) UpdateBootstrap(cfg BootstrapConfig, token string) errors.SDKEr
 
 	url := fmt.Sprintf("%s/%s/%s", sdk.bootstrapURL, configsEndpoint, cfg.MFThing)
 	_, _, sdkerr := sdk.processRequest(http.MethodPut, url, token, string(CTJSON), data, http.StatusOK)
+
 	return sdkerr
 }
 
@@ -140,6 +143,7 @@ func (sdk mfSDK) UpdateBootstrapCerts(id, clientCert, clientKey, ca, token strin
 	}
 
 	_, _, sdkerr := sdk.processRequest(http.MethodPatch, url, token, string(CTJSON), data, http.StatusOK)
+	
 	return sdkerr
 }
 
@@ -154,12 +158,14 @@ func (sdk mfSDK) UpdateBootstrapConnection(id string, channels []string, token s
 	}
 
 	_, _, sdkerr := sdk.processRequest(http.MethodPut, url, token, string(CTJSON), data, http.StatusOK)
+	
 	return sdkerr
 }
 
 func (sdk mfSDK) RemoveBootstrap(id, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s", sdk.bootstrapURL, configsEndpoint, id)
 	_, _, err := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
+	
 	return err
 }
 

--- a/pkg/sdk/go/certs.go
+++ b/pkg/sdk/go/certs.go
@@ -46,6 +46,7 @@ func (sdk mfSDK) IssueCert(thingID, valid, token string) (Cert, errors.SDKError)
 	if err := json.Unmarshal(body, &c); err != nil {
 		return Cert{}, errors.NewSDKError(err)
 	}
+	
 	return c, nil
 }
 

--- a/pkg/sdk/go/channels.go
+++ b/pkg/sdk/go/channels.go
@@ -145,12 +145,10 @@ func (sdk mfSDK) UpdateChannel(c Channel, token string) (Channel, errors.SDKErro
 	return c, nil
 }
 
-// EnableChannel enables the channel identified with the provided ID.
 func (sdk mfSDK) EnableChannel(id, token string) (Channel, errors.SDKError) {
 	return sdk.changeChannelStatus(id, enableEndpoint, token)
 }
 
-// DisableChannel enabled the channel identified with the provided ID.
 func (sdk mfSDK) DisableChannel(id, token string) (Channel, errors.SDKError) {
 	return sdk.changeChannelStatus(id, disableEndpoint, token)
 }

--- a/pkg/sdk/go/channels.go
+++ b/pkg/sdk/go/channels.go
@@ -12,6 +12,8 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
+const channelsEndpoint = "channels"
+
 // Channel represents mainflux channel.
 type Channel struct {
 	ID          string     `json:"id"`
@@ -27,8 +29,6 @@ type Channel struct {
 	UpdatedAt   time.Time  `json:"updated_at,omitempty"`
 	Status      string     `json:"status,omitempty"`
 }
-
-const channelsEndpoint = "channels"
 
 func (sdk mfSDK) CreateChannel(c Channel, token string) (Channel, errors.SDKError) {
 	data, err := json.Marshal(c)

--- a/pkg/sdk/go/consumers.go
+++ b/pkg/sdk/go/consumers.go
@@ -37,6 +37,7 @@ func (sdk mfSDK) CreateSubscription(topic, contact, token string) (string, error
 	}
 
 	id := strings.TrimPrefix(headers.Get("Location"), fmt.Sprintf("/%s/", subscriptionEndpoint))
+	
 	return id, nil
 }
 
@@ -77,5 +78,6 @@ func (sdk mfSDK) DeleteSubscription(id, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s", sdk.usersURL, subscriptionEndpoint, id)
 
 	_, _, err := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
+	
 	return err
 }

--- a/pkg/sdk/go/consumers_test.go
+++ b/pkg/sdk/go/consumers_test.go
@@ -41,12 +41,14 @@ func newSubscriptionService() notifiers.Service {
 	notifier := mocks.NewNotifier()
 	idp := uuid.NewMock()
 	from := "exampleFrom"
+	
 	return notifiers.New(auth, repo, idp, notifier, from)
 }
 
 func newSubscriptionServer(svc notifiers.Service) *httptest.Server {
 	logger := logger.NewMock()
 	mux := httpapi.MakeHandler(svc, logger)
+	
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/groups.go
+++ b/pkg/sdk/go/groups.go
@@ -53,6 +53,7 @@ func (sdk mfSDK) CreateGroup(g Group, token string) (Group, errors.SDKError) {
 	if err := json.Unmarshal(body, &g); err != nil {
 		return Group{}, errors.NewSDKError(err)
 	}
+	
 	return g, nil
 }
 
@@ -80,6 +81,7 @@ func (sdk mfSDK) Groups(pm PageMetadata, token string) (GroupsPage, errors.SDKEr
 	if err != nil {
 		return GroupsPage{}, errors.NewSDKError(err)
 	}
+	
 	return sdk.getGroups(url, token)
 }
 
@@ -89,6 +91,7 @@ func (sdk mfSDK) Parents(id string, pm PageMetadata, token string) (GroupsPage, 
 	if err != nil {
 		return GroupsPage{}, errors.NewSDKError(err)
 	}
+	
 	return sdk.getGroups(url, token)
 }
 
@@ -98,6 +101,7 @@ func (sdk mfSDK) Children(id string, pm PageMetadata, token string) (GroupsPage,
 	if err != nil {
 		return GroupsPage{}, errors.NewSDKError(err)
 	}
+	
 	return sdk.getGroups(url, token)
 }
 
@@ -111,6 +115,7 @@ func (sdk mfSDK) getGroups(url, token string) (GroupsPage, errors.SDKError) {
 	if err := json.Unmarshal(body, &tp); err != nil {
 		return GroupsPage{}, errors.NewSDKError(err)
 	}
+	
 	return tp, nil
 }
 
@@ -149,12 +154,10 @@ func (sdk mfSDK) UpdateGroup(g Group, token string) (Group, errors.SDKError) {
 	return g, nil
 }
 
-// EnableGroup removes the group identified with the provided ID.
 func (sdk mfSDK) EnableGroup(id, token string) (Group, errors.SDKError) {
 	return sdk.changeGroupStatus(id, enableEndpoint, token)
 }
 
-// DisableGroup removes the group identified with the provided ID.
 func (sdk mfSDK) DisableGroup(id, token string) (Group, errors.SDKError) {
 	return sdk.changeGroupStatus(id, disableEndpoint, token)
 }

--- a/pkg/sdk/go/groups_test.go
+++ b/pkg/sdk/go/groups_test.go
@@ -30,6 +30,7 @@ func newGroupsServer(svc groups.Service) *httptest.Server {
 	logger := logger.NewMock()
 	mux := bone.New()
 	api.MakeGroupsHandler(svc, mux, logger)
+
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/health.go
+++ b/pkg/sdk/go/health.go
@@ -8,26 +8,43 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
-func (sdk mfSDK) Health() (mainflux.HealthInfo, errors.SDKError) {
+// HealthInfo contains version endpoint response.
+type HealthInfo struct {
+	// Status contains service status.
+	Status string `json:"status"`
+
+	// Version contains current service version.
+	Version string `json:"version"`
+
+	// Commit represents the git hash commit.
+	Commit string `json:"commit"`
+
+	// Description contains service description.
+	Description string `json:"description"`
+
+	// BuildTime contains service build time.
+	BuildTime string `json:"build_time"`
+}
+
+func (sdk mfSDK) Health() (HealthInfo, errors.SDKError) {
 	url := fmt.Sprintf("%s/health", sdk.thingsURL)
 
 	resp, err := sdk.client.Get(url)
 	if err != nil {
-		return mainflux.HealthInfo{}, errors.NewSDKError(err)
+		return HealthInfo{}, errors.NewSDKError(err)
 	}
 	defer resp.Body.Close()
 
 	if err := errors.CheckError(resp, http.StatusOK); err != nil {
-		return mainflux.HealthInfo{}, err
+		return HealthInfo{}, err
 	}
 
-	var h mainflux.HealthInfo
+	var h HealthInfo
 	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
-		return mainflux.HealthInfo{}, errors.NewSDKError(err)
+		return HealthInfo{}, errors.NewSDKError(err)
 	}
 
 	return h, nil

--- a/pkg/sdk/go/message.go
+++ b/pkg/sdk/go/message.go
@@ -12,25 +12,30 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
+const (
+	channelParts = 2
+)
+
 func (sdk mfSDK) SendMessage(chanName, msg, key string) errors.SDKError {
-	chanNameParts := strings.SplitN(chanName, ".", 2)
+	chanNameParts := strings.SplitN(chanName, ".", channelParts)
 	chanID := chanNameParts[0]
 	subtopicPart := ""
-	if len(chanNameParts) == 2 {
+	if len(chanNameParts) == channelParts {
 		subtopicPart = fmt.Sprintf("/%s", strings.Replace(chanNameParts[1], ".", "/", -1))
 	}
 
 	url := fmt.Sprintf("%s/channels/%s/messages/%s", sdk.httpAdapterURL, chanID, subtopicPart)
 
 	_, _, err := sdk.processRequest(http.MethodPost, url, ThingPrefix+key, string(CTJSON), []byte(msg), http.StatusAccepted)
+	
 	return err
 }
 
 func (sdk mfSDK) ReadMessages(chanName, token string) (MessagesPage, errors.SDKError) {
-	chanNameParts := strings.SplitN(chanName, ".", 2)
+	chanNameParts := strings.SplitN(chanName, ".", channelParts)
 	chanID := chanNameParts[0]
 	subtopicPart := ""
-	if len(chanNameParts) == 2 {
+	if len(chanNameParts) == channelParts {
 		subtopicPart = fmt.Sprintf("?subtopic=%s", strings.Replace(chanNameParts[1], ".", "/", -1))
 	}
 
@@ -55,5 +60,6 @@ func (sdk *mfSDK) SetContentType(ct ContentType) errors.SDKError {
 	}
 
 	sdk.msgContentType = ct
+	
 	return nil
 }

--- a/pkg/sdk/go/message.go
+++ b/pkg/sdk/go/message.go
@@ -12,9 +12,7 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
-const (
-	channelParts = 2
-)
+const channelParts = 2
 
 func (sdk mfSDK) SendMessage(chanName, msg, key string) errors.SDKError {
 	chanNameParts := strings.SplitN(chanName, ".", channelParts)
@@ -27,7 +25,7 @@ func (sdk mfSDK) SendMessage(chanName, msg, key string) errors.SDKError {
 	url := fmt.Sprintf("%s/channels/%s/messages/%s", sdk.httpAdapterURL, chanID, subtopicPart)
 
 	_, _, err := sdk.processRequest(http.MethodPost, url, ThingPrefix+key, string(CTJSON), []byte(msg), http.StatusAccepted)
-	
+
 	return err
 }
 
@@ -60,6 +58,6 @@ func (sdk *mfSDK) SetContentType(ct ContentType) errors.SDKError {
 	}
 
 	sdk.msgContentType = ct
-	
+
 	return nil
 }

--- a/pkg/sdk/go/message.go
+++ b/pkg/sdk/go/message.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mainflux/mainflux/internal/apiutil"
 	"github.com/mainflux/mainflux/pkg/errors"
 )
 
@@ -23,7 +22,7 @@ func (sdk mfSDK) SendMessage(chanName, msg, key string) errors.SDKError {
 
 	url := fmt.Sprintf("%s/channels/%s/messages/%s", sdk.httpAdapterURL, chanID, subtopicPart)
 
-	_, _, err := sdk.processRequest(http.MethodPost, url, apiutil.ThingPrefix+key, string(CTJSON), []byte(msg), http.StatusAccepted)
+	_, _, err := sdk.processRequest(http.MethodPost, url, ThingPrefix+key, string(CTJSON), []byte(msg), http.StatusAccepted)
 	return err
 }
 

--- a/pkg/sdk/go/message_test.go
+++ b/pkg/sdk/go/message_test.go
@@ -23,11 +23,13 @@ const eof = "EOF"
 
 func newMessageService(cc policies.ThingsServiceClient) adapter.Service {
 	pub := mocks.NewPublisher()
+
 	return adapter.New(pub, cc)
 }
 
 func newMessageServer(svc adapter.Service) *httptest.Server {
 	mux := api.MakeHandler(svc)
+
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/policies.go
+++ b/pkg/sdk/go/policies.go
@@ -122,20 +122,10 @@ func (sdk mfSDK) Assign(memberType []string, memberID, groupID, token string) er
 	return sdkerr
 }
 
-func (sdk mfSDK) Unassign(memberType []string, groupID string, memberID string, token string) errors.SDKError {
-	var policy = Policy{
-		Subject: memberID,
-		Object:  groupID,
-		Actions: memberType,
-	}
-	data, err := json.Marshal(policy)
-	if err != nil {
-		return errors.NewSDKError(err)
-	}
+func (sdk mfSDK) Unassign(memberID, groupID, token string) errors.SDKError {
+	url := fmt.Sprintf("%s/%s/%s/%s", sdk.usersURL, policiesEndpoint, memberID, groupID)
 
-	url := fmt.Sprintf("%s/%s/%s/%s", sdk.usersURL, policiesEndpoint, groupID, memberID)
-
-	_, _, sdkerr := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), data, http.StatusNoContent)
+	_, _, sdkerr := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
 	return sdkerr
 }
 

--- a/pkg/sdk/go/policies.go
+++ b/pkg/sdk/go/policies.go
@@ -120,7 +120,7 @@ func (sdk mfSDK) Assign(memberType []string, memberID, groupID, token string) er
 	}
 	url := fmt.Sprintf("%s/%s", sdk.usersURL, policiesEndpoint)
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusCreated)
-	
+
 	return sdkerr
 }
 
@@ -128,7 +128,7 @@ func (sdk mfSDK) Unassign(memberID, groupID, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.usersURL, policiesEndpoint, memberID, groupID)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
-	
+
 	return sdkerr
 }
 
@@ -141,7 +141,7 @@ func (sdk mfSDK) Connect(connIDs ConnectionIDs, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s", sdk.thingsURL, connectEndpoint)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusCreated)
-	
+
 	return sdkerr
 }
 
@@ -153,7 +153,7 @@ func (sdk mfSDK) Disconnect(connIDs ConnectionIDs, token string) errors.SDKError
 
 	url := fmt.Sprintf("%s/%s", sdk.thingsURL, disconnectEndpoint)
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusNoContent)
-	
+
 	return sdkerr
 }
 
@@ -161,7 +161,7 @@ func (sdk mfSDK) ConnectThing(thingID, chanID, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", sdk.thingsURL, channelsEndpoint, chanID, thingsEndpoint, thingID)
 
 	_, _, err := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), nil, http.StatusCreated)
-	
+
 	return err
 }
 
@@ -169,7 +169,7 @@ func (sdk mfSDK) DisconnectThing(thingID, chanID, token string) errors.SDKError 
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", sdk.thingsURL, channelsEndpoint, chanID, thingsEndpoint, thingID)
 
 	_, _, err := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
-	
+
 	return err
 }
 

--- a/pkg/sdk/go/policies.go
+++ b/pkg/sdk/go/policies.go
@@ -181,7 +181,7 @@ func (sdk mfSDK) UpdateThingsPolicy(p Policy, token string) errors.SDKError {
 
 	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, thingsEndpoint, policiesEndpoint)
 
-	_, _, sdkerr := sdk.processRequest(http.MethodPut, url, token, string(CTJSON), data, http.StatusNoContent)
+	_, _, sdkerr := sdk.processRequest(http.MethodPut, url, token, string(CTJSON), data, http.StatusOK)
 	if sdkerr != nil {
 		return sdkerr
 	}

--- a/pkg/sdk/go/policies.go
+++ b/pkg/sdk/go/policies.go
@@ -104,6 +104,7 @@ func (sdk mfSDK) DeletePolicy(p Policy, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.usersURL, policiesEndpoint, p.Subject, p.Object)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
+
 	return sdkerr
 }
 
@@ -119,6 +120,7 @@ func (sdk mfSDK) Assign(memberType []string, memberID, groupID, token string) er
 	}
 	url := fmt.Sprintf("%s/%s", sdk.usersURL, policiesEndpoint)
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusCreated)
+	
 	return sdkerr
 }
 
@@ -126,6 +128,7 @@ func (sdk mfSDK) Unassign(memberID, groupID, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s/%s", sdk.usersURL, policiesEndpoint, memberID, groupID)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
+	
 	return sdkerr
 }
 
@@ -138,6 +141,7 @@ func (sdk mfSDK) Connect(connIDs ConnectionIDs, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s", sdk.thingsURL, connectEndpoint)
 
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusCreated)
+	
 	return sdkerr
 }
 
@@ -149,6 +153,7 @@ func (sdk mfSDK) Disconnect(connIDs ConnectionIDs, token string) errors.SDKError
 
 	url := fmt.Sprintf("%s/%s", sdk.thingsURL, disconnectEndpoint)
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusNoContent)
+	
 	return sdkerr
 }
 
@@ -156,6 +161,7 @@ func (sdk mfSDK) ConnectThing(thingID, chanID, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", sdk.thingsURL, channelsEndpoint, chanID, thingsEndpoint, thingID)
 
 	_, _, err := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), nil, http.StatusCreated)
+	
 	return err
 }
 
@@ -163,6 +169,7 @@ func (sdk mfSDK) DisconnectThing(thingID, chanID, token string) errors.SDKError 
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", sdk.thingsURL, channelsEndpoint, chanID, thingsEndpoint, thingID)
 
 	_, _, err := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
+	
 	return err
 }
 

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -70,7 +70,7 @@ func TestCreatePolicy(t *testing.T) {
 				Object:  object,
 				Actions: []string{"m_write", "g_add"},
 			},
-			page:  sdk.PolicyPage{Policies: []sdk.Policy{sdk.Policy(clientPolicy)}},
+			page:  sdk.PolicyPage{Policies: []sdk.Policy{clientPolicy}},
 			token: generateValidToken(t, csvc, cRepo),
 			err:   errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
 		},

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -26,6 +26,7 @@ func newPolicyServer(svc policies.Service) *httptest.Server {
 	logger := logger.NewMock()
 	mux := bone.New()
 	api.MakePolicyHandler(svc, mux, logger)
+	
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -26,7 +26,7 @@ func newPolicyServer(svc policies.Service) *httptest.Server {
 	logger := logger.NewMock()
 	mux := bone.New()
 	api.MakePolicyHandler(svc, mux, logger)
-	
+
 	return httptest.NewServer(mux)
 }
 
@@ -345,7 +345,7 @@ func TestListPolicies(t *testing.T) {
 				Action: "wrong",
 			},
 			response: []sdk.Policy(nil),
-			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
 		},
 	}
 

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -43,7 +43,8 @@ type identifyThingReq struct {
 }
 
 type shareThingReq struct {
-	UserIDs  []string `json:"user_ids"`
+	GroupID  string   `json:"group_id"`
+	UserID   string   `json:"user_id"`
 	Policies []string `json:"policies"`
 }
 

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -38,10 +38,6 @@ type tokenReq struct {
 	Secret   string `json:"secret"`
 }
 
-type identifyThingReq struct {
-	Token string `json:"token,omitempty"`
-}
-
 type shareThingReq struct {
 	GroupID  string   `json:"group_id"`
 	UserID   string   `json:"user_id"`

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -39,16 +39,9 @@ type tokenReq struct {
 }
 
 type shareThingReq struct {
-	GroupID  string   `json:"group_id"`
-	UserID   string   `json:"user_id"`
-	Policies []string `json:"policies"`
-}
-
-type authorizeReq struct {
-	Subject    string `json:"subject,omitempty"`
-	Object     string `json:"object,omitempty"`
-	Action     string `json:"action,omitempty"`
-	EntityType string `json:"entity_type,omitempty"`
+	GroupID string   `json:"group_id"`
+	UserID  string   `json:"user_id"`
+	Actions []string `json:"actions"`
 }
 
 type canAccessReq struct {

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -41,3 +41,22 @@ type tokenReq struct {
 type identifyThingReq struct {
 	Token string `json:"token,omitempty"`
 }
+
+type shareThingReq struct {
+	UserIDs  []string `json:"user_ids"`
+	Policies []string `json:"policies"`
+}
+
+type authorizeReq struct {
+	Subject    string `json:"subject,omitempty"`
+	Object     string `json:"object,omitempty"`
+	Action     string `json:"action,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+}
+
+type canAccessReq struct {
+	ClientSecret string `json:"secret"`
+	GroupID      string `json:"group_id"`
+	Action       string `json:"action"`
+	EntityType   string `json:"entity_type"`
+}

--- a/pkg/sdk/go/requests.go
+++ b/pkg/sdk/go/requests.go
@@ -3,7 +3,7 @@
 
 package sdk
 
-// updateClientSecretReq is used to update the client secret
+// updateClientSecretReq is used to update the client secret.
 type updateClientSecretReq struct {
 	OldSecret string `json:"old_secret,omitempty"`
 	NewSecret string `json:"new_secret,omitempty"`
@@ -13,20 +13,20 @@ type updateThingSecretReq struct {
 	Secret string `json:"secret,omitempty"`
 }
 
-// updateClientIdentityReq is used to update the client identity
+// updateClientIdentityReq is used to update the client identity.
 type updateClientIdentityReq struct {
 	token    string
 	id       string
 	Identity string `json:"identity,omitempty"`
 }
 
-// UserPasswordReq contains old and new passwords
+// UserPasswordReq contains old and new passwords.
 type UserPasswordReq struct {
 	OldPassword string `json:"old_password,omitempty"`
 	Password    string `json:"password,omitempty"`
 }
 
-// ConnectionIDs contains ID lists of things and channels to be connected
+// ConnectionIDs contains ID lists of things and channels to be connected.
 type ConnectionIDs struct {
 	ChannelIDs []string `json:"group_ids"`
 	ThingIDs   []string `json:"client_ids"`

--- a/pkg/sdk/go/responses.go
+++ b/pkg/sdk/go/responses.go
@@ -112,3 +112,12 @@ type SubscriptionPage struct {
 type identifyThingResp struct {
 	ID string `json:"id,omitempty"`
 }
+
+type authorizeRes struct {
+	Authorized bool `json:"authorized"`
+}
+
+type canAccessRes struct {
+	ThingID    string `json:"thing_id"`
+	Authorized bool   `json:"authorized"`
+}

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -68,27 +68,26 @@ var (
 )
 
 type PageMetadata struct {
-	Total        uint64   `json:"total"`
-	Offset       uint64   `json:"offset"`
-	Limit        uint64   `json:"limit"`
-	Level        uint64   `json:"level,omitempty"`
-	Email        string   `json:"email,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Type         string   `json:"type,omitempty"`
-	Disconnected bool     `json:"disconnected,omitempty"`
-	Metadata     Metadata `json:"metadata,omitempty"`
-	Status       string   `json:"status,omitempty"`
-	Action       string   `json:"action,omitempty"`
-	Subject      string   `json:"subject,omitempty"`
-	Object       string   `json:"object,omitempty"`
-	Tag          string   `json:"tag,omitempty"`
-	Owner        string   `json:"owner,omitempty"`
-	SharedBy     string   `json:"shared_by,omitempty"`
-	Visibility   string   `json:"visibility,omitempty"`
-	OwnerID      string   `json:"owner_id,omitempty"`
-	Topic        string   `json:"topic,omitempty"`
-	Contact      string   `json:"contact,omitempty"`
-	State        string   `json:"state,omitempty"`
+	Total      uint64   `json:"total"`
+	Offset     uint64   `json:"offset"`
+	Limit      uint64   `json:"limit"`
+	Level      uint64   `json:"level,omitempty"`
+	Email      string   `json:"email,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	Type       string   `json:"type,omitempty"`
+	Metadata   Metadata `json:"metadata,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Subject    string   `json:"subject,omitempty"`
+	Object     string   `json:"object,omitempty"`
+	Tag        string   `json:"tag,omitempty"`
+	Owner      string   `json:"owner,omitempty"`
+	SharedBy   string   `json:"shared_by,omitempty"`
+	Visibility string   `json:"visibility,omitempty"`
+	OwnerID    string   `json:"owner_id,omitempty"`
+	Topic      string   `json:"topic,omitempty"`
+	Contact    string   `json:"contact,omitempty"`
+	State      string   `json:"state,omitempty"`
 }
 
 // Credentials represent client credentials: it contains
@@ -288,8 +287,7 @@ type SDK interface {
 	//  fmt.Println(things)
 	Things(pm PageMetadata, token string) (ThingsPage, errors.SDKError)
 
-	// ThingsByChannel returns page of things that are connected or not connected
-	// to specified channel.
+	// ThingsByChannel returns page of things that are connected to specified channel.
 	//
 	// example:
 	//  pm := sdk.PageMetadata{
@@ -521,8 +519,7 @@ type SDK interface {
 	//  fmt.Println(channels)
 	Channels(pm PageMetadata, token string) (ChannelsPage, errors.SDKError)
 
-	// ChannelsByThing returns page of channels that are connected or not connected
-	// to specified thing.
+	// ChannelsByThing returns page of channels that are connected to specified thing.
 	//
 	// example:
 	//  pm := sdk.PageMetadata{
@@ -1030,6 +1027,33 @@ func (pm PageMetadata) query() (string, error) {
 			return "", errors.NewSDKError(err)
 		}
 		q.Add("metadata", string(md))
+	}
+	if pm.Action != "" {
+		q.Add("action", pm.Action)
+	}
+	if pm.Subject != "" {
+		q.Add("subject", pm.Subject)
+	}
+	if pm.Object != "" {
+		q.Add("object", pm.Object)
+	}
+	if pm.Tag != "" {
+		q.Add("tag", pm.Tag)
+	}
+	if pm.Owner != "" {
+		q.Add("owner", pm.Owner)
+	}
+	if pm.SharedBy != "" {
+		q.Add("shared_by", pm.SharedBy)
+	}
+	if pm.Topic != "" {
+		q.Add("topic", pm.Topic)
+	}
+	if pm.Contact != "" {
+		q.Add("contact", pm.Contact)
+	}
+	if pm.State != "" {
+		q.Add("state", pm.State)
 	}
 
 	return q.Encode(), nil

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -375,9 +375,9 @@ type SDK interface {
 	// ShareThing shares thing with other user.
 	//
 	// example:
-	//  err := sdk.ShareThing("thingID", []string{"userID1", "userID2"}, []string{"c_list", "c_delete"}, "token")
+	//  err := sdk.ShareThing("thingID", "groupID", "userID", []string{"c_list", "c_delete"}, "token")
 	//  fmt.Println(err)
-	ShareThing(thingID string, userIDs, actions []string, token string) errors.SDKError
+	ShareThing(thingID, groupID, userID string, actions []string, token string) errors.SDKError
 
 	// CreateGroup creates new group and returns its id.
 	//
@@ -991,7 +991,7 @@ func (sdk mfSDK) withQueryParams(baseURL, endpoint string, pm PageMetadata) (str
 	if err != nil {
 		return "", err
 	}
-	
+
 	return fmt.Sprintf("%s/%s?%s", baseURL, endpoint, q), nil
 }
 
@@ -1031,6 +1031,6 @@ func (pm PageMetadata) query() (string, error) {
 		}
 		q.Add("metadata", string(md))
 	}
-	
+
 	return q.Encode(), nil
 }

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -641,9 +641,9 @@ type SDK interface {
 	// Unassign removes member from a group.
 	//
 	// example:
-	//  err := sdk.Unassign([]string{"g_add"}, "userID:1", "groupID:1", "token")
+	//  err := sdk.Unassign("userID:1", "groupID:1", "token")
 	//  fmt.Println(err)
-	Unassign(memberType []string, groupID string, memberID string, token string) errors.SDKError
+	Unassign(memberID, groupID, token string) errors.SDKError
 
 	// Connect bulk connects things to channels specified by id.
 	//

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -28,10 +28,10 @@ const (
 	// CTBinary represents binary content type.
 	CTBinary ContentType = "application/octet-stream"
 
-	// EnabledStatus represents enable status for a client
+	// EnabledStatus represents enable status for a client.
 	EnabledStatus = "enabled"
 
-	// DisabledStatus represents disabled status for a client
+	// DisabledStatus represents disabled status for a client.
 	DisabledStatus = "disabled"
 
 	BearerPrefix = "Bearer "
@@ -991,6 +991,7 @@ func (sdk mfSDK) withQueryParams(baseURL, endpoint string, pm PageMetadata) (str
 	if err != nil {
 		return "", err
 	}
+	
 	return fmt.Sprintf("%s/%s?%s", baseURL, endpoint, q), nil
 }
 
@@ -1030,5 +1031,6 @@ func (pm PageMetadata) query() (string, error) {
 		}
 		q.Add("metadata", string(md))
 	}
+	
 	return q.Encode(), nil
 }

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -102,247 +102,804 @@ type Credentials struct {
 // SDK contains Mainflux API.
 type SDK interface {
 	// CreateUser registers mainflux user.
+	//
+	// example:
+	//  user := sdk.User{
+	//    Name:	 "John Doe",
+	//    Credentials: sdk.Credentials{
+	//      Identity: "john.doe@example",
+	//      Secret:   "12345678",
+	//    },
+	//  }
+	//  user, _ := sdk.CreateUser(user)
+	//  fmt.Println(user)
 	CreateUser(user User, token string) (User, errors.SDKError)
 
 	// User returns user object by id.
+	//
+	// example:
+	//  user, _ := sdk.User("userID", "token")
+	//  fmt.Println(user)
 	User(id, token string) (User, errors.SDKError)
 
 	// Users returns list of users.
+	//
+	// example:
+	//	pm := sdk.PageMetadata{
+	//		Offset: 0,
+	//		Limit:  10,
+	//		Name:   "John Doe",
+	//	}
+	//	users, _ := sdk.Users(pm, "token")
+	//	fmt.Println(users)
 	Users(pm PageMetadata, token string) (UsersPage, errors.SDKError)
 
 	// Members retrieves everything that is assigned to a group identified by groupID.
+	//
+	// example:
+	//	pm := sdk.PageMetadata{
+	//		Offset: 0,
+	//		Limit:  10,
+	//	}
+	//	members, _ := sdk.Members("groupID", pm, "token")
+	//	fmt.Println(members)
 	Members(groupID string, meta PageMetadata, token string) (MembersPage, errors.SDKError)
 
 	// UserProfile returns user logged in.
+	//
+	// example:
+	//  user, _ := sdk.UserProfile("token")
+	//  fmt.Println(user)
 	UserProfile(token string) (User, errors.SDKError)
 
 	// UpdateUser updates existing user.
+	//
+	// example:
+	//  user := sdk.User{
+	//    ID:   "userID",
+	//    Name: "John Doe",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  user, _ := sdk.UpdateUser(user, "token")
+	//  fmt.Println(user)
 	UpdateUser(user User, token string) (User, errors.SDKError)
 
 	// UpdateUserTags updates the user's tags.
+	//
+	// example:
+	//  user := sdk.User{
+	//    ID:   "userID",
+	//    Tags: []string{"tag1", "tag2"},
+	//  }
+	//  user, _ := sdk.UpdateUserTags(user, "token")
+	//  fmt.Println(user)
 	UpdateUserTags(user User, token string) (User, errors.SDKError)
 
 	// UpdateUserIdentity updates the user's identity
+	//
+	// example:
+	//  user := sdk.User{
+	//    ID:   "userID",
+	//    Credentials: sdk.Credentials{
+	//      Identity: "john.doe@example",
+	//    },
+	//  }
+	//  user, _ := sdk.UpdateUserIdentity(user, "token")
+	//  fmt.Println(user)
 	UpdateUserIdentity(user User, token string) (User, errors.SDKError)
 
 	// UpdateUserOwner updates the user's owner.
+	//
+	// example:
+	//  user := sdk.User{
+	//    ID:   "userID",
+	//    Owner: "ownerID",
+	//  }
+	//  user, _ := sdk.UpdateUserOwner(user, "token")
+	//  fmt.Println(user)
 	UpdateUserOwner(user User, token string) (User, errors.SDKError)
 
 	// UpdatePassword updates user password.
+	//
+	// example:
+	//  user, _ := sdk.UpdatePassword("oldPass", "newPass", "token")
+	//  fmt.Println(user)
 	UpdatePassword(oldPass, newPass, token string) (User, errors.SDKError)
 
 	// EnableUser changes the status of the user to enabled.
+	//
+	// example:
+	//  user, _ := sdk.EnableUser("userID", "token")
+	//  fmt.Println(user)
 	EnableUser(id, token string) (User, errors.SDKError)
 
 	// DisableUser changes the status of the user to disabled.
+	//
+	// example:
+	//  user, _ := sdk.DisableUser("userID", "token")
+	//  fmt.Println(user)
 	DisableUser(id, token string) (User, errors.SDKError)
 
 	// CreateToken receives credentials and returns user token.
+	//
+	// example:
+	//  user := sdk.User{
+	//    Credentials: sdk.Credentials{
+	//      Identity: "john.doe@example",
+	//      Secret:   "12345678",
+	//    },
+	//  }
+	//  token, _ := sdk.CreateToken(user)
+	//  fmt.Println(token)
 	CreateToken(user User) (Token, errors.SDKError)
 
 	// RefreshToken receives credentials and returns user token.
+	//
+	// example:
+	//  token, _ := sdk.RefreshToken("refresh_token")
+	//  fmt.Println(token)
 	RefreshToken(token string) (Token, errors.SDKError)
 
 	// CreateThing registers new thing and returns its id.
+	//
+	// example:
+	//  thing := sdk.Thing{
+	//    Name: "My Thing",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  thing, _ := sdk.CreateThing(thing, "token")
+	//  fmt.Println(thing)
 	CreateThing(thing Thing, token string) (Thing, errors.SDKError)
 
 	// CreateThings registers new things and returns their ids.
+	//
+	// example:
+	//  things := []sdk.Thing{
+	//    {
+	//      Name: "My Thing 1",
+	//      Metadata: sdk.Metadata{
+	//        "key": "value",
+	//      },
+	//    },
+	//    {
+	//      Name: "My Thing 2",
+	//      Metadata: sdk.Metadata{
+	//        "key": "value",
+	//      },
+	//    },
+	//  }
+	//  things, _ := sdk.CreateThings(things, "token")
+	//  fmt.Println(things)
 	CreateThings(things []Thing, token string) ([]Thing, errors.SDKError)
 
 	// Filters things and returns a page result.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Thing",
+	//  }
+	//  things, _ := sdk.Things(pm, "token")
+	//  fmt.Println(things)
 	Things(pm PageMetadata, token string) (ThingsPage, errors.SDKError)
 
 	// ThingsByChannel returns page of things that are connected or not connected
 	// to specified channel.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Thing",
+	//  }
+	//  things, _ := sdk.ThingsByChannel("channelID", pm, "token")
+	//  fmt.Println(things)
 	ThingsByChannel(chanID string, pm PageMetadata, token string) (ThingsPage, errors.SDKError)
 
 	// Thing returns thing object by id.
+	//
+	// example:
+	//  thing, _ := sdk.Thing("thingID", "token")
+	//  fmt.Println(thing)
 	Thing(id, token string) (Thing, errors.SDKError)
 
 	// UpdateThing updates existing thing.
+	//
+	// example:
+	//  thing := sdk.Thing{
+	//    ID:   "thingID",
+	//    Name: "My Thing",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  thing, _ := sdk.UpdateThing(thing, "token")
+	//  fmt.Println(thing)
 	UpdateThing(thing Thing, token string) (Thing, errors.SDKError)
 
 	// UpdateThingTags updates the client's tags.
+	//
+	// example:
+	//  thing := sdk.Thing{
+	//    ID:   "thingID",
+	//    Tags: []string{"tag1", "tag2"},
+	//  }
+	//  thing, _ := sdk.UpdateThingTags(thing, "token")
+	//  fmt.Println(thing)
 	UpdateThingTags(thing Thing, token string) (Thing, errors.SDKError)
 
 	// UpdateThingSecret updates the client's secret
+	//
+	// example:
+	//  thing, err := sdk.UpdateThingSecret("thingID", "newSecret", "token")
+	//  fmt.Println(thing)
 	UpdateThingSecret(id, secret, token string) (Thing, errors.SDKError)
 
 	// UpdateThingOwner updates the client's owner.
+	//
+	// example:
+	//  thing := sdk.Thing{
+	//    ID:    "thingID",
+	//    Owner: "ownerID",
+	//  }
+	//  thing, _ := sdk.UpdateThingOwner(thing, "token")
+	//  fmt.Println(thing)
 	UpdateThingOwner(thing Thing, token string) (Thing, errors.SDKError)
 
 	// EnableThing changes client status to enabled.
+	//
+	// example:
+	//  thing, _ := sdk.EnableThing("thingID", "token")
+	//  fmt.Println(thing)
 	EnableThing(id, token string) (Thing, errors.SDKError)
 
 	// DisableThing changes client status to disabled - soft delete.
+	//
+	// example:
+	//  thing, _ := sdk.DisableThing("thingID", "token")
+	//  fmt.Println(thing)
 	DisableThing(id, token string) (Thing, errors.SDKError)
 
 	// IdentifyThing validates thing's key and returns its ID
+	//
+	// example:
+	//  id, _ := sdk.IdentifyThing("thingKey")
+	//  fmt.Println(id)
 	IdentifyThing(key string) (string, errors.SDKError)
 
 	// ShareThing shares thing with other user.
+	//
+	// example:
+	//  err := sdk.ShareThing("thingID", []string{"userID1", "userID2"}, []string{"c_list", "c_delete"}, "token")
+	//  fmt.Println(err)
 	ShareThing(thingID string, userIDs, actions []string, token string) errors.SDKError
 
 	// CreateGroup creates new group and returns its id.
+	//
+	// example:
+	//  group := sdk.Group{
+	//    Name: "My Group",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  group, _ := sdk.CreateGroup(group, "token")
+	//  fmt.Println(group)
 	CreateGroup(group Group, token string) (Group, errors.SDKError)
 
 	// Memberships
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Group",
+	//  }
+	//  groups, _ := sdk.Memberships("userID", pm, "token")
+	//  fmt.Println(groups)
 	Memberships(clientID string, pm PageMetadata, token string) (MembershipsPage, errors.SDKError)
 
 	// Groups returns page of groups.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Group",
+	//  }
+	//  groups, _ := sdk.Groups(pm, "token")
+	//  fmt.Println(groups)
 	Groups(pm PageMetadata, token string) (GroupsPage, errors.SDKError)
 
 	// Parents returns page of users groups.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Group",
+	//  }
+	//  groups, _ := sdk.Parents("groupID", pm, "token")
+	//  fmt.Println(groups)
 	Parents(id string, pm PageMetadata, token string) (GroupsPage, errors.SDKError)
 
 	// Children returns page of users groups.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Group",
+	//  }
+	//  groups, _ := sdk.Children("groupID", pm, "token")
+	//  fmt.Println(groups)
 	Children(id string, pm PageMetadata, token string) (GroupsPage, errors.SDKError)
 
 	// Group returns users group object by id.
+	//
+	// example:
+	//  group, _ := sdk.Group("groupID", "token")
+	//  fmt.Println(group)
 	Group(id, token string) (Group, errors.SDKError)
 
 	// UpdateGroup updates existing group.
+	//
+	// example:
+	//  group := sdk.Group{
+	//    ID:   "groupID",
+	//    Name: "My Group",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  group, _ := sdk.UpdateGroup(group, "token")
+	//  fmt.Println(group)
 	UpdateGroup(group Group, token string) (Group, errors.SDKError)
 
 	// EnableGroup changes group status to enabled.
+	//
+	// example:
+	//  group, _ := sdk.EnableGroup("groupID", "token")
+	//  fmt.Println(group)
 	EnableGroup(id, token string) (Group, errors.SDKError)
 
 	// DisableGroup changes group status to disabled - soft delete.
+	//
+	// example:
+	//  group, _ := sdk.DisableGroup("groupID", "token")
+	//  fmt.Println(group)
 	DisableGroup(id, token string) (Group, errors.SDKError)
 
 	// CreateChannel creates new channel and returns its id.
+	//
+	// example:
+	//  channel := sdk.Channel{
+	//    Name: "My Channel",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  channel, _ := sdk.CreateChannel(channel, "token")
+	//  fmt.Println(channel)
 	CreateChannel(channel Channel, token string) (Channel, errors.SDKError)
 
 	// CreateChannels registers new channels and returns their ids.
+	//
+	// example:
+	//  channels := []sdk.Channel{
+	//    {
+	//      Name: "My Channel 1",
+	//      Metadata: sdk.Metadata{
+	//        "key": "value",
+	//      },
+	//    },
+	//    {
+	//      Name: "My Channel 2",
+	//      Metadata: sdk.Metadata{
+	//        "key": "value",
+	//      },
+	//    },
+	//  }
+	//  channels, _ := sdk.CreateChannels(channels, "token")
+	//  fmt.Println(channels)
 	CreateChannels(channels []Channel, token string) ([]Channel, errors.SDKError)
 
 	// Channels returns page of channels.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Channel",
+	//  }
+	//  channels, _ := sdk.Channels(pm, "token")
+	//  fmt.Println(channels)
 	Channels(pm PageMetadata, token string) (ChannelsPage, errors.SDKError)
 
 	// ChannelsByThing returns page of channels that are connected or not connected
 	// to specified thing.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Name:   "My Channel",
+	//  }
+	//  channels, _ := sdk.ChannelsByThing("thingID", pm, "token")
+	//  fmt.Println(channels)
 	ChannelsByThing(thingID string, pm PageMetadata, token string) (ChannelsPage, errors.SDKError)
 
 	// Channel returns channel data by id.
+	//
+	// example:
+	//  channel, _ := sdk.Channel("channelID", "token")
+	//  fmt.Println(channel)
 	Channel(id, token string) (Channel, errors.SDKError)
 
 	// UpdateChannel updates existing channel.
+	//
+	// example:
+	//  channel := sdk.Channel{
+	//    ID:   "channelID",
+	//    Name: "My Channel",
+	//    Metadata: sdk.Metadata{
+	//      "key": "value",
+	//    },
+	//  }
+	//  channel, _ := sdk.UpdateChannel(channel, "token")
+	//  fmt.Println(channel)
 	UpdateChannel(channel Channel, token string) (Channel, errors.SDKError)
 
 	// EnableChannel changes channel status to enabled.
+	//
+	// example:
+	//  channel, _ := sdk.EnableChannel("channelID", "token")
+	//  fmt.Println(channel)
 	EnableChannel(id, token string) (Channel, errors.SDKError)
 
 	// DisableChannel changes channel status to disabled - soft delete.
+	//
+	// example:
+	//  channel, _ := sdk.DisableChannel("channelID", "token")
+	//  fmt.Println(channel)
 	DisableChannel(id, token string) (Channel, errors.SDKError)
 
 	// CreatePolicy creates a policy for the given subject, so that, after
 	// CreatePolicy, `subject` has a `relation` on `object`. Returns a non-nil
 	// error in case of failures.
+	//
+	// example:
+	//  policy := sdk.Policy{
+	//    Subject: "userID:1",
+	//    Object:  "groupID:1",
+	//    Actions: []string{"g_add"},
+	//  }
+	//  err := sdk.CreatePolicy(policy, "token")
+	//  fmt.Println(err)
 	CreatePolicy(policy Policy, token string) errors.SDKError
 
 	// DeletePolicy deletes policies.
+	//
+	// example:
+	//  policy := sdk.Policy{
+	//    Subject: "userID:1",
+	//    Object:  "groupID:1",
+	//    Actions: []string{"g_add"},
+	//  }
+	//  err := sdk.DeletePolicy(policy, "token")
+	//  fmt.Println(err)
 	DeletePolicy(policy Policy, token string) errors.SDKError
 
 	// UpdatePolicy updates policies based on the given policy structure.
+	//
+	// example:
+	//  policy := sdk.Policy{
+	//    Subject: "userID:1",
+	//    Object:  "groupID:1",
+	//    Actions: []string{"g_add"},
+	//  }
+	//  err := sdk.UpdatePolicy(policy, "token")
+	//  fmt.Println(err)
 	UpdatePolicy(p Policy, token string) errors.SDKError
 
 	// ListPolicies lists policies based on the given policy structure.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Subject: "userID:1",
+	//  }
+	//  policies, _ := sdk.ListPolicies(pm, "token")
+	//  fmt.Println(policies)
 	ListPolicies(pm PageMetadata, token string) (PolicyPage, errors.SDKError)
 
 	// Authorize returns true if the given policy structure allows the action.
+	//
+	// example:
+	//  p := sdk.Policy{
+	//    Subject: "userID:1",
+	//    Object:  "groupID:1",
+	//    Actions: []string{"g_add"},
+	//  }
+	//  ok, _ := sdk.Authorize(p, "clients" "token")
+	//  fmt.Println(ok)
 	Authorize(p Policy, entityType, token string) (bool, errors.SDKError)
 
 	// Assign assigns member of member type (thing or user) to a group.
+	//
+	// example:
+	//  err := sdk.Assign([]string{"g_add"}, "userID:1", "groupID:1", "token")
+	//  fmt.Println(err)
 	Assign(memberType []string, memberID, groupID, token string) errors.SDKError
 
 	// Unassign removes member from a group.
+	//
+	// example:
+	//  err := sdk.Unassign([]string{"g_add"}, "userID:1", "groupID:1", "token")
+	//  fmt.Println(err)
 	Unassign(memberType []string, groupID string, memberID string, token string) errors.SDKError
 
 	// Connect bulk connects things to channels specified by id.
+	//
+	// example:
+	//  conns := sdk.ConnectionIDs{
+	//    ChannelIDs: []string{"thingID:1", "thingID:2"},
+	//    ThingIDs:   []string{"channelID:1", "channelID:2"},
+	//    Actions:    []string{"m_read"},
+	//  }
+	//  err := sdk.Connect(conns, "token")
+	//  fmt.Println(err)
 	Connect(conns ConnectionIDs, token string) errors.SDKError
 
 	// Disconnect
+	//
+	// example:
+	//  conns := sdk.ConnectionIDs{
+	//    ChannelIDs: []string{"thingID:1", "thingID:2"},
+	//    ThingIDs:   []string{"channelID:1", "channelID:2"},
+	//  }
+	//  err := sdk.Disconnect(conns, "token")
+	//  fmt.Println(err)
 	Disconnect(connIDs ConnectionIDs, token string) errors.SDKError
 
 	// ConnectThing
+	//
+	// example:
+	//  err := sdk.ConnectThing("thingID", "channelID", "token")
+	//  fmt.Println(err)
 	ConnectThing(thingID, chanID, token string) errors.SDKError
 
 	// DisconnectThing disconnect thing from specified channel by id.
+	//
+	// example:
+	//  err := sdk.DisconnectThing("thingID", "channelID", "token")
+	//  fmt.Println(err)
 	DisconnectThing(thingID, chanID, token string) errors.SDKError
 
 	// UpdateThingsPolicy updates policies based on the given policy structure.
+	//
+	// example:
+	//  policy := sdk.Policy{
+	//    Subject: "thingID",
+	//    Object:  "channelID",
+	//    Actions: []string{"m_read"},
+	//  }
+	//  err := sdk.UpdateThingsPolicy(policy, "token")
+	//  fmt.Println(err)
 	UpdateThingsPolicy(p Policy, token string) errors.SDKError
 
 	// ListThingsPolicies lists policies based on the given policy structure.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//    Subject: "thingID:1",
+	//  }
+	//  policies, _ := sdk.ListThingsPolicies(pm, "token")
+	//  fmt.Println(policies)
 	ListThingsPolicies(pm PageMetadata, token string) (PolicyPage, errors.SDKError)
 
-	// ThingsCanAccess returns true if the given policy structure allows the action.
+	// ThingCanAccess returns true if the given policy structure allows the action.
+	//
+	// example:
+	//  p := sdk.Policy{
+	//    Subject: "thingID",
+	//    Object:  "channelID",
+	//    Actions: []string{"m_read"},
+	//  }
+	//  ok, _ := sdk.ThingCanAccess(p, "things", "token")
+	//  fmt.Println(ok)
 	ThingCanAccess(p Policy, entityType, token string) (bool, string, errors.SDKError)
 
 	// SendMessage send message to specified channel.
+	//
+	// example:
+	//  msg := '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+	//  err := sdk.SendMessage("channelID", msg, "thingSecret")
+	//  fmt.Println(err)
 	SendMessage(chanID, msg, key string) errors.SDKError
 
 	// ReadMessages read messages of specified channel.
+	//
+	// example:
+	//  msgs, _ := sdk.ReadMessages("channelID", "token")
+	//  fmt.Println(msgs)
 	ReadMessages(chanID, token string) (MessagesPage, errors.SDKError)
 
 	// SetContentType sets message content type.
+	//
+	// example:
+	//  err := sdk.SetContentType("application/json")
+	//  fmt.Println(err)
 	SetContentType(ct ContentType) errors.SDKError
 
 	// Health returns things service health check.
+	//
+	// example:
+	//  health, _ := sdk.Health()
+	//  fmt.Println(health)
 	Health() (HealthInfo, errors.SDKError)
 
 	// AddBootstrap add bootstrap configuration
+	//
+	// example:
+	//  cfg := sdk.BootstrapConfig{
+	//    ThingID: "thingID",
+	//    Name: "bootstrap",
+	//    ExternalID: "externalID",
+	//    ExternalKey: "externalKey",
+	//    Channels: []string{"channel1", "channel2"},
+	//  }
+	//  id, _ := sdk.AddBootstrap(cfg, "token")
+	//  fmt.Println(id)
 	AddBootstrap(cfg BootstrapConfig, token string) (string, errors.SDKError)
 
 	// View returns Thing Config with given ID belonging to the user identified by the given token.
+	//
+	// example:
+	//  bootstrap, _ := sdk.ViewBootstrap("id", "token")
+	//  fmt.Println(bootstrap)
 	ViewBootstrap(id, token string) (BootstrapConfig, errors.SDKError)
 
 	// Update updates editable fields of the provided Config.
+	//
+	// example:
+	//  cfg := sdk.BootstrapConfig{
+	//    ThingID: "thingID",
+	//    Name: "bootstrap",
+	//    ExternalID: "externalID",
+	//    ExternalKey: "externalKey",
+	//    Channels: []string{"channel1", "channel2"},
+	//  }
+	//  err := sdk.UpdateBootstrap(cfg, "token")
+	//  fmt.Println(err)
 	UpdateBootstrap(cfg BootstrapConfig, token string) errors.SDKError
 
 	// Update bootstrap config certificates.
+	//
+	// example:
+	//  err := sdk.UpdateBootstrapCerts("id", "clientCert", "clientKey", "ca", "token")
+	//  fmt.Println(err)
 	UpdateBootstrapCerts(id string, clientCert, clientKey, ca string, token string) errors.SDKError
 
 	// UpdateBootstrapConnection updates connections performs update of the channel list corresponding Thing is connected to.
+	//
+	// example:
+	//  err := sdk.UpdateBootstrapConnection("id", []string{"channel1", "channel2"}, "token")
+	//  fmt.Println(err)
 	UpdateBootstrapConnection(id string, channels []string, token string) errors.SDKError
 
 	// Remove removes Config with specified token that belongs to the user identified by the given token.
+	//
+	// example:
+	//  err := sdk.RemoveBootstrap("id", "token")
+	//  fmt.Println(err)
 	RemoveBootstrap(id, token string) errors.SDKError
 
 	// Bootstrap returns Config to the Thing with provided external ID using external key.
+	//
+	// example:
+	//  bootstrap, _ := sdk.Bootstrap("externalID", "externalKey")
+	//  fmt.Println(bootstrap)
 	Bootstrap(externalID, externalKey string) (BootstrapConfig, errors.SDKError)
 
 	// BootstrapSecure retrieves a configuration with given external ID and encrypted external key.
+	//
+	// example:
+	//  bootstrap, _ := sdk.BootstrapSecure("externalID", "externalKey")
+	//  fmt.Println(bootstrap)
 	BootstrapSecure(externalID, externalKey string) (BootstrapConfig, errors.SDKError)
 
 	// Bootstraps retrieves a list of managed configs.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//  }
+	//  bootstraps, _ := sdk.Bootstraps(pm, "token")
+	//  fmt.Println(bootstraps)
 	Bootstraps(pm PageMetadata, token string) (BoostrapsPage, errors.SDKError)
 
 	// Whitelist updates Thing state Config with given ID belonging to the user identified by the given token.
+	//
+	// example:
+	//  cfg := sdk.BootstrapConfig{
+	//    ThingID: "thingID",
+	//    Name: "bootstrap",
+	//    ExternalID: "externalID",
+	//    ExternalKey: "externalKey",
+	//    Channels: []string{"channel1", "channel2"},
+	//  }
+	//  err := sdk.Whitelist(cfg, "token")
+	//  fmt.Println(err)
 	Whitelist(cfg BootstrapConfig, token string) errors.SDKError
 
 	// IssueCert issues a certificate for a thing required for mTLS.
+	//
+	// example:
+	//  cert, _ := sdk.IssueCert("thingID", "valid", "token")
+	//  fmt.Println(cert)
 	IssueCert(thingID, valid, token string) (Cert, errors.SDKError)
 
 	// ViewCert returns a certificate given certificate ID
+	//
+	// example:
+	//  cert, _ := sdk.ViewCert("certID", "token")
+	//  fmt.Println(cert)
 	ViewCert(certID, token string) (Cert, errors.SDKError)
 
 	// ViewCertByThing retrieves a list of certificates' serial IDs for a given thing ID.
+	//
+	// example:
+	//  cserial, _ := sdk.ViewCertByThing("thingID", "token")
+	//  fmt.Println(cserial)
 	ViewCertByThing(thingID, token string) (CertSerials, errors.SDKError)
 
 	// RevokeCert revokes certificate for thing with thingID
+	//
+	// example:
+	//  tm, _ := sdk.RevokeCert("thingID", "token")
+	//  fmt.Println(tm)
 	RevokeCert(thingID, token string) (time.Time, errors.SDKError)
 
 	// CreateSubscription creates a new subscription
+	//
+	// example:
+	//  subscription, _ := sdk.CreateSubscription("topic", "contact", "token")
+	//  fmt.Println(subscription)
 	CreateSubscription(topic, contact, token string) (string, errors.SDKError)
 
 	// ListSubscriptions list subscriptions given list parameters.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//    Offset: 0,
+	//    Limit:  10,
+	//  }
+	//  subscriptions, _ := sdk.ListSubscriptions(pm, "token")
+	//  fmt.Println(subscriptions)
 	ListSubscriptions(pm PageMetadata, token string) (SubscriptionPage, errors.SDKError)
 
 	// ViewSubscription retrieves a subscription with the provided id.
+	//
+	// example:
+	//  subscription, _ := sdk.ViewSubscription("id", "token")
+	//  fmt.Println(subscription)
 	ViewSubscription(id, token string) (Subscription, errors.SDKError)
 
 	// DeleteSubscription removes a subscription with the provided id.
+	//
+	// example:
+	//  err := sdk.DeleteSubscription("id", "token")
+	//  fmt.Println(err)
 	DeleteSubscription(id, token string) errors.SDKError
 }
 

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -619,14 +619,15 @@ type SDK interface {
 	// Authorize returns true if the given policy structure allows the action.
 	//
 	// example:
-	//  p := sdk.Policy{
-	//    Subject: "userID:1",
-	//    Object:  "groupID:1",
-	//    Actions: []string{"g_add"},
+	//  aReq := sdk.AccessRequest{
+	//    Subject:    "userID:1",
+	//    Object:     "groupID:1",
+	//    Actions:    "g_add",
+	//    EntityType: "clients",
 	//  }
-	//  ok, _ := sdk.Authorize(p, "clients" "token")
+	//  ok, _ := sdk.Authorize(aReq, "token")
 	//  fmt.Println(ok)
-	Authorize(p Policy, entityType, token string) (bool, errors.SDKError)
+	Authorize(accessReq AccessRequest, token string) (bool, errors.SDKError)
 
 	// Assign assigns member of member type (thing or user) to a group.
 	//
@@ -706,14 +707,15 @@ type SDK interface {
 	// ThingCanAccess returns true if the given policy structure allows the action.
 	//
 	// example:
-	//  p := sdk.Policy{
-	//    Subject: "thingID",
-	//    Object:  "channelID",
-	//    Actions: []string{"m_read"},
+	//  aReq := sdk.AccessRequest{
+	//    Subject:    "thingID",
+	//    Object:     "channelID",
+	//    Actions:    "m_read",
+	//    EntityType: "things",
 	//  }
-	//  ok, _ := sdk.ThingCanAccess(p, "things", "token")
+	//  ok, _ := sdk.ThingCanAccess(aReq "token")
 	//  fmt.Println(ok)
-	ThingCanAccess(p Policy, entityType, token string) (bool, string, errors.SDKError)
+	ThingCanAccess(accessReq AccessRequest, token string) (bool, string, errors.SDKError)
 
 	// SendMessage send message to specified channel.
 	//

--- a/pkg/sdk/go/setup_test.go
+++ b/pkg/sdk/go/setup_test.go
@@ -75,12 +75,14 @@ func generateValidToken(t *testing.T, svc clients.Service, cRepo *umocks.ClientR
 	token, err := svc.IssueToken(context.Background(), client.Credentials.Identity, client.Credentials.Secret)
 	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("Create token expected nil got %s\n", err))
 	repoCall.Unset()
+	
 	return token.AccessToken
 }
 
 func generateUUID(t *testing.T) string {
 	ulid, err := idProvider.ID()
 	assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+	
 	return ulid
 }
 
@@ -150,6 +152,7 @@ func convertClientPage(p sdk.PageMetadata) mfclients.Page {
 	if err != nil {
 		return mfclients.Page{}
 	}
+	
 	return mfclients.Page{
 		Status:   status,
 		Total:    p.Total,
@@ -179,6 +182,7 @@ func convertGroup(g sdk.Group) mfgroups.Group {
 	if err != nil {
 		return mfgroups.Group{}
 	}
+	
 	return mfgroups.Group{
 		ID:          g.ID,
 		Owner:       g.OwnerID,
@@ -218,6 +222,7 @@ func convertClient(c sdk.User) mfclients.Client {
 	if err != nil {
 		return mfclients.Client{}
 	}
+	
 	return mfclients.Client{
 		ID:          c.ID,
 		Name:        c.Name,

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -30,7 +30,6 @@ type Thing struct {
 	Status      string                 `json:"status,omitempty"`
 }
 
-// CreateThing creates a new client returning its id.
 func (sdk mfSDK) CreateThing(thing Thing, token string) (Thing, errors.SDKError) {
 	data, err := json.Marshal(thing)
 	if err != nil {
@@ -73,7 +72,6 @@ func (sdk mfSDK) CreateThings(things []Thing, token string) ([]Thing, errors.SDK
 	return ctr.Things, nil
 }
 
-// Things returns page of clients.
 func (sdk mfSDK) Things(pm PageMetadata, token string) (ThingsPage, errors.SDKError) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, thingsEndpoint, pm)
 	if err != nil {
@@ -93,7 +91,6 @@ func (sdk mfSDK) Things(pm PageMetadata, token string) (ThingsPage, errors.SDKEr
 	return cp, nil
 }
 
-// ThingsByChannel retrieves everything that is assigned to a group identified by groupID.
 func (sdk mfSDK) ThingsByChannel(chanID string, pm PageMetadata, token string) (ThingsPage, errors.SDKError) {
 	url, err := sdk.withQueryParams(sdk.thingsURL, fmt.Sprintf("channels/%s/%s", chanID, thingsEndpoint), pm)
 	if err != nil {
@@ -113,7 +110,6 @@ func (sdk mfSDK) ThingsByChannel(chanID string, pm PageMetadata, token string) (
 	return tp, nil
 }
 
-// Thing returns client object by id.
 func (sdk mfSDK) Thing(id, token string) (Thing, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, thingsEndpoint, id)
 
@@ -130,7 +126,6 @@ func (sdk mfSDK) Thing(id, token string) (Thing, errors.SDKError) {
 	return t, nil
 }
 
-// UpdateThing updates existing client.
 func (sdk mfSDK) UpdateThing(t Thing, token string) (Thing, errors.SDKError) {
 	data, err := json.Marshal(t)
 	if err != nil {
@@ -152,7 +147,6 @@ func (sdk mfSDK) UpdateThing(t Thing, token string) (Thing, errors.SDKError) {
 	return t, nil
 }
 
-// UpdateThingTags updates the client's tags.
 func (sdk mfSDK) UpdateThingTags(t Thing, token string) (Thing, errors.SDKError) {
 	data, err := json.Marshal(t)
 	if err != nil {
@@ -174,7 +168,6 @@ func (sdk mfSDK) UpdateThingTags(t Thing, token string) (Thing, errors.SDKError)
 	return t, nil
 }
 
-// UpdateThingSecret updates the client's secret
 func (sdk mfSDK) UpdateThingSecret(id, secret, token string) (Thing, errors.SDKError) {
 	var ucsr = updateThingSecretReq{Secret: secret}
 
@@ -198,7 +191,6 @@ func (sdk mfSDK) UpdateThingSecret(id, secret, token string) (Thing, errors.SDKE
 	return t, nil
 }
 
-// UpdateThingOwner updates the client's owner.
 func (sdk mfSDK) UpdateThingOwner(t Thing, token string) (Thing, errors.SDKError) {
 	data, err := json.Marshal(t)
 	if err != nil {
@@ -220,12 +212,10 @@ func (sdk mfSDK) UpdateThingOwner(t Thing, token string) (Thing, errors.SDKError
 	return t, nil
 }
 
-// EnableThing changes client status to enabled.
 func (sdk mfSDK) EnableThing(id, token string) (Thing, errors.SDKError) {
 	return sdk.changeThingStatus(id, enableEndpoint, token)
 }
 
-// DisableThing changes client status to disabled - soft delete.
 func (sdk mfSDK) DisableThing(id, token string) (Thing, errors.SDKError) {
 	return sdk.changeThingStatus(id, disableEndpoint, token)
 }

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -251,7 +251,7 @@ func (sdk mfSDK) IdentifyThing(key string) (string, errors.SDKError) {
 }
 
 func (sdk mfSDK) ShareThing(thingID, groupID, userID string, actions []string, token string) errors.SDKError {
-	sreq := shareThingReq{GroupID: groupID, UserID: userID, Policies: actions}
+	sreq := shareThingReq{GroupID: groupID, UserID: userID, Actions: actions}
 	data, err := json.Marshal(sreq)
 	if err != nil {
 		return errors.NewSDKError(err)

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -256,14 +256,14 @@ func (sdk mfSDK) IdentifyThing(key string) (string, errors.SDKError) {
 	return i.ID, nil
 }
 
-func (sdk mfSDK) ShareThing(thingID string, userIDs, actions []string, token string) errors.SDKError {
-	sreq := shareThingReq{Policies: actions, UserIDs: userIDs}
+func (sdk mfSDK) ShareThing(thingID, groupID, userID string, actions []string, token string) errors.SDKError {
+	sreq := shareThingReq{GroupID: groupID, UserID: userID, Policies: actions}
 	data, err := json.Marshal(sreq)
 	if err != nil {
 		return errors.NewSDKError(err)
 	}
 
-	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, thingID, shareEndpoint)
+	url := fmt.Sprintf("%s/%s/%s/%s", sdk.thingsURL, thingsEndpoint, thingID, shareEndpoint)
 	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusOK)
 	if sdkerr != nil {
 		return sdkerr

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -236,14 +236,8 @@ func (sdk mfSDK) changeThingStatus(id, status, token string) (Thing, errors.SDKE
 }
 
 func (sdk mfSDK) IdentifyThing(key string) (string, errors.SDKError) {
-	idReq := identifyThingReq{Token: key}
-	data, err := json.Marshal(idReq)
-	if err != nil {
-		return "", errors.NewSDKError(err)
-	}
-
 	url := fmt.Sprintf("%s/%s", sdk.thingsURL, identifyEndpoint)
-	_, body, sdkerr := sdk.processRequest(http.MethodPost, url, "", string(CTJSON), data, http.StatusOK)
+	_, body, sdkerr := sdk.processRequest(http.MethodPost, url, ThingPrefix+key, string(CTJSON), nil, http.StatusOK)
 	if sdkerr != nil {
 		return "", sdkerr
 	}

--- a/pkg/sdk/go/things.go
+++ b/pkg/sdk/go/things.go
@@ -14,6 +14,7 @@ const (
 	connectEndpoint    = "connect"
 	disconnectEndpoint = "disconnect"
 	identifyEndpoint   = "identify"
+	shareEndpoint      = "share"
 )
 
 // Thing represents mainflux thing.
@@ -263,4 +264,20 @@ func (sdk mfSDK) IdentifyThing(key string) (string, errors.SDKError) {
 	}
 
 	return i.ID, nil
+}
+
+func (sdk mfSDK) ShareThing(thingID string, userIDs, actions []string, token string) errors.SDKError {
+	sreq := shareThingReq{Policies: actions, UserIDs: userIDs}
+	data, err := json.Marshal(sreq)
+	if err != nil {
+		return errors.NewSDKError(err)
+	}
+
+	url := fmt.Sprintf("%s/%s/%s", sdk.thingsURL, thingID, shareEndpoint)
+	_, _, sdkerr := sdk.processRequest(http.MethodPost, url, token, string(CTJSON), data, http.StatusOK)
+	if sdkerr != nil {
+		return sdkerr
+	}
+
+	return nil
 }

--- a/pkg/sdk/go/tokens.go
+++ b/pkg/sdk/go/tokens.go
@@ -16,7 +16,6 @@ type Token struct {
 	AccessType   string `json:"access_type,omitempty"`
 }
 
-// CreateToken receives credentials and returns user token.
 func (sdk mfSDK) CreateToken(user User) (Token, errors.SDKError) {
 	var treq = tokenReq{
 		Identity: user.Credentials.Identity,
@@ -41,7 +40,6 @@ func (sdk mfSDK) CreateToken(user User) (Token, errors.SDKError) {
 	return token, nil
 }
 
-// RefreshToken refreshes expired access tokens.
 func (sdk mfSDK) RefreshToken(token string) (Token, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.usersURL, usersEndpoint, refreshTokenEndpoint)
 

--- a/pkg/sdk/go/users.go
+++ b/pkg/sdk/go/users.go
@@ -32,7 +32,6 @@ type User struct {
 	Role        string      `json:"role,omitempty"`
 }
 
-// CreateUser creates a new client returning its id.
 func (sdk mfSDK) CreateUser(user User, token string) (User, errors.SDKError) {
 	data, err := json.Marshal(user)
 	if err != nil {
@@ -50,10 +49,10 @@ func (sdk mfSDK) CreateUser(user User, token string) (User, errors.SDKError) {
 	if err := json.Unmarshal(body, &user); err != nil {
 		return User{}, errors.NewSDKError(err)
 	}
+
 	return user, nil
 }
 
-// Users returns page of users.
 func (sdk mfSDK) Users(pm PageMetadata, token string) (UsersPage, errors.SDKError) {
 	url, err := sdk.withQueryParams(sdk.usersURL, usersEndpoint, pm)
 	if err != nil {
@@ -73,7 +72,6 @@ func (sdk mfSDK) Users(pm PageMetadata, token string) (UsersPage, errors.SDKErro
 	return cp, nil
 }
 
-// Members retrieves everything that is assigned to a group identified by groupID.
 func (sdk mfSDK) Members(groupID string, meta PageMetadata, token string) (MembersPage, errors.SDKError) {
 	url, err := sdk.withQueryParams(sdk.usersURL, fmt.Sprintf("%s/%s/%s", groupsEndpoint, groupID, membersEndpoint), meta)
 	if err != nil {
@@ -93,7 +91,6 @@ func (sdk mfSDK) Members(groupID string, meta PageMetadata, token string) (Membe
 	return mp, nil
 }
 
-// User returns user object by id.
 func (sdk mfSDK) User(id, token string) (User, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/%s", sdk.usersURL, usersEndpoint, id)
 
@@ -110,7 +107,6 @@ func (sdk mfSDK) User(id, token string) (User, errors.SDKError) {
 	return user, nil
 }
 
-// User returns user object by id.
 func (sdk mfSDK) UserProfile(token string) (User, errors.SDKError) {
 	url := fmt.Sprintf("%s/%s/profile", sdk.usersURL, usersEndpoint)
 
@@ -127,7 +123,6 @@ func (sdk mfSDK) UserProfile(token string) (User, errors.SDKError) {
 	return user, nil
 }
 
-// UpdateUser updates existing user.
 func (sdk mfSDK) UpdateUser(user User, token string) (User, errors.SDKError) {
 	data, err := json.Marshal(user)
 	if err != nil {
@@ -145,10 +140,10 @@ func (sdk mfSDK) UpdateUser(user User, token string) (User, errors.SDKError) {
 	if err := json.Unmarshal(body, &user); err != nil {
 		return User{}, errors.NewSDKError(err)
 	}
+	
 	return user, nil
 }
 
-// UpdateUserTags updates the user's tags.
 func (sdk mfSDK) UpdateUserTags(user User, token string) (User, errors.SDKError) {
 	data, err := json.Marshal(user)
 	if err != nil {
@@ -166,10 +161,10 @@ func (sdk mfSDK) UpdateUserTags(user User, token string) (User, errors.SDKError)
 	if err := json.Unmarshal(body, &user); err != nil {
 		return User{}, errors.NewSDKError(err)
 	}
+	
 	return user, nil
 }
 
-// UpdateUserIdentity updates the user's identity
 func (sdk mfSDK) UpdateUserIdentity(user User, token string) (User, errors.SDKError) {
 	ucir := updateClientIdentityReq{token: token, id: user.ID, Identity: user.Credentials.Identity}
 
@@ -193,7 +188,6 @@ func (sdk mfSDK) UpdateUserIdentity(user User, token string) (User, errors.SDKEr
 	return user, nil
 }
 
-// UpdatePassword updates user password.
 func (sdk mfSDK) UpdatePassword(oldPass, newPass, token string) (User, errors.SDKError) {
 	var ucsr = updateClientSecretReq{OldSecret: oldPass, NewSecret: newPass}
 
@@ -217,7 +211,6 @@ func (sdk mfSDK) UpdatePassword(oldPass, newPass, token string) (User, errors.SD
 	return user, nil
 }
 
-// UpdateUserOwner updates the user's owner.
 func (sdk mfSDK) UpdateUserOwner(user User, token string) (User, errors.SDKError) {
 	data, err := json.Marshal(user)
 	if err != nil {
@@ -239,12 +232,10 @@ func (sdk mfSDK) UpdateUserOwner(user User, token string) (User, errors.SDKError
 	return user, nil
 }
 
-// EnableUser changes the status of the user to enabled.
 func (sdk mfSDK) EnableUser(id, token string) (User, errors.SDKError) {
 	return sdk.changeClientStatus(token, id, enableEndpoint)
 }
 
-// DisableUser changes the status of the user to disabled.
 func (sdk mfSDK) DisableUser(id, token string) (User, errors.SDKError) {
 	return sdk.changeClientStatus(token, id, disableEndpoint)
 }

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -30,6 +30,7 @@ func newClientServer(svc clients.Service) *httptest.Server {
 	logger := mflog.NewMock()
 	mux := bone.New()
 	api.MakeClientsHandler(svc, mux, logger)
+
 	return httptest.NewServer(mux)
 }
 

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -74,10 +74,17 @@ func TestCreateClient(t *testing.T) {
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
 		},
 		{
+			desc:     "register empty user",
+			client:   sdk.User{},
+			response: sdk.User{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
+		},
+		{
 			desc: "register user with invalid identity",
 			client: sdk.User{
 				Credentials: sdk.Credentials{
-					Identity: invalidIdentity,
+					Identity: mocks.WrongID,
 					Secret:   "password",
 				},
 			},
@@ -88,20 +95,9 @@ func TestCreateClient(t *testing.T) {
 		{
 			desc: "register user with empty secret",
 			client: sdk.User{
+				Name: "emptysecret",
 				Credentials: sdk.Credentials{
-					Identity: Identity + "2",
-					Secret:   "",
-				},
-			},
-			response: sdk.User{},
-			token:    token,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
-		},
-		{
-			desc: "register user with no secret",
-			client: sdk.User{
-				Credentials: sdk.Credentials{
-					Identity: Identity + "2",
+					Secret: "",
 				},
 			},
 			response: sdk.User{},
@@ -114,17 +110,6 @@ func TestCreateClient(t *testing.T) {
 				Credentials: sdk.Credentials{
 					Identity: "",
 					Secret:   secret,
-				},
-			},
-			response: sdk.User{},
-			token:    token,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
-		},
-		{
-			desc: "register user with no identity",
-			client: sdk.User{
-				Credentials: sdk.Credentials{
-					Secret: secret,
 				},
 			},
 			response: sdk.User{},
@@ -584,6 +569,60 @@ func TestClient(t *testing.T) {
 		}
 		repoCall2.Unset()
 		repoCall1.Unset()
+		repoCall.Unset()
+	}
+}
+
+func TestProfile(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	svc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	ts := newClientServer(svc)
+	defer ts.Close()
+
+	user = sdk.User{
+		Name:        "clientname",
+		Tags:        []string{"tag1", "tag2"},
+		Credentials: sdk.Credentials{Identity: "clientidentity", Secret: secret},
+		Metadata:    validMetadata,
+		Status:      mfclients.EnabledStatus.String(),
+	}
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	clientSDK := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc     string
+		token    string
+		response sdk.User
+		err      errors.SDKError
+	}{
+		{
+			desc:     "view client successfully",
+			response: user,
+			token:    generateValidToken(t, svc, cRepo),
+			err:      nil,
+		},
+		{
+			desc:     "view client with an invalid token",
+			response: sdk.User{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := cRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
+		rClient, err := clientSDK.UserProfile(tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, rClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rClient))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+		}
 		repoCall.Unset()
 	}
 }

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -334,8 +334,8 @@ func TestListClients(t *testing.T) {
 		pm := sdk.PageMetadata{
 			Status:   tc.status,
 			Total:    total,
-			Offset:   uint64(tc.offset),
-			Limit:    uint64(tc.limit),
+			Offset:   tc.offset,
+			Limit:    tc.limit,
 			Name:     tc.name,
 			OwnerID:  tc.ownerID,
 			Metadata: tc.metadata,

--- a/things/clients/api/endpoints.go
+++ b/things/clients/api/endpoints.go
@@ -162,7 +162,7 @@ func shareClientEndpoint(svc clients.Service) endpoint.Endpoint {
 		if err := req.validate(); err != nil {
 			return nil, err
 		}
-		if err := svc.ShareClient(ctx, req.token, req.UserID, req.GroupID, req.clientID, req.Policies); err != nil {
+		if err := svc.ShareClient(ctx, req.token, req.UserID, req.GroupID, req.clientID, req.Actions); err != nil {
 			return nil, err
 		}
 		return shareClientRes{}, nil

--- a/things/clients/api/requests.go
+++ b/things/clients/api/requests.go
@@ -211,7 +211,7 @@ type shareClientReq struct {
 	clientID string
 	GroupID  string   `json:"group_id"`
 	UserID   string   `json:"user_id"`
-	Policies []string `json:"policies"`
+	Actions  []string `json:"actions"`
 }
 
 func (req shareClientReq) validate() error {
@@ -223,7 +223,7 @@ func (req shareClientReq) validate() error {
 		return apiutil.ErrMissingID
 	}
 
-	if len(req.Policies) == 0 {
+	if len(req.Actions) == 0 {
 		return apiutil.ErrEmptyList
 	}
 

--- a/things/clients/mocks/clients.go
+++ b/things/clients/mocks/clients.go
@@ -76,9 +76,6 @@ func (m *ClientRepository) Save(ctx context.Context, clis ...mfclients.Client) (
 		if cli.Owner == WrongID {
 			return []mfclients.Client{}, errors.ErrMalformedEntity
 		}
-		if cli.Credentials.Secret == "" {
-			return []mfclients.Client{}, errors.ErrMalformedEntity
-		}
 	}
 	return clis, ret.Error(1)
 }

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -256,7 +256,7 @@ func (svc service) ListClientsByGroup(ctx context.Context, token, groupID string
 		return mfclients.MembersPage{}, err
 	}
 	// If the user is admin, fetch all things connected to the channel.
-	if err := svc.checkAdmin(ctx, token, thingsObjectKey, listRelationKey); err == nil {
+	if err := svc.checkAdmin(ctx, userID, thingsObjectKey, listRelationKey); err == nil {
 		return svc.clients.Members(ctx, groupID, pm)
 	}
 	pm.Owner = userID

--- a/things/policies/api/http/endpoints.go
+++ b/things/policies/api/http/endpoints.go
@@ -15,7 +15,7 @@ func identifyEndpoint(svc clients.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		id, err := svc.Identify(ctx, req.Token)
+		id, err := svc.Identify(ctx, req.Secret)
 		if err != nil {
 			return nil, err
 		}
@@ -31,8 +31,8 @@ func authorizeEndpoint(svc policies.Service) endpoint.Endpoint {
 			return nil, err
 		}
 		ar := policies.AccessRequest{
-			Subject: req.ClientSecret,
-			Object:  req.GroupID,
+			Subject: req.Subject,
+			Object:  req.Object,
 			Action:  req.Action,
 			Entity:  req.EntityType,
 		}
@@ -106,9 +106,9 @@ func updatePolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 			return nil, err
 		}
 		policy := policies.Policy{
-			Subject: cr.ClientID,
-			Object:  cr.GroupID,
-			Actions: policies.PolicyTypes,
+			Subject: cr.Subject,
+			Object:  cr.Object,
+			Actions: cr.Actions,
 		}
 		policy, err := svc.UpdatePolicy(ctx, cr.token, policy)
 		if err != nil {

--- a/things/policies/api/http/endpoints.go
+++ b/things/policies/api/http/endpoints.go
@@ -115,7 +115,7 @@ func updatePolicyEndpoint(svc policies.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return policyRes{[]policies.Policy{policy}, true}, nil
+		return policyRes{[]policies.Policy{policy}, false}, nil
 	}
 }
 

--- a/things/policies/api/http/requests.go
+++ b/things/policies/api/http/requests.go
@@ -54,29 +54,29 @@ func (req createPoliciesReq) validate() error {
 }
 
 type identifyReq struct {
-	Token string `json:"token"`
+	Secret string `json:"token"`
 }
 
 func (req identifyReq) validate() error {
-	if req.Token == "" {
-		return apiutil.ErrBearerKey
+	if req.Secret == "" {
+		return apiutil.ErrMissingSecret
 	}
 
 	return nil
 }
 
 type authorizeReq struct {
-	ClientSecret string `json:"secret"`
-	GroupID      string `json:"group_id"`
-	Action       string `json:"action"`
-	EntityType   string `json:"entity_type"`
+	Subject    string `json:"secret"`
+	Object     string
+	Action     string `json:"action"`
+	EntityType string `json:"entity_type"`
 }
 
 func (req authorizeReq) validate() error {
-	if req.GroupID == "" {
+	if req.Object == "" {
 		return apiutil.ErrMissingID
 	}
-	if req.ClientSecret == "" {
+	if req.Subject == "" {
 		return apiutil.ErrMissingSecret
 	}
 
@@ -84,11 +84,10 @@ func (req authorizeReq) validate() error {
 }
 
 type policyReq struct {
-	token    string
-	Owner    string `json:"owner,omitempty"`
-	ClientID string `json:"client,omitempty"`
-	GroupID  string `json:"group,omitempty"`
-	Action   string `json:"action,omitempty"`
+	token   string
+	Subject string   `json:"subject,omitempty"`
+	Object  string   `json:"object,omitempty"`
+	Actions []string `json:"actions,omitempty"`
 }
 
 func (req policyReq) validate() error {

--- a/things/policies/api/http/responses.go
+++ b/things/policies/api/http/responses.go
@@ -37,7 +37,7 @@ func (res policyRes) Empty() bool {
 }
 
 type listPolicyRes struct {
-	policies.PolicyPage `json:"policies"`
+	policies.PolicyPage
 }
 
 func (res listPolicyRes) Code() int {

--- a/things/policies/api/http/transport.go
+++ b/things/policies/api/http/transport.go
@@ -128,10 +128,7 @@ func decodeIdentify(_ context.Context, r *http.Request) (interface{}, error) {
 		return nil, errors.ErrUnsupportedContentType
 	}
 
-	req := identifyReq{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return nil, errors.Wrap(errors.ErrMalformedEntity, err)
-	}
+	req := identifyReq{Secret: apiutil.ExtractThingKey(r)}
 
 	return req, nil
 }
@@ -142,7 +139,7 @@ func decodeCanAccess(_ context.Context, r *http.Request) (interface{}, error) {
 	}
 
 	req := authorizeReq{
-		GroupID: bone.GetValue(r, "chanID"),
+		Object: bone.GetValue(r, "chanID"),
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, errors.Wrap(errors.ErrMalformedEntity, err)

--- a/things/policies/api/http/transport.go
+++ b/things/policies/api/http/transport.go
@@ -57,21 +57,21 @@ func MakePolicyHandler(csvc clients.Service, psvc policies.Service, mux *bone.Mu
 		opts...,
 	))
 
-	mux.Put("/identify", kithttp.NewServer(
+	mux.Put("/things/policies", kithttp.NewServer(
 		otelkit.EndpointMiddleware(otelkit.WithOperation("update_policy"))(updatePolicyEndpoint(psvc)),
 		decodeUpdatePolicy,
 		api.EncodeResponse,
 		opts...,
 	))
 
-	mux.Get("/identify", kithttp.NewServer(
+	mux.Get("/things/policies", kithttp.NewServer(
 		otelkit.EndpointMiddleware(otelkit.WithOperation("list_policies"))(listPoliciesEndpoint(psvc)),
 		decodeListPolicies,
 		api.EncodeResponse,
 		opts...,
 	))
 
-	mux.Post("/identify/channels/:chanID/access", kithttp.NewServer(
+	mux.Post("/channels/:chanID/access", kithttp.NewServer(
 		otelkit.EndpointMiddleware(otelkit.WithOperation("authorize"))(authorizeEndpoint(psvc)),
 		decodeCanAccess,
 		api.EncodeResponse,

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -240,7 +240,7 @@ func (svc service) UpdateClientIdentity(ctx context.Context, token, clientID, id
 	}
 
 	cli := mfclients.Client{
-		ID: id,
+		ID: clientID,
 		Credentials: mfclients.Credentials{
 			Identity: identity,
 		},

--- a/users/policies/api/http/endpoints.go
+++ b/users/policies/api/http/endpoints.go
@@ -11,19 +11,19 @@ func authorizeEndpoint(svc policies.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(authorizeReq)
 		if err := req.validate(); err != nil {
-			return authorizeRes{authorized: false}, err
+			return authorizeRes{Authorized: false}, err
 		}
 		policy := policies.Policy{
 			Subject: req.Subject,
 			Object:  req.Object,
-			Actions: req.Actions,
+			Actions: []string{req.Action},
 		}
 		err := svc.Authorize(ctx, req.EntityType, policy)
 		if err != nil {
-			return authorizeRes{authorized: false}, err
+			return authorizeRes{Authorized: false}, err
 		}
 
-		return authorizeRes{authorized: true}, nil
+		return authorizeRes{Authorized: true}, nil
 	}
 }
 

--- a/users/policies/api/http/requests.go
+++ b/users/policies/api/http/requests.go
@@ -6,18 +6,17 @@ import (
 )
 
 type authorizeReq struct {
-	Subject    string   `json:"subject,omitempty"`
-	Object     string   `json:"object,omitempty"`
-	Actions    []string `json:"actions,omitempty"`
-	EntityType string   `json:"entity_type,omitempty"`
+	Subject    string `json:"subject,omitempty"`
+	Object     string `json:"object,omitempty"`
+	Action     string `json:"action,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
 }
 
 func (req authorizeReq) validate() error {
-	for _, a := range req.Actions {
-		if ok := policies.ValidateAction(a); !ok {
-			return apiutil.ErrMalformedPolicyAct
-		}
+	if ok := policies.ValidateAction(req.Action); !ok {
+		return apiutil.ErrMalformedPolicyAct
 	}
+
 	if req.Subject == "" {
 		return apiutil.ErrMissingPolicySub
 	}

--- a/users/policies/api/http/responses.go
+++ b/users/policies/api/http/responses.go
@@ -23,7 +23,7 @@ type pageRes struct {
 }
 
 type authorizeRes struct {
-	authorized bool
+	Authorized bool `json:"authorized"`
 }
 
 func (res authorizeRes) Code() int {


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?
- Adds functions relating to things policies on SDK
- Removes unnecessary configs on nginx
- Add examples to go docs for SDK
- Update `unassign` SDK function not to take `actions` as parameter
- Fix `list things by channel` by checking admin using `userID` rather than `token`.
- Fixes
```
        	Error Trace:	/home/runner/mainflux/bootstrap/redis/producer/streams_test.go:579
        	            				/home/runner/mainflux/bootstrap/redis/producer/streams_test.go:277
        	Error:      	Not equal: 
        	            	expected: map[string]interface {}{"channels":"[1, 2]", "content":"new-config", "external_id":"external_id", "mainflux_thing":"1", "name":"new name", "operation":"config.update", "owner":"user@example.com", "state":"0"}
        	            	actual  : map[string]interface {}{"channels":"[2, 1]", "content":"new-config", "external_id":"external_id", "mainflux_thing":"1", "name":"new name", "operation":"config.update", "owner":"user@example.com", "state":"0"}
```
- Add examples to `CLI`
- Make `HTTP` endpoint for identify take in `secret` as header

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
Yes

### Notes
N/A