### PR TITLE
NOISSUE - Add SDK Tests

### DIFF
--- a/bootstrap/mocks/users.go
+++ b/bootstrap/mocks/users.go
@@ -23,7 +23,7 @@ func NewAuthClient(users map[string]string) policies.AuthServiceClient {
 }
 
 func (svc serviceMock) Identify(ctx context.Context, in *policies.Token, opts ...grpc.CallOption) (*policies.UserIdentity, error) {
-	if id, ok := svc.users[in.Value]; ok {
+	if id, ok := svc.users[in.GetValue()]; ok {
 		return &policies.UserIdentity{Id: id}, nil
 	}
 	return nil, errors.ErrAuthentication

--- a/cli/channels.go
+++ b/cli/channels.go
@@ -116,8 +116,8 @@ var cmdChannels = []cobra.Command{
 				return
 			}
 			pm := mfxsdk.PageMetadata{
-				Offset:       uint64(Offset),
-				Limit:        uint64(Limit),
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
 			}
 			cl, err := sdk.ThingsByChannel(args[0], pm, args[1])
 			if err != nil {

--- a/cli/things.go
+++ b/cli/things.go
@@ -300,8 +300,8 @@ var cmdThings = []cobra.Command{
 				return
 			}
 			pm := mfxsdk.PageMetadata{
-				Offset:       uint64(Offset),
-				Limit:        uint64(Limit),
+				Offset: uint64(Offset),
+				Limit:  uint64(Limit),
 			}
 			cl, err := sdk.ChannelsByThing(args[0], pm, args[1])
 			if err != nil {

--- a/consumers/notifiers/api/endpoint_test.go
+++ b/consumers/notifiers/api/endpoint_test.go
@@ -412,7 +412,7 @@ func TestRemove(t *testing.T) {
 			desc:   "remove not existing",
 			id:     "not existing",
 			auth:   token,
-			status: http.StatusNoContent,
+			status: http.StatusNotFound,
 		},
 		{
 			desc:   "remove empty id",

--- a/consumers/notifiers/mocks/subscriptions.go
+++ b/consumers/notifiers/mocks/subscriptions.go
@@ -123,6 +123,9 @@ func appendSubs(subs []notifiers.Subscription, sub notifiers.Subscription, max i
 func (srm *subRepoMock) Remove(_ context.Context, id string) error {
 	srm.mu.Lock()
 	defer srm.mu.Unlock()
+	if _, ok := srm.subs[id]; !ok {
+		return errors.ErrNotFound
+	}
 	delete(srm.subs, id)
 	return nil
 }

--- a/consumers/notifiers/service_test.go
+++ b/consumers/notifiers/service_test.go
@@ -257,7 +257,7 @@ func TestRemoveSubscription(t *testing.T) {
 			desc:  "test not existing",
 			token: exampleUser1,
 			id:    "not_exist",
-			err:   nil,
+			err:   errors.ErrNotFound,
 		},
 		{
 			desc:  "test with empty token",

--- a/pkg/sdk/go/certs_test.go
+++ b/pkg/sdk/go/certs_test.go
@@ -1,0 +1,363 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package sdk_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bsmocks "github.com/mainflux/mainflux/bootstrap/mocks"
+	"github.com/mainflux/mainflux/certs"
+	httpapi "github.com/mainflux/mainflux/certs/api"
+	"github.com/mainflux/mainflux/certs/mocks"
+	"github.com/mainflux/mainflux/internal/apiutil"
+	"github.com/mainflux/mainflux/logger"
+	mfclients "github.com/mainflux/mainflux/pkg/clients"
+	"github.com/mainflux/mainflux/pkg/errors"
+	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"github.com/mainflux/mainflux/things/clients"
+	"github.com/mainflux/mainflux/things/policies"
+	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	upolicies "github.com/mainflux/mainflux/users/policies"
+)
+
+var (
+	thingsNum         = 1
+	thingKey          = "thingKey"
+	thingID           = "1"
+	caPath            = "../../../docker/ssl/certs/ca.crt"
+	caKeyPath         = "../../../docker/ssl/certs/ca.key"
+	cfgAuthTimeout    = "1s"
+	cfgSignHoursValid = "24h"
+)
+
+func newCertsThingsService(auth upolicies.AuthServiceClient) clients.Service {
+	ths := make(map[string]mfclients.Client, thingsNum)
+	for i := 0; i < thingsNum; i++ {
+		id := strconv.Itoa(i + 1)
+		ths[id] = mfclients.Client{
+			ID: id,
+			Credentials: mfclients.Credentials{
+				Secret: thingKey,
+			},
+			Owner:  adminID,
+			Status: mfclients.EnabledStatus,
+		}
+	}
+
+	return bsmocks.NewThingsService(ths, auth)
+}
+
+func newCertService() (certs.Service, error) {
+	uauth := bsmocks.NewAuthClient(map[string]string{adminToken: adminID})
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+	server := newThingsServer(newCertsThingsService(uauth), psvc)
+
+	config := sdk.Config{
+		ThingsURL: server.URL,
+	}
+
+	mfsdk := sdk.NewSDK(config)
+	repo := mocks.NewCertsRepository()
+
+	tlsCert, caCert, err := certs.LoadCertificates(caPath, caKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	authTimeout, err := time.ParseDuration(cfgAuthTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	pki := mocks.NewPkiAgent(tlsCert, caCert, cfgSignHoursValid, authTimeout)
+
+	return certs.New(uauth, repo, mfsdk, pki), nil
+}
+
+func newCertServer(svc certs.Service) *httptest.Server {
+	logger := logger.NewMock()
+	mux := httpapi.MakeHandler(svc, logger)
+	return httptest.NewServer(mux)
+}
+
+func TestIssueCert(t *testing.T) {
+	svc, err := newCertService()
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating service: %s", err))
+	ts := newCertServer(svc)
+	defer ts.Close()
+
+	sdkConf := sdk.Config{
+		CertsURL:        ts.URL,
+		MsgContentType:  contentType,
+		TLSVerification: false,
+	}
+
+	csdk := sdk.NewSDK(sdkConf)
+
+	cases := []struct {
+		desc     string
+		thingID  string
+		duration string
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "create new cert with thing id and duration",
+			thingID:  thingID,
+			duration: "10h",
+			token:    adminToken,
+			err:      nil,
+		},
+		{
+			desc:     "create new cert with empty thing id and duration",
+			thingID:  "",
+			duration: "10h",
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+		},
+		{
+			desc:     "create new cert with invalid thing id and duration",
+			thingID:  "ah",
+			duration: "10h",
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(certs.ErrFailedCertCreation, http.StatusInternalServerError),
+		},
+		{
+			desc:     "create new cert with thing id and empty duration",
+			thingID:  thingID,
+			duration: "",
+			token:    exampleUser1,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrMissingCertData, http.StatusBadRequest),
+		},
+		{
+			desc:     "create new cert with thing id and malformed duration",
+			thingID:  thingID,
+			duration: "10g",
+			token:    exampleUser1,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrInvalidCertData, http.StatusBadRequest),
+		},
+		{
+			desc:     "create new cert with empty token",
+			thingID:  thingID,
+			duration: "10h",
+			token:    "",
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
+		},
+		{
+			desc:     "create new cert with invalid token",
+			thingID:  thingID,
+			duration: "10h",
+			token:    wrongValue,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+		{
+			desc:     "create new empty cert",
+			thingID:  "",
+			duration: "",
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+		},
+	}
+
+	for _, tc := range cases {
+		cert, err := csdk.IssueCert(tc.thingID, tc.duration, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if err == nil {
+			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
+		}
+	}
+}
+
+func TestViewCert(t *testing.T) {
+	svc, err := newCertService()
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating service: %s", err))
+	ts := newCertServer(svc)
+	defer ts.Close()
+
+	sdkConf := sdk.Config{
+		CertsURL:        ts.URL,
+		MsgContentType:  contentType,
+		TLSVerification: false,
+	}
+
+	csdk := sdk.NewSDK(sdkConf)
+
+	cert, err := csdk.IssueCert(thingID, "10h", token)
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
+
+	cases := []struct {
+		desc     string
+		certID   string
+		token    string
+		err      errors.SDKError
+		response sdk.Subscription
+	}{
+		{
+			desc:     "get existing cert",
+			certID:   cert.CertSerial,
+			token:    token,
+			err:      nil,
+			response: sub1,
+		},
+		{
+			desc:     "get non-existent cert",
+			certID:   "43",
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusInternalServerError),
+			response: sdk.Subscription{},
+		},
+		{
+			desc:     "get cert with invalid token",
+			certID:   cert.CertSerial,
+			token:    "",
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
+			response: sdk.Subscription{},
+		},
+	}
+
+	for _, tc := range cases {
+		cert, err := csdk.ViewCert(tc.certID, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if err == nil {
+			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
+		}
+	}
+}
+
+func TestViewCertByThing(t *testing.T) {
+	svc, err := newCertService()
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating service: %s", err))
+	ts := newCertServer(svc)
+	defer ts.Close()
+
+	sdkConf := sdk.Config{
+		CertsURL:        ts.URL,
+		MsgContentType:  contentType,
+		TLSVerification: false,
+	}
+
+	csdk := sdk.NewSDK(sdkConf)
+
+	_, err = csdk.IssueCert(thingID, "10h", token)
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
+
+	cases := []struct {
+		desc     string
+		thingID  string
+		token    string
+		err      errors.SDKError
+		response sdk.Subscription
+	}{
+		{
+			desc:     "get existing cert",
+			thingID:  thingID,
+			token:    token,
+			err:      nil,
+			response: sub1,
+		},
+		{
+			desc:     "get non-existent cert",
+			thingID:  "43",
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusInternalServerError),
+			response: sdk.Subscription{},
+		},
+		{
+			desc:     "get cert with invalid token",
+			thingID:  thingID,
+			token:    "",
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
+			response: sdk.Subscription{},
+		},
+	}
+
+	for _, tc := range cases {
+		cert, err := csdk.ViewCertByThing(tc.thingID, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if err == nil {
+			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
+		}
+	}
+}
+
+func TestRevokeCert(t *testing.T) {
+	svc, err := newCertService()
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating service: %s", err))
+	ts := newCertServer(svc)
+	defer ts.Close()
+
+	sdkConf := sdk.Config{
+		CertsURL:        ts.URL,
+		MsgContentType:  contentType,
+		TLSVerification: false,
+	}
+
+	csdk := sdk.NewSDK(sdkConf)
+
+	_, err = csdk.IssueCert(thingID, "10h", adminToken)
+	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
+
+	cases := []struct {
+		desc    string
+		thingID string
+		token   string
+		err     errors.SDKError
+	}{
+		{
+			desc:    "revoke cert with invalid token",
+			thingID: thingID,
+			token:   wrongValue,
+			err:     errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+		{
+			desc:    "revoke non-existing cert",
+			thingID: "2",
+			token:   token,
+			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedCertRevocation, http.StatusInternalServerError),
+		},
+		{
+			desc:    "revoke cert with invalid id",
+			thingID: "",
+			token:   token,
+			err:     errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+		},
+		{
+			desc:    "revoke cert with empty token",
+			thingID: thingID,
+			token:   "",
+			err:     errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
+		},
+		{
+			desc:    "revoke existing cert",
+			thingID: thingID,
+			token:   token,
+			err:     nil,
+		},
+		{
+			desc:    "revoke deleted cert",
+			thingID: thingID,
+			token:   token,
+			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedToRemoveCertFromDB, http.StatusInternalServerError),
+		},
+	}
+
+	for _, tc := range cases {
+		response, err := csdk.RevokeCert(tc.thingID, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if err == nil {
+			assert.NotEmpty(t, response, fmt.Sprintf("%s: got empty revocation time", tc.desc))
+		}
+	}
+}

--- a/pkg/sdk/go/certs_test.go
+++ b/pkg/sdk/go/certs_test.go
@@ -104,7 +104,7 @@ func TestIssueCert(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	csdk := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
 	cases := []struct {
 		desc     string
@@ -172,7 +172,7 @@ func TestIssueCert(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		cert, err := csdk.IssueCert(tc.thingID, tc.duration, tc.token)
+		cert, err := mfsdk.IssueCert(tc.thingID, tc.duration, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if err == nil {
 			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
@@ -192,9 +192,9 @@ func TestViewCert(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	csdk := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
-	cert, err := csdk.IssueCert(thingID, "10h", token)
+	cert, err := mfsdk.IssueCert(thingID, "10h", token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
 
 	cases := []struct {
@@ -228,7 +228,7 @@ func TestViewCert(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		cert, err := csdk.ViewCert(tc.certID, tc.token)
+		cert, err := mfsdk.ViewCert(tc.certID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if err == nil {
 			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
@@ -248,9 +248,9 @@ func TestViewCertByThing(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	csdk := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
-	_, err = csdk.IssueCert(thingID, "10h", token)
+	_, err = mfsdk.IssueCert(thingID, "10h", token)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
 
 	cases := []struct {
@@ -284,7 +284,7 @@ func TestViewCertByThing(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		cert, err := csdk.ViewCertByThing(tc.thingID, tc.token)
+		cert, err := mfsdk.ViewCertByThing(tc.thingID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if err == nil {
 			assert.NotEmpty(t, cert, fmt.Sprintf("%s: got empty cert", tc.desc))
@@ -304,9 +304,9 @@ func TestRevokeCert(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	csdk := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
-	_, err = csdk.IssueCert(thingID, "10h", adminToken)
+	_, err = mfsdk.IssueCert(thingID, "10h", adminToken)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during creating cert: %s", err))
 
 	cases := []struct {
@@ -354,7 +354,7 @@ func TestRevokeCert(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		response, err := csdk.RevokeCert(tc.thingID, tc.token)
+		response, err := mfsdk.RevokeCert(tc.thingID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if err == nil {
 			assert.NotEmpty(t, response, fmt.Sprintf("%s: got empty revocation time", tc.desc))

--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -1,0 +1,1 @@
+package sdk_test

--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -1,1 +1,906 @@
 package sdk_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-zoo/bone"
+	"github.com/mainflux/mainflux/internal/apiutil"
+	"github.com/mainflux/mainflux/internal/testsutil"
+	"github.com/mainflux/mainflux/logger"
+	mfclients "github.com/mainflux/mainflux/pkg/clients"
+	"github.com/mainflux/mainflux/pkg/errors"
+	mfgroups "github.com/mainflux/mainflux/pkg/groups"
+	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"github.com/mainflux/mainflux/things/clients"
+	"github.com/mainflux/mainflux/things/clients/mocks"
+	"github.com/mainflux/mainflux/things/groups"
+	"github.com/mainflux/mainflux/things/groups/api"
+	gmocks "github.com/mainflux/mainflux/things/groups/mocks"
+	"github.com/mainflux/mainflux/things/policies"
+	papi "github.com/mainflux/mainflux/things/policies/api/http"
+	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	umocks "github.com/mainflux/mainflux/users/clients/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newChannelsServer(csvc clients.Service, svc groups.Service, psvc policies.Service) *httptest.Server {
+	logger := logger.NewMock()
+	mux := bone.New()
+	api.MakeHandler(svc, mux, logger)
+	papi.MakePolicyHandler(csvc, psvc, mux, logger)
+	return httptest.NewServer(mux)
+}
+
+func TestCreateChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	channel := sdk.Channel{
+		Name:     "channelName",
+		Metadata: validMetadata,
+		Status:   mfclients.EnabledStatus.String(),
+	}
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+	cases := []struct {
+		desc    string
+		channel sdk.Channel
+		token   string
+		err     errors.SDKError
+	}{
+		{
+			desc:    "create channel successfully",
+			channel: channel,
+			token:   token,
+			err:     nil,
+		},
+		{
+			desc:    "create channel with existing name",
+			channel: channel,
+			err:     nil,
+		},
+		{
+			desc: "update channel that can't be marshalled",
+			channel: sdk.Channel{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			token: token,
+			err:   errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
+		{
+			desc: "create channel with parent",
+			channel: sdk.Channel{
+				Name:     gName,
+				ParentID: testsutil.GenerateUUID(t, idProvider),
+				Status:   mfclients.EnabledStatus.String(),
+			},
+			err: nil,
+		},
+		{
+			desc: "create channel with invalid parent",
+			channel: sdk.Channel{
+				Name:     gName,
+				ParentID: gmocks.WrongID,
+				Status:   mfclients.EnabledStatus.String(),
+			},
+			err: errors.NewSDKErrorWithStatus(errors.ErrCreateEntity, http.StatusInternalServerError),
+		},
+		{
+			desc: "create channel with invalid owner",
+			channel: sdk.Channel{
+				Name:    gName,
+				OwnerID: gmocks.WrongID,
+				Status:  mfclients.EnabledStatus.String(),
+			},
+			err: errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc: "create channel with missing name",
+			channel: sdk.Channel{
+				Status: mfclients.EnabledStatus.String(),
+			},
+			err: errors.NewSDKErrorWithStatus(apiutil.ErrNameSize, http.StatusBadRequest),
+		},
+		{
+			desc: "create a channel with every field defined",
+			channel: sdk.Channel{
+				ID:          generateUUID(t),
+				OwnerID:     "owner",
+				ParentID:    "parent",
+				Name:        "name",
+				Description: description,
+				Metadata:    validMetadata,
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+				Status:      mfclients.EnabledStatus.String(),
+			},
+			token: token,
+			err:   nil,
+		},
+	}
+	for _, tc := range cases {
+		repoCall := gRepo.On("Save", mock.Anything, mock.Anything).Return(convertChannel(sdk.Channel{}), tc.err)
+		rChannel, err := chSDK.CreateChannel(tc.channel, adminToken)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+		if err == nil {
+			assert.NotEmpty(t, rChannel, fmt.Sprintf("%s: expected not nil on client ID", tc.desc))
+			ok := repoCall.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestCreateChannels(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	channels := []sdk.Channel{
+		{
+			Name:     "channelName",
+			Metadata: validMetadata,
+			Status:   mfclients.EnabledStatus.String(),
+		},
+		{
+			Name:     "channelName2",
+			Metadata: validMetadata,
+			Status:   mfclients.EnabledStatus.String(),
+		},
+	}
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+	cases := []struct {
+		desc     string
+		channels []sdk.Channel
+		response []sdk.Channel
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "create channels successfully",
+			channels: channels,
+			response: channels,
+			token:    token,
+			err:      nil,
+		},
+		{
+			desc:     "register empty channels",
+			channels: []sdk.Channel{},
+			response: []sdk.Channel{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrEmptyList, http.StatusBadRequest),
+		},
+		{
+			desc: "register channels that can't be marshalled",
+			channels: []sdk.Channel{
+				{
+					Name: "test",
+					Metadata: map[string]interface{}{
+						"test": make(chan int),
+					},
+				},
+			},
+			response: []sdk.Channel{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
+	}
+	for _, tc := range cases {
+		repoCall := gRepo.On("Save", mock.Anything, mock.Anything).Return(convertChannels(tc.response), tc.err)
+		rChannel, err := chSDK.CreateChannels(tc.channels, adminToken)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
+		if err == nil {
+			assert.NotEmpty(t, rChannel, fmt.Sprintf("%s: expected not nil on client ID", tc.desc))
+			ok := repoCall.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestListChannels(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	var chs []sdk.Channel
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+
+	for i := 10; i < 100; i++ {
+		gr := sdk.Channel{
+			ID:       generateUUID(t),
+			Name:     fmt.Sprintf("channel_%d", i),
+			Metadata: sdk.Metadata{"name": fmt.Sprintf("thing_%d", i)},
+			Status:   mfclients.EnabledStatus.String(),
+		}
+		chs = append(chs, gr)
+	}
+
+	cases := []struct {
+		desc     string
+		token    string
+		status   mfclients.Status
+		total    uint64
+		offset   uint64
+		limit    uint64
+		level    int
+		name     string
+		ownerID  string
+		metadata sdk.Metadata
+		err      errors.SDKError
+		response []sdk.Channel
+	}{
+		{
+			desc:     "get a list of channels",
+			token:    token,
+			limit:    limit,
+			offset:   offset,
+			total:    total,
+			err:      nil,
+			response: chs[offset:limit],
+		},
+		{
+			desc:     "get a list of channels with invalid token",
+			token:    invalidToken,
+			offset:   offset,
+			limit:    limit,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of channels with empty token",
+			token:    "",
+			offset:   offset,
+			limit:    limit,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of channels with zero limit",
+			token:    token,
+			offset:   offset,
+			limit:    0,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of channels with limit greater than max",
+			token:    token,
+			offset:   offset,
+			limit:    110,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: []sdk.Channel(nil),
+		},
+		{
+			desc:     "get a list of channels with given name",
+			token:    token,
+			offset:   0,
+			limit:    1,
+			err:      nil,
+			metadata: sdk.Metadata{},
+			response: []sdk.Channel{chs[89]},
+		},
+		{
+			desc:     "get a list of channels with level",
+			token:    token,
+			offset:   0,
+			limit:    1,
+			level:    1,
+			err:      nil,
+			response: []sdk.Channel{chs[0]},
+		},
+		{
+			desc:     "get a list of channels with metadata",
+			token:    token,
+			offset:   0,
+			limit:    1,
+			err:      nil,
+			metadata: sdk.Metadata{},
+			response: []sdk.Channel{chs[89]},
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := gRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfgroups.GroupsPage{Groups: convertChannels(tc.response)}, tc.err)
+		pm := sdk.PageMetadata{}
+		page, err := chSDK.Channels(pm, adminToken)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, len(tc.response), len(page.Channels), fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
+		if tc.err == nil {
+			ok := repoCall1.Parent.AssertCalled(t, "RetrieveAll", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("RetrieveAll was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestViewChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	channel := sdk.Channel{
+		Name:        "channelName",
+		Description: description,
+		Metadata:    validMetadata,
+		Children:    []*sdk.Channel{},
+		Status:      mfclients.EnabledStatus.String(),
+	}
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+	channel.ID = generateUUID(t)
+
+	cases := []struct {
+		desc      string
+		token     string
+		channelID string
+		response  sdk.Channel
+		err       errors.SDKError
+	}{
+		{
+
+			desc:      "view channel",
+			token:     adminToken,
+			channelID: channel.ID,
+			response:  channel,
+			err:       nil,
+		},
+		{
+			desc:      "view channel with invalid token",
+			token:     "wrongtoken",
+			channelID: channel.ID,
+			response:  sdk.Channel{Children: []*sdk.Channel{}},
+			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:      "view channel for wrong id",
+			token:     adminToken,
+			channelID: gmocks.WrongID,
+			response:  sdk.Channel{Children: []*sdk.Channel{}},
+			err:       errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := gRepo.On("RetrieveByID", mock.Anything, tc.channelID).Return(convertChannel(tc.response), tc.err)
+		grp, err := chSDK.Channel(tc.channelID, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if len(tc.response.Children) == 0 {
+			tc.response.Children = nil
+		}
+		if len(grp.Children) == 0 {
+			grp.Children = nil
+		}
+		assert.Equal(t, tc.response, grp, fmt.Sprintf("%s: expected metadata %v got %v\n", tc.desc, tc.response, grp))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateGroupAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, tc.channelID)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestUpdateChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	channel := sdk.Channel{
+		ID:          generateUUID(t),
+		Name:        "channelsName",
+		Description: description,
+		Metadata:    validMetadata,
+	}
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+
+	channel.ID = generateUUID(t)
+
+	cases := []struct {
+		desc     string
+		token    string
+		channel  sdk.Channel
+		response sdk.Channel
+		err      errors.SDKError
+	}{
+		{
+			desc: "update channel name",
+			channel: sdk.Channel{
+				ID:   channel.ID,
+				Name: "NewName",
+			},
+			response: sdk.Channel{
+				ID:   channel.ID,
+				Name: "NewName",
+			},
+			token: adminToken,
+			err:   nil,
+		},
+		{
+			desc: "update channel description",
+			channel: sdk.Channel{
+				ID:          channel.ID,
+				Description: "NewDescription",
+			},
+			response: sdk.Channel{
+				ID:          channel.ID,
+				Description: "NewDescription",
+			},
+			token: adminToken,
+			err:   nil,
+		},
+		{
+			desc: "update channel metadata",
+			channel: sdk.Channel{
+				ID: channel.ID,
+				Metadata: sdk.Metadata{
+					"field": "value2",
+				},
+			},
+			response: sdk.Channel{
+				ID: channel.ID,
+				Metadata: sdk.Metadata{
+					"field": "value2",
+				},
+			},
+			token: adminToken,
+			err:   nil,
+		},
+		{
+			desc: "update channel name with invalid channel id",
+			channel: sdk.Channel{
+				ID:   gmocks.WrongID,
+				Name: "NewName",
+			},
+			response: sdk.Channel{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+		{
+			desc: "update channel description with invalid channel id",
+			channel: sdk.Channel{
+				ID:          gmocks.WrongID,
+				Description: "NewDescription",
+			},
+			response: sdk.Channel{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+		{
+			desc: "update channel metadata with invalid channel id",
+			channel: sdk.Channel{
+				ID: gmocks.WrongID,
+				Metadata: sdk.Metadata{
+					"field": "value2",
+				},
+			},
+			response: sdk.Channel{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+		{
+			desc: "update channel name with invalid token",
+			channel: sdk.Channel{
+				ID:   channel.ID,
+				Name: "NewName",
+			},
+			response: sdk.Channel{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc: "update channel description with invalid token",
+			channel: sdk.Channel{
+				ID:          channel.ID,
+				Description: "NewDescription",
+			},
+			response: sdk.Channel{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc: "update channel metadata with invalid token",
+			channel: sdk.Channel{
+				ID: channel.ID,
+				Metadata: sdk.Metadata{
+					"field": "value2",
+				},
+			},
+			response: sdk.Channel{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc: "update channel that can't be marshalled",
+			channel: sdk.Channel{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.Channel{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := gRepo.On("Update", mock.Anything, mock.Anything).Return(convertChannel(tc.response), tc.err)
+		_, err := chSDK.UpdateChannel(tc.channel, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateGroupAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestListChannelsByThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+
+	var nChannels = uint64(100)
+	var aChannels = []sdk.Channel{}
+
+	for i := uint64(1); i < nChannels; i++ {
+		channel := sdk.Channel{
+			Name:     fmt.Sprintf("membership_%d@example.com", i),
+			Metadata: sdk.Metadata{"role": "channel"},
+			Status:   mfclients.EnabledStatus.String(),
+		}
+		aChannels = append(aChannels, channel)
+	}
+
+	cases := []struct {
+		desc     string
+		token    string
+		clientID string
+		page     sdk.PageMetadata
+		response []sdk.Channel
+		err      errors.SDKError
+	}{
+		{
+			desc:     "list channel with authorized token",
+			token:    adminToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page:     sdk.PageMetadata{},
+			response: aChannels,
+			err:      nil,
+		},
+		{
+			desc:     "list channel with offset and limit",
+			token:    adminToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Offset: 6,
+				Total:  nChannels,
+				Limit:  nChannels,
+				Status: mfclients.AllStatus.String(),
+			},
+			response: aChannels[6 : nChannels-1],
+			err:      nil,
+		},
+		{
+			desc:     "list channel with given name",
+			token:    adminToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Name:   gName,
+				Offset: 6,
+				Total:  nChannels,
+				Limit:  nChannels,
+				Status: mfclients.AllStatus.String(),
+			},
+			response: aChannels[6 : nChannels-1],
+			err:      nil,
+		},
+		{
+			desc:     "list channel with given level",
+			token:    adminToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Level:  1,
+				Offset: 6,
+				Total:  nChannels,
+				Limit:  nChannels,
+				Status: mfclients.AllStatus.String(),
+			},
+			response: aChannels[6 : nChannels-1],
+			err:      nil,
+		},
+		{
+			desc:     "list channel with metadata",
+			token:    adminToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Metadata: validMetadata,
+				Offset:   6,
+				Total:    nChannels,
+				Limit:    nChannels,
+				Status:   mfclients.AllStatus.String(),
+			},
+			response: aChannels[6 : nChannels-1],
+			err:      nil,
+		},
+		{
+			desc:     "list channel with an invalid token",
+			token:    invalidToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page:     sdk.PageMetadata{},
+			response: []sdk.Channel(nil),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:     "list channel with an invalid id",
+			token:    adminToken,
+			clientID: gmocks.WrongID,
+			page:     sdk.PageMetadata{},
+			response: []sdk.Channel(nil),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := gRepo.On("Memberships", mock.Anything, tc.clientID, mock.Anything).Return(convertChannelsMembershipPage(sdk.ChannelsPage{Channels: tc.response}), tc.err)
+		page, err := chSDK.ChannelsByThing(tc.clientID, tc.page, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, page.Channels, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page.Channels))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateGroupAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "Memberships", mock.Anything, tc.clientID, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Memberships was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestEnableChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+
+	creationTime := time.Now().UTC()
+	channel := sdk.Channel{
+		ID:        generateUUID(t),
+		Name:      gName,
+		OwnerID:   generateUUID(t),
+		CreatedAt: creationTime,
+		UpdatedAt: creationTime,
+		Status:    mfclients.Disabled,
+	}
+
+	repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+	repoCall1 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
+	repoCall2 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
+	_, err := chSDK.EnableChannel("wrongID", adminToken)
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(mfgroups.ErrEnableGroup, http.StatusNotFound), fmt.Sprintf("Enable channel with wrong id: expected %v got %v", errors.ErrNotFound, err))
+	ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+	assert.True(t, ok, "EvaluateGroupAccess was not called on enabling channel")
+	ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
+	assert.True(t, ok, "RetrieveByID was not called on enabling channel")
+	repoCall.Unset()
+	repoCall1.Unset()
+	repoCall2.Unset()
+
+	ch := mfgroups.Group{
+		ID:        channel.ID,
+		Name:      channel.Name,
+		Owner:     channel.OwnerID,
+		CreatedAt: creationTime,
+		UpdatedAt: creationTime,
+		Status:    mfclients.DisabledStatus,
+	}
+
+	repoCall = pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+	repoCall1 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(ch, nil)
+	repoCall2 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(ch, nil)
+	res, err := chSDK.EnableChannel(channel.ID, adminToken)
+	assert.Nil(t, err, fmt.Sprintf("Enable channel with correct id: expected %v got %v", nil, err))
+	assert.Equal(t, channel, res, fmt.Sprintf("Enable channel with correct id: expected %v got %v", channel, res))
+	ok = repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+	assert.True(t, ok, "EvaluateGroupAccess was not called on enabling channel")
+	ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, channel.ID)
+	assert.True(t, ok, "RetrieveByID was not called on enabling channel")
+	ok = repoCall2.Parent.AssertCalled(t, "ChangeStatus", mock.Anything, mock.Anything)
+	assert.True(t, ok, "ChangeStatus was not called on enabling channel")
+	repoCall.Unset()
+	repoCall1.Unset()
+	repoCall2.Unset()
+}
+
+func TestDisableChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	csvc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	svc := groups.NewService(uauth, psvc, gRepo, idProvider)
+
+	ts := newChannelsServer(csvc, svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	chSDK := sdk.NewSDK(conf)
+
+	creationTime := time.Now().UTC()
+	channel := sdk.Channel{
+		ID:        generateUUID(t),
+		Name:      gName,
+		OwnerID:   generateUUID(t),
+		CreatedAt: creationTime,
+		UpdatedAt: creationTime,
+		Status:    mfclients.Enabled,
+	}
+
+	repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+	repoCall1 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
+	repoCall2 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
+	_, err := chSDK.DisableChannel("wrongID", adminToken)
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(mfgroups.ErrDisableGroup, http.StatusNotFound), fmt.Sprintf("Disable channel with wrong id: expected %v got %v", errors.ErrNotFound, err))
+	ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+	assert.True(t, ok, "EvaluateGroupAccess was not called on disabling group with wrong id")
+	ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
+	assert.True(t, ok, "Memberships was not called on disabling channel with wrong id")
+	repoCall.Unset()
+	repoCall1.Unset()
+	repoCall2.Unset()
+
+	ch := mfgroups.Group{
+		ID:        channel.ID,
+		Name:      channel.Name,
+		Owner:     channel.OwnerID,
+		CreatedAt: creationTime,
+		UpdatedAt: creationTime,
+		Status:    mfclients.EnabledStatus,
+	}
+
+	repoCall = pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+	repoCall1 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(ch, nil)
+	repoCall2 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(ch, nil)
+	res, err := chSDK.DisableChannel(channel.ID, adminToken)
+	assert.Nil(t, err, fmt.Sprintf("Disable channel with correct id: expected %v got %v", nil, err))
+	assert.Equal(t, channel, res, fmt.Sprintf("Disable channel with correct id: expected %v got %v", channel, res))
+	ok = repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
+	assert.True(t, ok, "EvaluateGroupAccess was not called on disabling channel with correct id")
+	ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, channel.ID)
+	assert.True(t, ok, "RetrieveByID was not called on disabling channel with correct id")
+	ok = repoCall2.Parent.AssertCalled(t, "ChangeStatus", mock.Anything, mock.Anything)
+	assert.True(t, ok, "ChangeStatus was not called on disabling channel with correct id")
+	repoCall.Unset()
+	repoCall1.Unset()
+	repoCall2.Unset()
+}

--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -61,7 +61,7 @@ func TestCreateChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	cases := []struct {
 		desc    string
 		channel sdk.Channel
@@ -143,7 +143,7 @@ func TestCreateChannel(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := gRepo.On("Save", mock.Anything, mock.Anything).Return(convertChannel(sdk.Channel{}), tc.err)
-		rChannel, err := chSDK.CreateChannel(tc.channel, adminToken)
+		rChannel, err := mfsdk.CreateChannel(tc.channel, adminToken)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
 		if err == nil {
 			assert.NotEmpty(t, rChannel, fmt.Sprintf("%s: expected not nil on client ID", tc.desc))
@@ -186,7 +186,7 @@ func TestCreateChannels(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	cases := []struct {
 		desc     string
 		channels []sdk.Channel
@@ -225,7 +225,7 @@ func TestCreateChannels(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := gRepo.On("Save", mock.Anything, mock.Anything).Return(convertChannels(tc.response), tc.err)
-		rChannel, err := chSDK.CreateChannels(tc.channels, adminToken)
+		rChannel, err := mfsdk.CreateChannels(tc.channels, adminToken)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
 		if err == nil {
 			assert.NotEmpty(t, rChannel, fmt.Sprintf("%s: expected not nil on client ID", tc.desc))
@@ -256,7 +256,7 @@ func TestListChannels(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	for i := 10; i < 100; i++ {
 		gr := sdk.Channel{
@@ -356,7 +356,7 @@ func TestListChannels(t *testing.T) {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := gRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfgroups.GroupsPage{Groups: convertChannels(tc.response)}, tc.err)
 		pm := sdk.PageMetadata{}
-		page, err := chSDK.Channels(pm, adminToken)
+		page, err := mfsdk.Channels(pm, adminToken)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, len(tc.response), len(page.Channels), fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
@@ -395,7 +395,7 @@ func TestViewChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	channel.ID = generateUUID(t)
 
 	cases := []struct {
@@ -432,7 +432,7 @@ func TestViewChannel(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := gRepo.On("RetrieveByID", mock.Anything, tc.channelID).Return(convertChannel(tc.response), tc.err)
-		grp, err := chSDK.Channel(tc.channelID, tc.token)
+		grp, err := mfsdk.Channel(tc.channelID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if len(tc.response.Children) == 0 {
 			tc.response.Children = nil
@@ -478,7 +478,7 @@ func TestUpdateChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	channel.ID = generateUUID(t)
 
@@ -613,7 +613,7 @@ func TestUpdateChannel(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := gRepo.On("Update", mock.Anything, mock.Anything).Return(convertChannel(tc.response), tc.err)
-		_, err := chSDK.UpdateChannel(tc.channel, tc.token)
+		_, err := mfsdk.UpdateChannel(tc.channel, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if tc.err == nil {
 			ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
@@ -645,7 +645,7 @@ func TestListChannelsByThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	var nChannels = uint64(100)
 	var aChannels = []sdk.Channel{}
@@ -751,7 +751,7 @@ func TestListChannelsByThing(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := gRepo.On("Memberships", mock.Anything, tc.clientID, mock.Anything).Return(convertChannelsMembershipPage(sdk.ChannelsPage{Channels: tc.response}), tc.err)
-		page, err := chSDK.ChannelsByThing(tc.clientID, tc.page, tc.token)
+		page, err := mfsdk.ChannelsByThing(tc.clientID, tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Channels, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page.Channels))
 		if tc.err == nil {
@@ -784,7 +784,7 @@ func TestEnableChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	creationTime := time.Now().UTC()
 	channel := sdk.Channel{
@@ -799,7 +799,7 @@ func TestEnableChannel(t *testing.T) {
 	repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 	repoCall1 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
 	repoCall2 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
-	_, err := chSDK.EnableChannel("wrongID", adminToken)
+	_, err := mfsdk.EnableChannel("wrongID", adminToken)
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(mfgroups.ErrEnableGroup, http.StatusNotFound), fmt.Sprintf("Enable channel with wrong id: expected %v got %v", errors.ErrNotFound, err))
 	ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
 	assert.True(t, ok, "EvaluateGroupAccess was not called on enabling channel")
@@ -821,7 +821,7 @@ func TestEnableChannel(t *testing.T) {
 	repoCall = pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 	repoCall1 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(ch, nil)
 	repoCall2 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(ch, nil)
-	res, err := chSDK.EnableChannel(channel.ID, adminToken)
+	res, err := mfsdk.EnableChannel(channel.ID, adminToken)
 	assert.Nil(t, err, fmt.Sprintf("Enable channel with correct id: expected %v got %v", nil, err))
 	assert.Equal(t, channel, res, fmt.Sprintf("Enable channel with correct id: expected %v got %v", channel, res))
 	ok = repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
@@ -854,7 +854,7 @@ func TestDisableChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	chSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	creationTime := time.Now().UTC()
 	channel := sdk.Channel{
@@ -869,7 +869,7 @@ func TestDisableChannel(t *testing.T) {
 	repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 	repoCall1 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
 	repoCall2 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
-	_, err := chSDK.DisableChannel("wrongID", adminToken)
+	_, err := mfsdk.DisableChannel("wrongID", adminToken)
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(mfgroups.ErrDisableGroup, http.StatusNotFound), fmt.Sprintf("Disable channel with wrong id: expected %v got %v", errors.ErrNotFound, err))
 	ok := repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)
 	assert.True(t, ok, "EvaluateGroupAccess was not called on disabling group with wrong id")
@@ -891,7 +891,7 @@ func TestDisableChannel(t *testing.T) {
 	repoCall = pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 	repoCall1 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(ch, nil)
 	repoCall2 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(ch, nil)
-	res, err := chSDK.DisableChannel(channel.ID, adminToken)
+	res, err := mfsdk.DisableChannel(channel.ID, adminToken)
 	assert.Nil(t, err, fmt.Sprintf("Disable channel with correct id: expected %v got %v", nil, err))
 	assert.Equal(t, channel, res, fmt.Sprintf("Disable channel with correct id: expected %v got %v", channel, res))
 	ok = repoCall.Parent.AssertCalled(t, "EvaluateGroupAccess", mock.Anything, mock.Anything)

--- a/pkg/sdk/go/consumers.go
+++ b/pkg/sdk/go/consumers.go
@@ -37,12 +37,12 @@ func (sdk mfSDK) CreateSubscription(topic, contact, token string) (string, error
 	}
 
 	id := strings.TrimPrefix(headers.Get("Location"), fmt.Sprintf("/%s/", subscriptionEndpoint))
-	
+
 	return id, nil
 }
 
 func (sdk mfSDK) ListSubscriptions(pm PageMetadata, token string) (SubscriptionPage, errors.SDKError) {
-	url, err := sdk.withQueryParams(sdk.certsURL, subscriptionEndpoint, pm)
+	url, err := sdk.withQueryParams(sdk.usersURL, subscriptionEndpoint, pm)
 	if err != nil {
 		return SubscriptionPage{}, errors.NewSDKError(err)
 	}
@@ -78,6 +78,6 @@ func (sdk mfSDK) DeleteSubscription(id, token string) errors.SDKError {
 	url := fmt.Sprintf("%s/%s/%s", sdk.usersURL, subscriptionEndpoint, id)
 
 	_, _, err := sdk.processRequest(http.MethodDelete, url, token, string(CTJSON), nil, http.StatusNoContent)
-	
+
 	return err
 }

--- a/pkg/sdk/go/consumers_test.go
+++ b/pkg/sdk/go/consumers_test.go
@@ -63,7 +63,7 @@ func TestCreateSubscription(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
 	cases := []struct {
 		desc         string
@@ -103,7 +103,7 @@ func TestCreateSubscription(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		loc, err := mainfluxSDK.CreateSubscription(tc.subscription.Topic, tc.subscription.Contact, tc.token)
+		loc, err := mfsdk.CreateSubscription(tc.subscription.Topic, tc.subscription.Contact, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.empty, loc == "", fmt.Sprintf("%s: expected empty result location, got: %s", tc.desc, loc))
 	}
@@ -119,8 +119,8 @@ func TestViewSubscription(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
-	id, err := mainfluxSDK.CreateSubscription("topic", "contact", exampleUser1)
+	mfsdk := sdk.NewSDK(sdkConf)
+	id, err := mfsdk.CreateSubscription("topic", "contact", exampleUser1)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during creating subscription: %s", err))
 
 	cases := []struct {
@@ -154,7 +154,7 @@ func TestViewSubscription(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		respSub, err := mainfluxSDK.ViewSubscription(tc.subID, tc.token)
+		respSub, err := mfsdk.ViewSubscription(tc.subID, tc.token)
 
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		tc.response.ID = respSub.ID
@@ -173,13 +173,13 @@ func TestListSubscription(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 	var nSubs = 10
 	subs := make([]sdk.Subscription, nSubs)
 	for i := 0; i < nSubs; i++ {
-		id, err := mainfluxSDK.CreateSubscription(fmt.Sprintf("topic_%d", i), fmt.Sprintf("contact_%d", i), exampleUser1)
+		id, err := mfsdk.CreateSubscription(fmt.Sprintf("topic_%d", i), fmt.Sprintf("contact_%d", i), exampleUser1)
 		require.Nil(t, err, fmt.Sprintf("unexpected error during creating subscription: %s", err))
-		sub, err := mainfluxSDK.ViewSubscription(id, exampleUser1)
+		sub, err := mfsdk.ViewSubscription(id, exampleUser1)
 		require.Nil(t, err, fmt.Sprintf("unexpected error during getting subscription: %s", err))
 		subs[i] = sub
 	}
@@ -215,7 +215,7 @@ func TestListSubscription(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		subs, err := mainfluxSDK.ListSubscriptions(tc.page, tc.token)
+		subs, err := mfsdk.ListSubscriptions(tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, subs.Subscriptions, fmt.Sprintf("%s: expected response %v, got %v", tc.desc, tc.response, subs.Subscriptions))
 	}
@@ -231,8 +231,8 @@ func TestDeleteSubscription(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
-	id, err := mainfluxSDK.CreateSubscription("topic", "contact", exampleUser1)
+	mfsdk := sdk.NewSDK(sdkConf)
+	id, err := mfsdk.CreateSubscription("topic", "contact", exampleUser1)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during creating subscription: %s", err))
 
 	cases := []struct {
@@ -266,7 +266,7 @@ func TestDeleteSubscription(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		err := mainfluxSDK.DeleteSubscription(tc.subID, tc.token)
+		err := mfsdk.DeleteSubscription(tc.subID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 	}
 }

--- a/pkg/sdk/go/groups_test.go
+++ b/pkg/sdk/go/groups_test.go
@@ -53,7 +53,7 @@ func TestCreateGroup(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	cases := []struct {
 		desc  string
 		group sdk.Group
@@ -137,7 +137,7 @@ func TestCreateGroup(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := gRepo.On("Save", mock.Anything, mock.Anything).Return(convertGroup(sdk.Group{}), tc.err)
-		rGroup, err := groupSDK.CreateGroup(tc.group, generateValidToken(t, csvc, cRepo))
+		rGroup, err := mfsdk.CreateGroup(tc.group, generateValidToken(t, csvc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
 		if err == nil {
 			assert.NotEmpty(t, rGroup, fmt.Sprintf("%s: expected not nil on client ID", tc.desc))
@@ -163,7 +163,7 @@ func TestListGroups(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	for i := 10; i < 100; i++ {
 		gr := sdk.Group{
@@ -263,7 +263,7 @@ func TestListGroups(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfgroups.GroupsPage{Groups: convertGroups(tc.response)}, tc.err)
 		pm := sdk.PageMetadata{}
-		page, err := groupSDK.Groups(pm, generateValidToken(t, csvc, cRepo))
+		page, err := mfsdk.Groups(pm, generateValidToken(t, csvc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, len(tc.response), len(page.Groups), fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
@@ -290,7 +290,7 @@ func TestListParentGroups(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	parentID := ""
 	for i := 10; i < 100; i++ {
@@ -393,7 +393,7 @@ func TestListParentGroups(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfgroups.GroupsPage{Groups: convertGroups(tc.response)}, tc.err)
 		pm := sdk.PageMetadata{}
-		page, err := groupSDK.Parents(parentID, pm, generateValidToken(t, csvc, cRepo))
+		page, err := mfsdk.Parents(parentID, pm, generateValidToken(t, csvc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, len(tc.response), len(page.Groups), fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
@@ -420,7 +420,7 @@ func TestListChildrenGroups(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	parentID := ""
 	for i := 10; i < 100; i++ {
@@ -524,7 +524,7 @@ func TestListChildrenGroups(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfgroups.GroupsPage{Groups: convertGroups(tc.response)}, tc.err)
 		pm := sdk.PageMetadata{}
-		page, err := groupSDK.Children(childID, pm, generateValidToken(t, csvc, cRepo))
+		page, err := mfsdk.Children(childID, pm, generateValidToken(t, csvc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, len(tc.response), len(page.Groups), fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		if tc.err == nil {
@@ -557,7 +557,7 @@ func TestViewGroup(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	group.ID = generateUUID(t)
 
 	cases := []struct {
@@ -594,7 +594,7 @@ func TestViewGroup(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("RetrieveByID", mock.Anything, tc.groupID).Return(convertGroup(tc.response), tc.err)
-		grp, err := groupSDK.Group(tc.groupID, tc.token)
+		grp, err := mfsdk.Group(tc.groupID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if len(tc.response.Children) == 0 {
 			tc.response.Children = nil
@@ -635,7 +635,7 @@ func TestUpdateGroup(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	group.ID = generateUUID(t)
 
@@ -770,7 +770,7 @@ func TestUpdateGroup(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("Update", mock.Anything, mock.Anything).Return(convertGroup(tc.response), tc.err)
-		_, err := groupSDK.UpdateGroup(tc.group, tc.token)
+		_, err := mfsdk.UpdateGroup(tc.group, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if tc.err == nil {
 			ok := repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)
@@ -797,7 +797,7 @@ func TestListMemberships(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	var nGroups = uint64(100)
 	var aGroups = []sdk.Group{}
@@ -903,7 +903,7 @@ func TestListMemberships(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := gRepo.On("Memberships", mock.Anything, tc.clientID, mock.Anything).Return(convertMembershipsPage(sdk.MembershipsPage{Memberships: tc.response}), tc.err)
-		page, err := groupSDK.Memberships(tc.clientID, tc.page, tc.token)
+		page, err := mfsdk.Memberships(tc.clientID, tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Memberships, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page.Memberships))
 		if tc.err == nil {
@@ -931,7 +931,7 @@ func TestEnableGroup(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	creationTime := time.Now().UTC()
 	group := sdk.Group{
@@ -946,7 +946,7 @@ func TestEnableGroup(t *testing.T) {
 	repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
 	repoCall2 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
-	_, err := groupSDK.EnableGroup("wrongID", generateValidToken(t, csvc, cRepo))
+	_, err := mfsdk.EnableGroup("wrongID", generateValidToken(t, csvc, cRepo))
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound), fmt.Sprintf("Enable group with wrong id: expected %v got %v", errors.ErrNotFound, err))
 	ok := repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)
 	assert.True(t, ok, "CheckAdmin was not called on enabling group")
@@ -968,7 +968,7 @@ func TestEnableGroup(t *testing.T) {
 	repoCall = pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(g, nil)
 	repoCall2 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(g, nil)
-	res, err := groupSDK.EnableGroup(group.ID, generateValidToken(t, csvc, cRepo))
+	res, err := mfsdk.EnableGroup(group.ID, generateValidToken(t, csvc, cRepo))
 	assert.Nil(t, err, fmt.Sprintf("Enable group with correct id: expected %v got %v", nil, err))
 	assert.Equal(t, group, res, fmt.Sprintf("Enable group with correct id: expected %v got %v", group, res))
 	ok = repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)
@@ -996,7 +996,7 @@ func TestDisableGroup(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	groupSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	creationTime := time.Now().UTC()
 	group := sdk.Group{
@@ -1011,7 +1011,7 @@ func TestDisableGroup(t *testing.T) {
 	repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 := gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
 	repoCall2 := gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(nil)
-	_, err := groupSDK.DisableGroup("wrongID", generateValidToken(t, csvc, cRepo))
+	_, err := mfsdk.DisableGroup("wrongID", generateValidToken(t, csvc, cRepo))
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound), fmt.Sprintf("Disable group with wrong id: expected %v got %v", errors.ErrNotFound, err))
 	ok := repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)
 	assert.True(t, ok, "CheckAdmin was not called on disabling group with wrong id")
@@ -1033,7 +1033,7 @@ func TestDisableGroup(t *testing.T) {
 	repoCall = pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 = gRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(g, nil)
 	repoCall2 = gRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(g, nil)
-	res, err := groupSDK.DisableGroup(group.ID, generateValidToken(t, csvc, cRepo))
+	res, err := mfsdk.DisableGroup(group.ID, generateValidToken(t, csvc, cRepo))
 	assert.Nil(t, err, fmt.Sprintf("Disable group with correct id: expected %v got %v", nil, err))
 	assert.Equal(t, group, res, fmt.Sprintf("Disable group with correct id: expected %v got %v", group, res))
 	ok = repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)

--- a/pkg/sdk/go/health_test.go
+++ b/pkg/sdk/go/health_test.go
@@ -44,7 +44,7 @@ func TestHealth(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 	cases := map[string]struct {
 		empty bool
 		err   errors.SDKError
@@ -55,7 +55,7 @@ func TestHealth(t *testing.T) {
 		},
 	}
 	for desc, tc := range cases {
-		h, err := mainfluxSDK.Health()
+		h, err := mfsdk.Health()
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", desc, tc.err, err))
 		assert.Equal(t, thingsStatus, h.Status, fmt.Sprintf("%s: expected %s status, got %s", desc, thingsStatus, h.Status))
 		assert.Equal(t, tc.empty, h.Version == "", fmt.Sprintf("%s: expected non-empty version", desc))

--- a/pkg/sdk/go/health_test.go
+++ b/pkg/sdk/go/health_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package sdk_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mainflux/mainflux"
+	"github.com/mainflux/mainflux/pkg/errors"
+	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"github.com/mainflux/mainflux/things/clients"
+	"github.com/mainflux/mainflux/things/clients/mocks"
+	gmocks "github.com/mainflux/mainflux/things/groups/mocks"
+	"github.com/mainflux/mainflux/things/policies"
+	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	thingsDescription = "things service"
+	thingsStatus      = "pass"
+)
+
+func TestHealth(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	sdkConf := sdk.Config{
+		ThingsURL:       ts.URL,
+		MsgContentType:  contentType,
+		TLSVerification: false,
+	}
+
+	mainfluxSDK := sdk.NewSDK(sdkConf)
+	cases := map[string]struct {
+		empty bool
+		err   errors.SDKError
+	}{
+		"get things service health check": {
+			empty: false,
+			err:   nil,
+		},
+	}
+	for desc, tc := range cases {
+		h, err := mainfluxSDK.Health()
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", desc, tc.err, err))
+		assert.Equal(t, thingsStatus, h.Status, fmt.Sprintf("%s: expected %s status, got %s", desc, thingsStatus, h.Status))
+		assert.Equal(t, tc.empty, h.Version == "", fmt.Sprintf("%s: expected non-empty version", desc))
+		assert.Equal(t, mainflux.Commit, h.Commit, fmt.Sprintf("%s: expected non-empty commit", desc))
+		assert.Equal(t, thingsDescription, h.Description, fmt.Sprintf("%s: expected proper description, got %s", desc, h.Description))
+		assert.Equal(t, mainflux.BuildTime, h.BuildTime, fmt.Sprintf("%s: expected default epoch date, got %s", desc, h.BuildTime))
+	}
+}

--- a/pkg/sdk/go/message_test.go
+++ b/pkg/sdk/go/message_test.go
@@ -48,7 +48,7 @@ func TestSendMessage(t *testing.T) {
 		TLSVerification: false,
 	}
 
-	mainfluxSDK := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
 	cases := map[string]struct {
 		chanID string
@@ -94,7 +94,7 @@ func TestSendMessage(t *testing.T) {
 		},
 	}
 	for desc, tc := range cases {
-		err := mainfluxSDK.SendMessage(tc.chanID, tc.msg, tc.auth)
+		err := mfsdk.SendMessage(tc.chanID, tc.msg, tc.auth)
 		if tc.err == nil {
 			assert.Nil(t, err, fmt.Sprintf("%s: got unexpected error: %s", desc, err))
 		} else {
@@ -117,7 +117,7 @@ func TestSetContentType(t *testing.T) {
 		MsgContentType:  contentType,
 		TLSVerification: false,
 	}
-	mainfluxSDK := sdk.NewSDK(sdkConf)
+	mfsdk := sdk.NewSDK(sdkConf)
 
 	cases := []struct {
 		desc  string
@@ -136,7 +136,7 @@ func TestSetContentType(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err := mainfluxSDK.SetContentType(tc.cType)
+		err := mfsdk.SetContentType(tc.cType)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 	}
 }

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -192,87 +192,86 @@ func TestAuthorize(t *testing.T) {
 	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
-		desc       string
-		policy     sdk.Policy
-		entityType string
-		page       sdk.PolicyPage
-		token      string
-		err        errors.SDKError
+		desc   string
+		policy sdk.AccessRequest
+		page   sdk.PolicyPage
+		token  string
+		err    errors.SDKError
 	}{
 		{
 			desc: "authorize a valid policy with client entity",
-			policy: sdk.Policy{
-				Subject: subject,
-				Object:  object,
-				Actions: []string{"c_list"},
+			policy: sdk.AccessRequest{
+				Subject:    subject,
+				Object:     object,
+				Action:     "c_list",
+				EntityType: "client",
 			},
-			entityType: "client",
-			page:       sdk.PolicyPage{},
-			token:      generateValidToken(t, csvc, cRepo),
-			err:        nil,
+			page:  sdk.PolicyPage{},
+			token: generateValidToken(t, csvc, cRepo),
+			err:   nil,
 		},
 		{
 			desc: "authorize a valid policy with group entity",
-			policy: sdk.Policy{
-				Subject: subject,
-				Object:  object,
-				Actions: []string{"g_add"},
+			policy: sdk.AccessRequest{
+				Subject:    subject,
+				Object:     object,
+				Action:     "g_add",
+				EntityType: "group",
 			},
-			entityType: "group",
-			page:       sdk.PolicyPage{},
-			token:      generateValidToken(t, csvc, cRepo),
-			err:        nil,
+			page:  sdk.PolicyPage{},
+			token: generateValidToken(t, csvc, cRepo),
+			err:   nil,
 		},
 		{
 			desc: "authorize a policy with wrong action",
 			page: sdk.PolicyPage{},
-			policy: sdk.Policy{
-				Object:  "obj3",
-				Actions: []string{"wrong"},
-				Subject: "sub3",
+			policy: sdk.AccessRequest{
+				Object:     "obj3",
+				Action:     "wrong",
+				Subject:    "sub3",
+				EntityType: "client",
 			},
-			entityType: "client",
-			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
-			token:      generateValidToken(t, csvc, cRepo),
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
 		},
 		{
 			desc: "authorize a policy with empty object",
 			page: sdk.PolicyPage{},
-			policy: sdk.Policy{
-				Actions: []string{"c_delete"},
-				Subject: "sub4",
+			policy: sdk.AccessRequest{
+				Action:     "c_delete",
+				Subject:    "sub4",
+				EntityType: "client",
 			},
-			entityType: "client",
-			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicyObj, http.StatusInternalServerError),
-			token:      generateValidToken(t, csvc, cRepo),
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicyObj, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
 		},
 		{
 			desc: "authorize a policy with empty subject",
 			page: sdk.PolicyPage{},
-			policy: sdk.Policy{
-				Actions: []string{"c_delete"},
-				Object:  "obj4",
+			policy: sdk.AccessRequest{
+				Action:     "c_delete",
+				Object:     "obj4",
+				EntityType: "client",
 			},
-			entityType: "client",
-			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicySub, http.StatusInternalServerError),
-			token:      generateValidToken(t, csvc, cRepo),
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicySub, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
 		},
 		{
 			desc: "authorize a policy with empty action",
 			page: sdk.PolicyPage{},
-			policy: sdk.Policy{
-				Subject: "sub5",
-				Object:  "obj5",
+			policy: sdk.AccessRequest{
+				Subject:    "sub5",
+				Object:     "obj5",
+				EntityType: "client",
 			},
-			entityType: "client",
-			err:        errors.NewSDKError(fmt.Errorf("invalid number of actions, it should be exactly 1")),
-			token:      generateValidToken(t, csvc, cRepo),
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
 		},
 	}
 
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		ok, err := mfsdk.Authorize(tc.policy, tc.entityType, tc.token)
+		ok, err := mfsdk.Authorize(tc.policy, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if tc.err == nil {
 			assert.True(t, ok, fmt.Sprintf("%s: expected true, got false", tc.desc))

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -42,7 +42,7 @@ func TestCreatePolicy(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	policySDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	clientPolicy := sdk.Policy{Object: object, Actions: []string{"m_write", "g_add"}, Subject: subject}
 
@@ -146,7 +146,7 @@ func TestCreatePolicy(t *testing.T) {
 		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(tc.page), nil)
 		repoCall2 := pRepo.On("Update", mock.Anything, mock.Anything).Return(tc.err)
 		repoCall3 := pRepo.On("Save", mock.Anything, mock.Anything).Return(tc.err)
-		err := policySDK.CreatePolicy(tc.policy, tc.token)
+		err := mfsdk.CreatePolicy(tc.policy, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if tc.err == nil {
 			ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
@@ -178,7 +178,7 @@ func TestUpdatePolicy(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	policySDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	policy := sdk.Policy{
 		Subject: subject,
@@ -218,7 +218,7 @@ func TestUpdatePolicy(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(policies.PolicyPage{}, nil)
 		repoCall2 := pRepo.On("Update", mock.Anything, mock.Anything).Return(tc.err)
-		err := policySDK.UpdatePolicy(policy, tc.token)
+		err := mfsdk.UpdatePolicy(policy, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		ok := repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
 		assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
@@ -241,7 +241,7 @@ func TestListPolicies(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	policySDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	id := generateUUID(t)
 
 	var nPolicy = uint64(10)
@@ -352,7 +352,7 @@ func TestListPolicies(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: tc.response}), tc.err)
-		pp, err := policySDK.ListPolicies(tc.page, tc.token)
+		pp, err := mfsdk.ListPolicies(tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, pp.Policies, fmt.Sprintf("%s: expected %v, got %v", tc.desc, tc.response, pp))
 		ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
@@ -375,7 +375,7 @@ func TestDeletePolicy(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	policySDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	sub := generateUUID(t)
 	pr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
@@ -384,7 +384,7 @@ func TestDeletePolicy(t *testing.T) {
 	repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
 	repoCall2 := pRepo.On("Delete", mock.Anything, mock.Anything).Return(nil)
-	err := policySDK.DeletePolicy(pr, generateValidToken(t, csvc, cRepo))
+	err := mfsdk.DeletePolicy(pr, generateValidToken(t, csvc, cRepo))
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	ok := repoCall1.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
 	assert.True(t, ok, "Delete was not called on valid policy")
@@ -395,7 +395,7 @@ func TestDeletePolicy(t *testing.T) {
 	repoCall = pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 	repoCall1 = pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
 	repoCall2 = pRepo.On("Delete", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
-	err = policySDK.DeletePolicy(pr, invalidToken)
+	err = mfsdk.DeletePolicy(pr, invalidToken)
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized), fmt.Sprintf("expected %s got %s", pr, err))
 	ok = repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
 	assert.True(t, ok, "Delete was not called on invalid policy")

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -30,9 +30,7 @@ import (
 
 const addExistingPolicyDesc = "add existing policy"
 
-var (
-	utadminPolicy = umocks.SubjectSet{Subject: "things", Relation: []string{"g_add"}}
-)
+var utadminPolicy = umocks.SubjectSet{Subject: "things", Relation: []string{"g_add"}}
 
 func newPolicyServer(svc upolicies.Service) *httptest.Server {
 	logger := logger.NewMock()

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const addExistingPolicyDesc = "add existing policy"
+
 var (
 	utadminPolicy = umocks.SubjectSet{Subject: "things", Relation: []string{"g_add"}}
 )
@@ -75,7 +77,7 @@ func TestCreatePolicy(t *testing.T) {
 			err:   nil,
 		},
 		{
-			desc: "add existing policy",
+			desc: addExistingPolicyDesc,
 			policy: sdk.Policy{
 				Subject: subject,
 				Object:  object,
@@ -163,7 +165,7 @@ func TestCreatePolicy(t *testing.T) {
 			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
-			if tc.desc == "add existing policy" {
+			if tc.desc == addExistingPolicyDesc {
 				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
 				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
 			}
@@ -316,7 +318,7 @@ func TestAssign(t *testing.T) {
 			err:   nil,
 		},
 		{
-			desc: "add existing policy",
+			desc: addExistingPolicyDesc,
 			policy: sdk.Policy{
 				Subject: subject,
 				Object:  object,
@@ -404,7 +406,7 @@ func TestAssign(t *testing.T) {
 			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
-			if tc.desc == "add existing policy" {
+			if tc.desc == addExistingPolicyDesc {
 				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
 				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
 			}
@@ -801,7 +803,7 @@ func TestConnect(t *testing.T) {
 			err:   nil,
 		},
 		{
-			desc: "add existing policy",
+			desc: addExistingPolicyDesc,
 			policy: sdk.Policy{
 				Subject: subject,
 				Object:  object,
@@ -889,7 +891,7 @@ func TestConnect(t *testing.T) {
 			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
-			if tc.desc == "add existing policy" {
+			if tc.desc == addExistingPolicyDesc {
 				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
 				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
 			}
@@ -940,7 +942,7 @@ func TestConnectThing(t *testing.T) {
 			err:   nil,
 		},
 		{
-			desc: "add existing policy",
+			desc: addExistingPolicyDesc,
 			policy: sdk.Policy{
 				Subject: subject,
 				Object:  object,
@@ -1027,7 +1029,7 @@ func TestConnectThing(t *testing.T) {
 			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
 			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
-			if tc.desc == "add existing policy" {
+			if tc.desc == addExistingPolicyDesc {
 				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
 				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
 			}

--- a/pkg/sdk/go/policies_test.go
+++ b/pkg/sdk/go/policies_test.go
@@ -12,31 +12,41 @@ import (
 	"github.com/mainflux/mainflux/logger"
 	"github.com/mainflux/mainflux/pkg/errors"
 	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
-	"github.com/mainflux/mainflux/users/clients"
-	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
+	tclients "github.com/mainflux/mainflux/things/clients"
+	tmocks "github.com/mainflux/mainflux/things/clients/mocks"
+	tgmocks "github.com/mainflux/mainflux/things/groups/mocks"
+	"github.com/mainflux/mainflux/things/policies"
+	tpolicies "github.com/mainflux/mainflux/things/policies"
+	tpmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	uclients "github.com/mainflux/mainflux/users/clients"
+	umocks "github.com/mainflux/mainflux/users/clients/mocks"
 	"github.com/mainflux/mainflux/users/jwt"
-	"github.com/mainflux/mainflux/users/policies"
-	api "github.com/mainflux/mainflux/users/policies/api/http"
-	pmocks "github.com/mainflux/mainflux/users/policies/mocks"
+	upolicies "github.com/mainflux/mainflux/users/policies"
+	uapi "github.com/mainflux/mainflux/users/policies/api/http"
+	upmocks "github.com/mainflux/mainflux/users/policies/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func newPolicyServer(svc policies.Service) *httptest.Server {
+var (
+	utadminPolicy = umocks.SubjectSet{Subject: "things", Relation: []string{"g_add"}}
+)
+
+func newPolicyServer(svc upolicies.Service) *httptest.Server {
 	logger := logger.NewMock()
 	mux := bone.New()
-	api.MakePolicyHandler(svc, mux, logger)
+	uapi.MakePolicyHandler(svc, mux, logger)
 
 	return httptest.NewServer(mux)
 }
 
 func TestCreatePolicy(t *testing.T) {
-	cRepo := new(cmocks.ClientRepository)
-	pRepo := new(pmocks.PolicyRepository)
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
 	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
 
-	csvc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
-	svc := policies.NewService(pRepo, tokenizer, idProvider)
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
 	ts := newPolicyServer(svc)
 	defer ts.Close()
 	conf := sdk.Config{
@@ -143,7 +153,7 @@ func TestCreatePolicy(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(tc.page), nil)
+		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(tc.page), nil)
 		repoCall2 := pRepo.On("Update", mock.Anything, mock.Anything).Return(tc.err)
 		repoCall3 := pRepo.On("Save", mock.Anything, mock.Anything).Return(tc.err)
 		err := mfsdk.CreatePolicy(tc.policy, tc.token)
@@ -165,13 +175,253 @@ func TestCreatePolicy(t *testing.T) {
 	}
 }
 
-func TestUpdatePolicy(t *testing.T) {
-	cRepo := new(cmocks.ClientRepository)
-	pRepo := new(pmocks.PolicyRepository)
+func TestAuthorize(t *testing.T) {
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
 	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
 
-	csvc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
-	svc := policies.NewService(pRepo, tokenizer, idProvider)
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
+	ts := newPolicyServer(svc)
+	defer ts.Close()
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc       string
+		policy     sdk.Policy
+		entityType string
+		page       sdk.PolicyPage
+		token      string
+		err        errors.SDKError
+	}{
+		{
+			desc: "authorize a valid policy with client entity",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"c_list"},
+			},
+			entityType: "client",
+			page:       sdk.PolicyPage{},
+			token:      generateValidToken(t, csvc, cRepo),
+			err:        nil,
+		},
+		{
+			desc: "authorize a valid policy with group entity",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"g_add"},
+			},
+			entityType: "group",
+			page:       sdk.PolicyPage{},
+			token:      generateValidToken(t, csvc, cRepo),
+			err:        nil,
+		},
+		{
+			desc: "authorize a policy with wrong action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj3",
+				Actions: []string{"wrong"},
+				Subject: "sub3",
+			},
+			entityType: "client",
+			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token:      generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "authorize a policy with empty object",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Subject: "sub4",
+			},
+			entityType: "client",
+			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicyObj, http.StatusInternalServerError),
+			token:      generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "authorize a policy with empty subject",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Object:  "obj4",
+			},
+			entityType: "client",
+			err:        errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicySub, http.StatusInternalServerError),
+			token:      generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "authorize a policy with empty action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Subject: "sub5",
+				Object:  "obj5",
+			},
+			entityType: "client",
+			err:        errors.NewSDKError(fmt.Errorf("invalid number of actions, it should be exactly 1")),
+			token:      generateValidToken(t, csvc, cRepo),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		ok, err := mfsdk.Authorize(tc.policy, tc.entityType, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			assert.True(t, ok, fmt.Sprintf("%s: expected true, got false", tc.desc))
+			ok := repoCall.Parent.AssertCalled(t, "CheckAdmin", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("CheckAdmin was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestAssign(t *testing.T) {
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
+	ts := newPolicyServer(svc)
+	defer ts.Close()
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	clientPolicy := sdk.Policy{Object: object, Actions: []string{"m_write", "g_add"}, Subject: subject}
+
+	cases := []struct {
+		desc   string
+		policy sdk.Policy
+		page   sdk.PolicyPage
+		token  string
+		err    errors.SDKError
+	}{
+		{
+			desc: "add new policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{},
+			token: generateValidToken(t, csvc, cRepo),
+			err:   nil,
+		},
+		{
+			desc: "add existing policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{Policies: []sdk.Policy{clientPolicy}},
+			token: generateValidToken(t, csvc, cRepo),
+			err:   errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc: "add a new policy with owner",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				OwnerID: generateUUID(t),
+				Object:  "objwithowner",
+				Actions: []string{"m_read"},
+				Subject: "subwithowner",
+			},
+			err:   nil,
+			token: generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "add a new policy with more actions",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj2",
+				Actions: []string{"c_delete", "c_update", "c_list"},
+				Subject: "sub2",
+			},
+			err:   nil,
+			token: generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "add a new policy with wrong action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj3",
+				Actions: []string{"wrong"},
+				Subject: "sub3",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "add a new policy with empty object",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Subject: "sub4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicyObj, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "add a new policy with empty subject",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Object:  "obj4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingPolicySub, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
+		},
+		{
+			desc: "add a new policy with empty action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Subject: "sub5",
+				Object:  "obj5",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: generateValidToken(t, csvc, cRepo),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(tc.page), nil)
+		repoCall2 := pRepo.On("Update", mock.Anything, mock.Anything).Return(tc.err)
+		repoCall3 := pRepo.On("Save", mock.Anything, mock.Anything).Return(tc.err)
+		err := mfsdk.Assign(tc.policy.Actions, tc.policy.Subject, tc.policy.Object, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
+			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+			if tc.desc == "add existing policy" {
+				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+			}
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+		repoCall3.Unset()
+	}
+}
+func TestUpdatePolicy(t *testing.T) {
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
 	ts := newPolicyServer(svc)
 	defer ts.Close()
 
@@ -216,7 +466,7 @@ func TestUpdatePolicy(t *testing.T) {
 		policy.Actions = tc.action
 		policy.CreatedAt = time.Now()
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(policies.PolicyPage{}, nil)
+		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(upolicies.PolicyPage{}, nil)
 		repoCall2 := pRepo.On("Update", mock.Anything, mock.Anything).Return(tc.err)
 		err := mfsdk.UpdatePolicy(policy, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
@@ -228,13 +478,78 @@ func TestUpdatePolicy(t *testing.T) {
 	}
 }
 
+func TestUpdateThingsPolicy(t *testing.T) {
+	cRepo := new(tmocks.ClientRepository)
+	gRepo := new(tgmocks.GroupRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {utadminPolicy}})
+	thingCache := tmocks.NewCache()
+	policiesCache := tpmocks.NewCache()
+
+	pRepo := new(tpmocks.PolicyRepository)
+	psvc := tpolicies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := tclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	policy := sdk.Policy{
+		Subject: subject,
+		Object:  object,
+		Actions: []string{"m_write", "g_add"},
+	}
+
+	cases := []struct {
+		desc   string
+		action []string
+		token  string
+		err    errors.SDKError
+	}{
+		{
+			desc:   "update policy actions with valid token",
+			action: []string{"m_write", "m_read"},
+			token:  adminToken,
+			err:    nil,
+		},
+		{
+			desc:   "update policy action with invalid token",
+			action: []string{"m_write"},
+			token:  "non-existent",
+			err:    errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:   "update policy action with wrong policy action",
+			action: []string{"wrong"},
+			token:  adminToken,
+			err:    errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+		},
+	}
+
+	for _, tc := range cases {
+		policy.Actions = tc.action
+		policy.CreatedAt = time.Now()
+		repoCall := pRepo.On("Retrieve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tpolicies.PolicyPage{}, nil)
+		repoCall1 := pRepo.On("Update", mock.Anything, mock.Anything).Return(policies.Policy{}, tc.err)
+		err := mfsdk.UpdateThingsPolicy(policy, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		ok := repoCall.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+		assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
 func TestListPolicies(t *testing.T) {
-	cRepo := new(cmocks.ClientRepository)
-	pRepo := new(pmocks.PolicyRepository)
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
 	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
 
-	csvc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
-	svc := policies.NewService(pRepo, tokenizer, idProvider)
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
 	ts := newPolicyServer(svc)
 	defer ts.Close()
 
@@ -351,7 +666,7 @@ func TestListPolicies(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: tc.response}), tc.err)
+		repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(sdk.PolicyPage{Policies: tc.response}), tc.err)
 		pp, err := mfsdk.ListPolicies(tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, pp.Policies, fmt.Sprintf("%s: expected %v, got %v", tc.desc, tc.response, pp))
@@ -363,12 +678,12 @@ func TestListPolicies(t *testing.T) {
 }
 
 func TestDeletePolicy(t *testing.T) {
-	cRepo := new(cmocks.ClientRepository)
-	pRepo := new(pmocks.PolicyRepository)
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
 	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
 
-	csvc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
-	svc := policies.NewService(pRepo, tokenizer, idProvider)
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
 	ts := newPolicyServer(svc)
 	defer ts.Close()
 
@@ -382,7 +697,7 @@ func TestDeletePolicy(t *testing.T) {
 	cpr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
 
 	repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-	repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
+	repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
 	repoCall2 := pRepo.On("Delete", mock.Anything, mock.Anything).Return(nil)
 	err := mfsdk.DeletePolicy(pr, generateValidToken(t, csvc, cRepo))
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -393,7 +708,7 @@ func TestDeletePolicy(t *testing.T) {
 	repoCall.Unset()
 
 	repoCall = pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-	repoCall1 = pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
+	repoCall1 = pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
 	repoCall2 = pRepo.On("Delete", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
 	err = mfsdk.DeletePolicy(pr, invalidToken)
 	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized), fmt.Sprintf("expected %s got %s", pr, err))
@@ -401,5 +716,400 @@ func TestDeletePolicy(t *testing.T) {
 	assert.True(t, ok, "Delete was not called on invalid policy")
 	repoCall2.Unset()
 	repoCall1.Unset()
+	repoCall.Unset()
+}
+
+func TestUnassign(t *testing.T) {
+	cRepo := new(umocks.ClientRepository)
+	pRepo := new(upmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	csvc := uclients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	svc := upolicies.NewService(pRepo, tokenizer, idProvider)
+	ts := newPolicyServer(svc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	sub := generateUUID(t)
+	pr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
+	cpr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
+
+	repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+	repoCall1 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
+	repoCall2 := pRepo.On("Delete", mock.Anything, mock.Anything).Return(nil)
+	err := mfsdk.Unassign(pr.Subject, pr.Object, generateValidToken(t, csvc, cRepo))
+	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	ok := repoCall1.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on valid policy")
+	repoCall2.Unset()
+	repoCall1.Unset()
+	repoCall.Unset()
+
+	repoCall = pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+	repoCall1 = pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertUserPolicyPage(sdk.PolicyPage{Policies: []sdk.Policy{cpr}}), nil)
+	repoCall2 = pRepo.On("Delete", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
+	err = mfsdk.Unassign(pr.Subject, pr.Object, invalidToken)
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized), fmt.Sprintf("expected %s got %s", pr, err))
+	ok = repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on invalid policy")
+	repoCall2.Unset()
+	repoCall1.Unset()
+	repoCall.Unset()
+}
+
+func TestConnect(t *testing.T) {
+	cRepo := new(tmocks.ClientRepository)
+	gRepo := new(tgmocks.GroupRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {utadminPolicy}})
+	thingCache := tmocks.NewCache()
+	policiesCache := tpmocks.NewCache()
+
+	pRepo := new(tpmocks.PolicyRepository)
+	psvc := tpolicies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := tclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	clientPolicy := sdk.Policy{Object: object, Actions: []string{"m_write", "g_add"}, Subject: subject}
+
+	cases := []struct {
+		desc   string
+		policy sdk.Policy
+		page   sdk.PolicyPage
+		token  string
+		err    errors.SDKError
+	}{
+		{
+			desc: "add new policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{},
+			token: adminToken,
+			err:   nil,
+		},
+		{
+			desc: "add existing policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{Policies: []sdk.Policy{clientPolicy}},
+			token: adminToken,
+			err:   errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc: "add a new policy with owner",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				OwnerID: generateUUID(t),
+				Object:  "objwithowner",
+				Actions: []string{"m_read"},
+				Subject: "subwithowner",
+			},
+			err:   nil,
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with more actions",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj2",
+				Actions: []string{"c_delete", "c_update", "c_list"},
+				Subject: "sub2",
+			},
+			err:   nil,
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with wrong action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj3",
+				Actions: []string{"wrong"},
+				Subject: "sub3",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty object",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Subject: "sub4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty subject",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Object:  "obj4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Subject: "sub5",
+				Object:  "obj5",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: adminToken,
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertThingPolicyPage(tc.page), nil)
+		repoCall1 := pRepo.On("Update", mock.Anything, mock.Anything).Return(convertThingPolicy(tc.policy), tc.err)
+		repoCall2 := pRepo.On("Save", mock.Anything, mock.Anything).Return(convertThingPolicy(tc.policy), tc.err)
+		conn := sdk.ConnectionIDs{ChannelIDs: []string{tc.policy.Object}, ThingIDs: []string{tc.policy.Subject}, Actions: tc.policy.Actions}
+		err := mfsdk.Connect(conn, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
+			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+			if tc.desc == "add existing policy" {
+				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+			}
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+	}
+}
+
+func TestConnectThing(t *testing.T) {
+	cRepo := new(tmocks.ClientRepository)
+	gRepo := new(tgmocks.GroupRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {utadminPolicy}})
+	thingCache := tmocks.NewCache()
+	policiesCache := tpmocks.NewCache()
+
+	pRepo := new(tpmocks.PolicyRepository)
+	psvc := tpolicies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := tclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	clientPolicy := sdk.Policy{Object: object, Actions: []string{"m_write", "g_add"}, Subject: subject}
+
+	cases := []struct {
+		desc   string
+		policy sdk.Policy
+		page   sdk.PolicyPage
+		token  string
+		err    errors.SDKError
+	}{
+		{
+			desc: "add new policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{},
+			token: adminToken,
+			err:   nil,
+		},
+		{
+			desc: "add existing policy",
+			policy: sdk.Policy{
+				Subject: subject,
+				Object:  object,
+				Actions: []string{"m_write", "g_add"},
+			},
+			page:  sdk.PolicyPage{Policies: []sdk.Policy{clientPolicy}},
+			token: adminToken,
+			err:   errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc: "add a new policy with owner",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				OwnerID: generateUUID(t),
+				Object:  "objwithowner",
+				Actions: []string{"m_read"},
+				Subject: "subwithowner",
+			},
+			err:   nil,
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with more actions",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj2",
+				Actions: []string{"c_delete", "c_update", "c_list"},
+				Subject: "sub2",
+			},
+			err:   nil,
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with wrong action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Object:  "obj3",
+				Actions: []string{"wrong"},
+				Subject: "sub3",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty object",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Subject: "sub4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty subject",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Actions: []string{"c_delete"},
+				Object:  "obj4",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMissingID, http.StatusBadRequest),
+			token: adminToken,
+		},
+		{
+			desc: "add a new policy with empty action",
+			page: sdk.PolicyPage{},
+			policy: sdk.Policy{
+				Subject: "sub5",
+				Object:  "obj5",
+			},
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrMalformedPolicyAct, http.StatusInternalServerError),
+			token: adminToken,
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(convertThingPolicyPage(tc.page), nil)
+		repoCall1 := pRepo.On("Update", mock.Anything, mock.Anything).Return(convertThingPolicy(tc.policy), tc.err)
+		repoCall2 := pRepo.On("Save", mock.Anything, mock.Anything).Return(convertThingPolicy(tc.policy), tc.err)
+		err := mfsdk.ConnectThing(tc.policy.Subject, tc.policy.Object, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Retrieve was not called on %s", tc.desc))
+			ok = repoCall2.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+			if tc.desc == "add existing policy" {
+				ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+				assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+			}
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+	}
+}
+
+func TestDisconnectThing(t *testing.T) {
+	cRepo := new(tmocks.ClientRepository)
+	gRepo := new(tgmocks.GroupRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {utadminPolicy}})
+	thingCache := tmocks.NewCache()
+	policiesCache := tpmocks.NewCache()
+
+	pRepo := new(tpmocks.PolicyRepository)
+	psvc := tpolicies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := tclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	sub := generateUUID(t)
+	pr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
+
+	repoCall := pRepo.On("Delete", mock.Anything, mock.Anything).Return(nil)
+	err := mfsdk.DisconnectThing(pr.Subject, pr.Object, adminToken)
+	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	ok := repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on valid policy")
+	repoCall.Unset()
+
+	repoCall = pRepo.On("Delete", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
+	err = mfsdk.DisconnectThing(pr.Subject, pr.Object, invalidToken)
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized), fmt.Sprintf("expected %s got %s", pr, err))
+	ok = repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on invalid policy")
+	repoCall.Unset()
+}
+
+func TestDisconnect(t *testing.T) {
+	cRepo := new(tmocks.ClientRepository)
+	gRepo := new(tgmocks.GroupRepository)
+	uauth := umocks.NewAuthService(users, map[string][]umocks.SubjectSet{adminID: {utadminPolicy}})
+	thingCache := tmocks.NewCache()
+	policiesCache := tpmocks.NewCache()
+
+	pRepo := new(tpmocks.PolicyRepository)
+	psvc := tpolicies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := tclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	sub := generateUUID(t)
+	pr := sdk.Policy{Object: authoritiesObj, Actions: []string{"m_read", "g_add", "c_delete"}, Subject: sub}
+
+	repoCall := pRepo.On("Delete", mock.Anything, mock.Anything).Return(nil)
+	conn := sdk.ConnectionIDs{ChannelIDs: []string{pr.Object}, ThingIDs: []string{pr.Subject}}
+	err := mfsdk.Disconnect(conn, adminToken)
+	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+	ok := repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on valid policy")
+	repoCall.Unset()
+
+	repoCall = pRepo.On("Delete", mock.Anything, mock.Anything).Return(sdk.ErrFailedRemoval)
+	conn = sdk.ConnectionIDs{ChannelIDs: []string{pr.Object}, ThingIDs: []string{pr.Subject}}
+	err = mfsdk.Disconnect(conn, invalidToken)
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized), fmt.Sprintf("expected %s got %s", pr, err))
+	ok = repoCall.Parent.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
+	assert.True(t, ok, "Delete was not called on invalid policy")
 	repoCall.Unset()
 }

--- a/pkg/sdk/go/responses.go
+++ b/pkg/sdk/go/responses.go
@@ -4,7 +4,6 @@
 package sdk
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/mainflux/mainflux/pkg/transformers/senml"
@@ -69,24 +68,6 @@ type MembershipsPage struct {
 type PolicyPage struct {
 	PageMetadata
 	Policies []Policy
-}
-type KeyRes struct {
-	ID        string     `json:"id,omitempty"`
-	Value     string     `json:"value,omitempty"`
-	IssuedAt  time.Time  `json:"issued_at,omitempty"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
-}
-
-func (res KeyRes) Code() int {
-	return http.StatusCreated
-}
-
-func (res KeyRes) Headers() map[string]string {
-	return map[string]string{}
-}
-
-func (res KeyRes) Empty() bool {
-	return res.Value == ""
 }
 
 type revokeCertsRes struct {

--- a/pkg/sdk/go/setup_test.go
+++ b/pkg/sdk/go/setup_test.go
@@ -135,6 +135,16 @@ func convertGroups(cs []sdk.Group) []mfgroups.Group {
 	return cgs
 }
 
+func convertChannels(cs []sdk.Channel) []mfgroups.Group {
+	cgs := []mfgroups.Group{}
+
+	for _, c := range cs {
+		cgs = append(cgs, convertChannel(c))
+	}
+
+	return cgs
+}
+
 func convertPolicies(cs []sdk.Policy) []policies.Policy {
 	ccs := []policies.Policy{}
 
@@ -164,6 +174,17 @@ func convertMembershipsPage(m sdk.MembershipsPage) mfgroups.MembershipsPage {
 			Offset: m.Offset,
 		},
 		Memberships: convertMemberships(m.Memberships),
+	}
+}
+
+func convertChannelsMembershipPage(m sdk.ChannelsPage) mfgroups.MembershipsPage {
+	return mfgroups.MembershipsPage{
+		Page: mfgroups.Page{
+			Limit:  m.Limit,
+			Total:  m.Total,
+			Offset: m.Offset,
+		},
+		Memberships: convertChannels(m.Channels),
 	}
 }
 
@@ -276,6 +297,29 @@ func convertThing(c sdk.Thing) mfclients.Client {
 		Metadata:    mfclients.Metadata(c.Metadata),
 		CreatedAt:   c.CreatedAt,
 		UpdatedAt:   c.UpdatedAt,
+		Status:      status,
+	}
+}
+
+func convertChannel(g sdk.Channel) mfgroups.Group {
+	if g.Status == "" {
+		g.Status = mfclients.EnabledStatus.String()
+	}
+	status, err := mfclients.ToStatus(g.Status)
+	if err != nil {
+		return mfgroups.Group{}
+	}
+	return mfgroups.Group{
+		ID:          g.ID,
+		Owner:       g.OwnerID,
+		Parent:      g.ParentID,
+		Name:        g.Name,
+		Description: g.Description,
+		Metadata:    mfclients.Metadata(g.Metadata),
+		Level:       g.Level,
+		Path:        g.Path,
+		CreatedAt:   g.CreatedAt,
+		UpdatedAt:   g.UpdatedAt,
 		Status:      status,
 	}
 }

--- a/pkg/sdk/go/setup_test.go
+++ b/pkg/sdk/go/setup_test.go
@@ -41,6 +41,13 @@ var (
 		Metadata:    validMetadata,
 		Status:      mfclients.EnabledStatus.String(),
 	}
+	thing = sdk.Thing{
+		Name:        "thingname",
+		Tags:        []string{"tag1", "tag2"},
+		Credentials: sdk.Credentials{Identity: "clientidentity", Secret: generateUUID(&testing.T{})},
+		Metadata:    validMetadata,
+		Status:      mfclients.EnabledStatus.String(),
+	}
 	description = "shortdescription"
 	gName       = "groupname"
 
@@ -92,11 +99,27 @@ func convertClientsPage(cp sdk.UsersPage) mfclients.ClientsPage {
 	}
 }
 
+func convertThingsPage(cp sdk.ThingsPage) mfclients.ClientsPage {
+	return mfclients.ClientsPage{
+		Clients: convertThings(cp.Things),
+	}
+}
+
 func convertClients(cs []sdk.User) []mfclients.Client {
 	ccs := []mfclients.Client{}
 
 	for _, c := range cs {
 		ccs = append(ccs, convertClient(c))
+	}
+
+	return ccs
+}
+
+func convertThings(cs []sdk.Thing) []mfclients.Client {
+	ccs := []mfclients.Client{}
+
+	for _, c := range cs {
+		ccs = append(ccs, convertThing(c))
 	}
 
 	return ccs
@@ -223,6 +246,27 @@ func convertClient(c sdk.User) mfclients.Client {
 		return mfclients.Client{}
 	}
 	
+	return mfclients.Client{
+		ID:          c.ID,
+		Name:        c.Name,
+		Tags:        c.Tags,
+		Owner:       c.Owner,
+		Credentials: mfclients.Credentials(c.Credentials),
+		Metadata:    mfclients.Metadata(c.Metadata),
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
+		Status:      status,
+	}
+}
+
+func convertThing(c sdk.Thing) mfclients.Client {
+	if c.Status == "" {
+		c.Status = mfclients.EnabledStatus.String()
+	}
+	status, err := mfclients.ToStatus(c.Status)
+	if err != nil {
+		return mfclients.Client{}
+	}
 	return mfclients.Client{
 		ID:          c.ID,
 		Name:        c.Name,

--- a/pkg/sdk/go/setup_test.go
+++ b/pkg/sdk/go/setup_test.go
@@ -13,10 +13,11 @@ import (
 	mfgroups "github.com/mainflux/mainflux/pkg/groups"
 	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
 	"github.com/mainflux/mainflux/pkg/uuid"
+	tpolicies "github.com/mainflux/mainflux/things/policies"
 	"github.com/mainflux/mainflux/users/clients"
 	umocks "github.com/mainflux/mainflux/users/clients/mocks"
 	"github.com/mainflux/mainflux/users/hasher"
-	"github.com/mainflux/mainflux/users/policies"
+	upolicies "github.com/mainflux/mainflux/users/policies"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -145,18 +146,39 @@ func convertChannels(cs []sdk.Channel) []mfgroups.Group {
 	return cgs
 }
 
-func convertPolicies(cs []sdk.Policy) []policies.Policy {
-	ccs := []policies.Policy{}
+func convertUserPolicies(cs []sdk.Policy) []upolicies.Policy {
+	ccs := []upolicies.Policy{}
 
 	for _, c := range cs {
-		ccs = append(ccs, convertPolicy(c))
+		ccs = append(ccs, convertUserPolicy(c))
 	}
 
 	return ccs
 }
 
-func convertPolicy(sp sdk.Policy) policies.Policy {
-	return policies.Policy{
+func convertThingPolicies(cs []sdk.Policy) []tpolicies.Policy {
+	ccs := []tpolicies.Policy{}
+
+	for _, c := range cs {
+		ccs = append(ccs, convertThingPolicy(c))
+	}
+
+	return ccs
+}
+
+func convertUserPolicy(sp sdk.Policy) upolicies.Policy {
+	return upolicies.Policy{
+		OwnerID:   sp.OwnerID,
+		Subject:   sp.Subject,
+		Object:    sp.Object,
+		Actions:   sp.Actions,
+		CreatedAt: sp.CreatedAt,
+		UpdatedAt: sp.UpdatedAt,
+	}
+}
+
+func convertThingPolicy(sp sdk.Policy) tpolicies.Policy {
+	return tpolicies.Policy{
 		OwnerID:   sp.OwnerID,
 		Subject:   sp.Subject,
 		Object:    sp.Object,
@@ -324,14 +346,25 @@ func convertChannel(g sdk.Channel) mfgroups.Group {
 	}
 }
 
-func convertPolicyPage(pp sdk.PolicyPage) policies.PolicyPage {
-	return policies.PolicyPage{
-		Page: policies.Page{
+func convertUserPolicyPage(pp sdk.PolicyPage) upolicies.PolicyPage {
+	return upolicies.PolicyPage{
+		Page: upolicies.Page{
 			Limit:  pp.Limit,
 			Total:  pp.Total,
 			Offset: pp.Offset,
 		},
-		Policies: convertPolicies(pp.Policies),
+		Policies: convertUserPolicies(pp.Policies),
+	}
+}
+
+func convertThingPolicyPage(pp sdk.PolicyPage) tpolicies.PolicyPage {
+	return tpolicies.PolicyPage{
+		Page: tpolicies.Page{
+			Limit:  pp.Limit,
+			Total:  pp.Total,
+			Offset: pp.Offset,
+		},
+		Policies: convertThingPolicies(pp.Policies),
 	}
 }
 

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -95,6 +95,18 @@ func TestCreateThing(t *testing.T) {
 			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
 		},
 		{
+			desc: "register a thing that can't be marshalled",
+			client: sdk.Thing{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
+		{
 			desc: "register thing with empty secret",
 			client: sdk.Thing{
 				Name: "emptysecret",
@@ -238,6 +250,20 @@ func TestCreateThings(t *testing.T) {
 			response: []sdk.Thing{},
 			token:    token,
 			err:      errors.NewSDKErrorWithStatus(apiutil.ErrEmptyList, http.StatusBadRequest),
+		},
+		{
+			desc: "register things that can't be marshalled",
+			things: []sdk.Thing{
+				{
+					Name: "test",
+					Metadata: map[string]interface{}{
+						"test": make(chan int),
+					},
+				},
+			},
+			response: []sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
 		},
 	}
 	for _, tc := range cases {
@@ -440,15 +466,11 @@ func TestListThings(t *testing.T) {
 			Tag:      tc.tag,
 		}
 
-		repoCall := pRepo.On("Evaluate", mock.Anything, mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
-		repoCall1 := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
-		repoCall2 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertThings(tc.response)}, tc.err)
+		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertThings(tc.response)}, tc.err)
 		page, err := tsdk.Things(pm, adminToken)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		repoCall.Unset()
-		repoCall1.Unset()
-		repoCall2.Unset()
 	}
 }
 
@@ -582,17 +604,15 @@ func TestListThingsByChannel(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
-		repoCall1 := cRepo.On("Members", mock.Anything, tc.channelID, mock.Anything).Return(mfclients.MembersPage{Members: convertThings(tc.response)}, tc.err)
+		repoCall := cRepo.On("Members", mock.Anything, tc.channelID, mock.Anything).Return(mfclients.MembersPage{Members: convertThings(tc.response)}, tc.err)
 		membersPage, err := tsdk.ThingsByChannel(tc.channelID, tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, membersPage.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, membersPage.Things))
 		if tc.err == nil {
-			ok := repoCall1.Parent.AssertCalled(t, "Members", mock.Anything, tc.channelID, mock.Anything)
+			ok := repoCall.Parent.AssertCalled(t, "Members", mock.Anything, tc.channelID, mock.Anything)
 			assert.True(t, ok, fmt.Sprintf("Members was not called on %s", tc.desc))
 		}
 		repoCall.Unset()
-		repoCall1.Unset()
 	}
 }
 
@@ -736,6 +756,18 @@ func TestUpdateThing(t *testing.T) {
 			token:    adminToken,
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
 		},
+		{
+			desc: "update thing that can't be marshalled",
+			thing: sdk.Thing{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
 	}
 
 	for _, tc := range cases {
@@ -815,6 +847,18 @@ func TestUpdateThingTags(t *testing.T) {
 			response: sdk.Thing{},
 			token:    adminToken,
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+		{
+			desc: "update thing that can't be marshalled",
+			thing: sdk.Thing{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
 		},
 	}
 
@@ -966,6 +1010,18 @@ func TestUpdateThingOwner(t *testing.T) {
 			response: sdk.Thing{},
 			token:    adminToken,
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+		{
+			desc: "update thing that can't be marshalled",
+			thing: sdk.Thing{
+				Name: "test",
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
 		},
 	}
 

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -64,7 +64,7 @@ func TestCreateThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc     string
@@ -177,7 +177,7 @@ func TestCreateThing(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := cRepo.On("Save", mock.Anything, mock.Anything).Return(tc.response, tc.err)
-		rThing, err := tsdk.CreateThing(tc.client, tc.token)
+		rThing, err := mfsdk.CreateThing(tc.client, tc.token)
 		tc.response.ID = rThing.ID
 		tc.response.Owner = rThing.Owner
 		tc.response.CreatedAt = rThing.CreatedAt
@@ -221,7 +221,7 @@ func TestCreateThings(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc     string
@@ -268,7 +268,7 @@ func TestCreateThings(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := cRepo.On("Save", mock.Anything, mock.Anything).Return(tc.response, tc.err)
-		rThing, err := tsdk.CreateThings(tc.things, tc.token)
+		rThing, err := mfsdk.CreateThings(tc.things, tc.token)
 		for i, t := range rThing {
 			tc.response[i].ID = t.ID
 			tc.response[i].Owner = t.Owner
@@ -305,7 +305,7 @@ func TestListThings(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	owner := generateUUID(t)
 	for i := 10; i < 100; i++ {
@@ -467,7 +467,7 @@ func TestListThings(t *testing.T) {
 		}
 
 		repoCall := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertThings(tc.response)}, tc.err)
-		page, err := tsdk.Things(pm, adminToken)
+		page, err := mfsdk.Things(pm, adminToken)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		repoCall.Unset()
@@ -491,7 +491,7 @@ func TestListThingsByChannel(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	var nThing = uint64(10)
 	var aThings = []sdk.Thing{}
@@ -605,7 +605,7 @@ func TestListThingsByChannel(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := cRepo.On("Members", mock.Anything, tc.channelID, mock.Anything).Return(mfclients.MembersPage{Members: convertThings(tc.response)}, tc.err)
-		membersPage, err := tsdk.ThingsByChannel(tc.channelID, tc.page, tc.token)
+		membersPage, err := mfsdk.ThingsByChannel(tc.channelID, tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, membersPage.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, membersPage.Things))
 		if tc.err == nil {
@@ -640,7 +640,7 @@ func TestThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc     string
@@ -682,7 +682,7 @@ func TestThing(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.thingID).Return(convertThing(tc.response), tc.err)
-		rClient, err := tsdk.Thing(tc.thingID, tc.token)
+		rClient, err := mfsdk.Thing(tc.thingID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, rClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rClient))
 		if tc.err == nil {
@@ -711,7 +711,7 @@ func TestUpdateThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	thing := sdk.Thing{
 		ID:          generateUUID(t),
@@ -773,7 +773,7 @@ func TestUpdateThing(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("Update", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		uClient, err := tsdk.UpdateThing(tc.thing, tc.token)
+		uClient, err := mfsdk.UpdateThing(tc.thing, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -804,7 +804,7 @@ func TestUpdateThingTags(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	thing := sdk.Thing{
 		ID:          generateUUID(t),
@@ -865,7 +865,7 @@ func TestUpdateThingTags(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("UpdateTags", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		uClient, err := tsdk.UpdateThingTags(tc.thing, tc.token)
+		uClient, err := mfsdk.UpdateThingTags(tc.thing, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -896,7 +896,7 @@ func TestUpdateThingSecret(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user.ID = generateUUID(t)
 	rthing := thing
@@ -939,7 +939,7 @@ func TestUpdateThingSecret(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("UpdateSecret", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		uClient, err := tsdk.UpdateThingSecret(tc.oldSecret, tc.newSecret, tc.token)
+		uClient, err := mfsdk.UpdateThingSecret(tc.oldSecret, tc.newSecret, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -968,7 +968,7 @@ func TestUpdateThingOwner(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	thing = sdk.Thing{
 		ID:          generateUUID(t),
@@ -1028,7 +1028,7 @@ func TestUpdateThingOwner(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("UpdateOwner", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		uClient, err := tsdk.UpdateThingOwner(tc.thing, tc.token)
+		uClient, err := mfsdk.UpdateThingOwner(tc.thing, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -1059,7 +1059,7 @@ func TestEnableThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	enabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: generateUUID(t)}, Status: mfclients.EnabledStatus.String()}
 	disabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: generateUUID(t)}, Status: mfclients.DisabledStatus.String()}
@@ -1105,7 +1105,7 @@ func TestEnableThing(t *testing.T) {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertThing(tc.thing), tc.err)
 		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		eClient, err := tsdk.EnableThing(tc.id, tc.token)
+		eClient, err := mfsdk.EnableThing(tc.id, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, eClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, eClient))
 		if tc.err == nil {
@@ -1164,7 +1164,7 @@ func TestEnableThing(t *testing.T) {
 		}
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertThingsPage(tc.response), nil)
-		clientsPage, err := tsdk.Things(pm, adminToken)
+		clientsPage, err := mfsdk.Things(pm, adminToken)
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(clientsPage.Things))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
@@ -1190,7 +1190,7 @@ func TestDisableThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	enabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: generateUUID(t)}, Status: mfclients.EnabledStatus.String()}
 	disabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: generateUUID(t)}, Status: mfclients.DisabledStatus.String()}
@@ -1236,7 +1236,7 @@ func TestDisableThing(t *testing.T) {
 		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertThing(tc.thing), tc.err)
 		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
-		dThing, err := tsdk.DisableThing(tc.id, tc.token)
+		dThing, err := mfsdk.DisableThing(tc.id, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, dThing, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, dThing))
 		if tc.err == nil {
@@ -1295,7 +1295,7 @@ func TestDisableThing(t *testing.T) {
 		}
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertThingsPage(tc.response), nil)
-		page, err := tsdk.Things(pm, adminToken)
+		page, err := mfsdk.Things(pm, adminToken)
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(page.Things))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
@@ -1321,7 +1321,7 @@ func TestIdentify(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	thing = sdk.Thing{
 		ID:          generateUUID(t),
@@ -1352,7 +1352,7 @@ func TestIdentify(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := cRepo.On("RetrieveBySecret", mock.Anything, mock.Anything).Return(convertThing(thing), tc.err)
-		id, err := tsdk.IdentifyThing(tc.secret)
+		id, err := mfsdk.IdentifyThing(tc.secret)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, id, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, id))
 		if tc.err == nil {
@@ -1380,7 +1380,7 @@ func TestShareThing(t *testing.T) {
 	conf := sdk.Config{
 		ThingsURL: ts.URL,
 	}
-	tsdk := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc    string
@@ -1413,7 +1413,7 @@ func TestShareThing(t *testing.T) {
 		repoCall1 := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
 		repoCall3 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(policies.PolicyPage{}, nil)
 		repoCall4 := pRepo.On("Save", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
-		err := tsdk.ShareThing(tc.thingID, tc.groupID, tc.userID, []string{"c_list", "c_delete"}, tc.token)
+		err := mfsdk.ShareThing(tc.thingID, tc.groupID, tc.userID, []string{"c_list", "c_delete"}, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		if tc.err == nil {
 			ok := repoCall4.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -1,0 +1,1371 @@
+package sdk_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-zoo/bone"
+	"github.com/mainflux/mainflux/internal/apiutil"
+	"github.com/mainflux/mainflux/internal/testsutil"
+	mflog "github.com/mainflux/mainflux/logger"
+	mfclients "github.com/mainflux/mainflux/pkg/clients"
+	"github.com/mainflux/mainflux/pkg/errors"
+	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"github.com/mainflux/mainflux/things/clients"
+	"github.com/mainflux/mainflux/things/clients/api"
+	"github.com/mainflux/mainflux/things/clients/mocks"
+	gmocks "github.com/mainflux/mainflux/things/groups/mocks"
+	"github.com/mainflux/mainflux/things/policies"
+	papi "github.com/mainflux/mainflux/things/policies/api/http"
+	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	adminToken   = "token"
+	adminID      = generateUUID(&testing.T{})
+	users        = map[string]string{adminToken: adminID}
+	ID           = testsutil.GenerateUUID(&testing.T{}, idProvider)
+	tadminPolicy = mocks.MockSubjectSet{Object: ID, Relation: clients.AdminRelationKey}
+	uadminPolicy = cmocks.SubjectSet{Subject: ID, Relation: clients.AdminRelationKey}
+)
+
+func newThingsServer(svc clients.Service, psvc policies.Service) *httptest.Server {
+	logger := mflog.NewMock()
+	mux := bone.New()
+	api.MakeHandler(svc, mux, logger)
+	papi.MakePolicyHandler(svc, psvc, mux, logger)
+	return httptest.NewServer(mux)
+}
+
+func TestCreateThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	thing := sdk.Thing{
+		Name:   "test",
+		Status: mfclients.EnabledStatus.String(),
+	}
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc     string
+		client   sdk.Thing
+		response sdk.Thing
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "register new thing",
+			client:   thing,
+			response: thing,
+			token:    token,
+			err:      nil,
+		},
+		{
+			desc:     "register existing thing",
+			client:   thing,
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc:     "register empty thing",
+			client:   sdk.Thing{},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
+		},
+		{
+			desc: "register thing with empty secret",
+			client: sdk.Thing{
+				Name: "emptysecret",
+				Credentials: sdk.Credentials{
+					Secret: "",
+				},
+			},
+			response: sdk.Thing{
+				Name: "emptysecret",
+				Credentials: sdk.Credentials{
+					Secret: "",
+				},
+			},
+			token: token,
+			err:   nil,
+		},
+		{
+			desc: "register thing with empty identity",
+			client: sdk.Thing{
+				Credentials: sdk.Credentials{
+					Identity: "",
+					Secret:   secret,
+				},
+			},
+			response: sdk.Thing{
+				Credentials: sdk.Credentials{
+					Identity: "",
+					Secret:   secret,
+				},
+			},
+			token: token,
+			err:   nil,
+		},
+		{
+			desc:     "register empty thing",
+			client:   sdk.Thing{},
+			response: sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrMalformedEntity, http.StatusBadRequest),
+		},
+		{
+			desc: "register thing with every field defined",
+			client: sdk.Thing{
+				ID:          id,
+				Name:        "name",
+				Tags:        []string{"tag1", "tag2"},
+				Owner:       id,
+				Credentials: user.Credentials,
+				Metadata:    validMetadata,
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+				Status:      mfclients.EnabledStatus.String(),
+			},
+			response: sdk.Thing{
+				ID:          id,
+				Name:        "name",
+				Tags:        []string{"tag1", "tag2"},
+				Owner:       id,
+				Credentials: user.Credentials,
+				Metadata:    validMetadata,
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+				Status:      mfclients.EnabledStatus.String(),
+			},
+			token: token,
+			err:   nil,
+		},
+	}
+	for _, tc := range cases {
+		repoCall := cRepo.On("Save", mock.Anything, mock.Anything).Return(tc.response, tc.err)
+		rThing, err := tsdk.CreateThing(tc.client, tc.token)
+		tc.response.ID = rThing.ID
+		tc.response.Owner = rThing.Owner
+		tc.response.CreatedAt = rThing.CreatedAt
+		tc.response.UpdatedAt = rThing.UpdatedAt
+		rThing.Credentials.Secret = tc.response.Credentials.Secret
+		rThing.Status = tc.response.Status
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, rThing, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rThing))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestCreateThings(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	things := []sdk.Thing{
+		{
+			Name:   "test",
+			Status: mfclients.EnabledStatus.String(),
+		},
+		{
+			Name:   "test2",
+			Status: mfclients.EnabledStatus.String(),
+		},
+	}
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc     string
+		things   []sdk.Thing
+		response []sdk.Thing
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "register new things",
+			things:   things,
+			response: things,
+			token:    token,
+			err:      nil,
+		},
+		{
+			desc:     "register existing things",
+			things:   things,
+			response: []sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedCreation, http.StatusInternalServerError),
+		},
+		{
+			desc:     "register empty things",
+			things:   []sdk.Thing{},
+			response: []sdk.Thing{},
+			token:    token,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrEmptyList, http.StatusBadRequest),
+		},
+	}
+	for _, tc := range cases {
+		repoCall := cRepo.On("Save", mock.Anything, mock.Anything).Return(tc.response, tc.err)
+		rThing, err := tsdk.CreateThings(tc.things, tc.token)
+		for i, t := range rThing {
+			tc.response[i].ID = t.ID
+			tc.response[i].Owner = t.Owner
+			tc.response[i].CreatedAt = t.CreatedAt
+			tc.response[i].UpdatedAt = t.UpdatedAt
+			tc.response[i].Credentials.Secret = t.Credentials.Secret
+			t.Status = tc.response[i].Status
+		}
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, rThing, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rThing))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestListThings(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	var ths []sdk.Thing
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	owner := generateUUID(t)
+	for i := 10; i < 100; i++ {
+		th := sdk.Thing{
+			ID:   generateUUID(t),
+			Name: fmt.Sprintf("thing_%d", i),
+			Credentials: sdk.Credentials{
+				Identity: fmt.Sprintf("identity_%d", i),
+				Secret:   generateUUID(t),
+			},
+			Metadata: sdk.Metadata{"name": fmt.Sprintf("thing_%d", i)},
+			Status:   mfclients.EnabledStatus.String(),
+		}
+		if i == 50 {
+			th.Owner = owner
+			th.Status = mfclients.DisabledStatus.String()
+			th.Tags = []string{"tag1", "tag2"}
+		}
+		ths = append(ths, th)
+	}
+
+	cases := []struct {
+		desc       string
+		token      string
+		status     string
+		total      uint64
+		offset     uint64
+		limit      uint64
+		name       string
+		identifier string
+		ownerID    string
+		tag        string
+		metadata   sdk.Metadata
+		err        errors.SDKError
+		response   []sdk.Thing
+	}{
+		{
+			desc:     "get a list of things",
+			token:    token,
+			limit:    limit,
+			offset:   offset,
+			total:    total,
+			err:      nil,
+			response: ths[offset:limit],
+		},
+		{
+			desc:     "get a list of things with invalid token",
+			token:    invalidToken,
+			offset:   offset,
+			limit:    limit,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of things with empty token",
+			token:    "",
+			offset:   offset,
+			limit:    limit,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedList, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of things with zero limit",
+			token:    token,
+			offset:   offset,
+			limit:    0,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrLimitSize, http.StatusInternalServerError),
+			response: nil,
+		},
+		{
+			desc:     "get a list of things with limit greater than max",
+			token:    token,
+			offset:   offset,
+			limit:    110,
+			err:      errors.NewSDKErrorWithStatus(apiutil.ErrLimitSize, http.StatusInternalServerError),
+			response: []sdk.Thing(nil),
+		},
+		{
+			desc:       "get a list of things with same identity",
+			token:      token,
+			offset:     0,
+			limit:      1,
+			err:        nil,
+			identifier: Identity,
+			metadata:   sdk.Metadata{},
+			response:   []sdk.Thing{ths[89]},
+		},
+		{
+			desc:       "get a list of things with same identity and metadata",
+			token:      token,
+			offset:     0,
+			limit:      1,
+			err:        nil,
+			identifier: Identity,
+			metadata: sdk.Metadata{
+				"name": "client99",
+			},
+			response: []sdk.Thing{ths[89]},
+		},
+		{
+			desc:   "list things with given metadata",
+			token:  adminToken,
+			offset: 0,
+			limit:  1,
+			metadata: sdk.Metadata{
+				"name": "client99",
+			},
+			response: []sdk.Thing{ths[89]},
+			err:      nil,
+		},
+		{
+			desc:     "list things with given name",
+			token:    adminToken,
+			offset:   0,
+			limit:    1,
+			name:     "client10",
+			response: []sdk.Thing{ths[0]},
+			err:      nil,
+		},
+		{
+			desc:     "list things with given owner",
+			token:    adminToken,
+			offset:   0,
+			limit:    1,
+			ownerID:  owner,
+			response: []sdk.Thing{ths[50]},
+			err:      nil,
+		},
+		{
+			desc:     "list things with given status",
+			token:    adminToken,
+			offset:   0,
+			limit:    1,
+			status:   mfclients.DisabledStatus.String(),
+			response: []sdk.Thing{ths[50]},
+			err:      nil,
+		},
+		{
+			desc:     "list things with given tag",
+			token:    adminToken,
+			offset:   0,
+			limit:    1,
+			tag:      "tag1",
+			response: []sdk.Thing{ths[50]},
+			err:      nil,
+		},
+	}
+
+	for _, tc := range cases {
+		pm := sdk.PageMetadata{
+			Status:   tc.status,
+			Total:    total,
+			Offset:   tc.offset,
+			Limit:    tc.limit,
+			Name:     tc.name,
+			OwnerID:  tc.ownerID,
+			Metadata: tc.metadata,
+			Tag:      tc.tag,
+		}
+
+		repoCall := pRepo.On("Evaluate", mock.Anything, mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
+		repoCall1 := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
+		repoCall2 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertThings(tc.response)}, tc.err)
+		page, err := tsdk.Things(pm, adminToken)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, page.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+	}
+}
+
+func TestListThingsByChannel(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	var nThing = uint64(10)
+	var aThings = []sdk.Thing{}
+
+	for i := uint64(1); i < nThing; i++ {
+		thing := sdk.Thing{
+			Name: fmt.Sprintf("member_%d@example.com", i),
+			Credentials: sdk.Credentials{
+				Secret: generateUUID(t),
+			},
+			Tags:     []string{"tag1", "tag2"},
+			Metadata: sdk.Metadata{"role": "client"},
+			Status:   mfclients.EnabledStatus.String(),
+		}
+		aThings = append(aThings, thing)
+	}
+
+	cases := []struct {
+		desc      string
+		token     string
+		channelID string
+		page      sdk.PageMetadata
+		response  []sdk.Thing
+		err       errors.SDKError
+	}{
+		{
+			desc:      "list things with authorized token",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page:      sdk.PageMetadata{},
+			response:  aThings,
+			err:       nil,
+		},
+		{
+			desc:      "list things with offset and limit",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Offset: 4,
+				Limit:  nThing,
+			},
+			response: aThings[4:],
+			err:      nil,
+		},
+		{
+			desc:      "list things with given name",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Name:   Identity,
+				Offset: 6,
+				Limit:  nThing,
+			},
+			response: aThings[6:],
+			err:      nil,
+		},
+
+		{
+			desc:      "list things with given ownerID",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				OwnerID: user.Owner,
+				Offset:  6,
+				Limit:   nThing,
+			},
+			response: aThings[6:],
+			err:      nil,
+		},
+		{
+			desc:      "list things with given subject",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Subject: subject,
+				Offset:  6,
+				Limit:   nThing,
+			},
+			response: aThings[6:],
+			err:      nil,
+		},
+		{
+			desc:      "list things with given object",
+			token:     adminToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page: sdk.PageMetadata{
+				Object: object,
+				Offset: 6,
+				Limit:  nThing,
+			},
+			response: aThings[6:],
+			err:      nil,
+		},
+		{
+			desc:      "list things with an invalid token",
+			token:     invalidToken,
+			channelID: testsutil.GenerateUUID(t, idProvider),
+			page:      sdk.PageMetadata{},
+			response:  []sdk.Thing(nil),
+			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:      "list things with an invalid id",
+			token:     adminToken,
+			channelID: mocks.WrongID,
+			page:      sdk.PageMetadata{},
+			response:  []sdk.Thing(nil),
+			err:       errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("Members", mock.Anything, tc.channelID, mock.Anything).Return(mfclients.MembersPage{Members: convertThings(tc.response)}, tc.err)
+		membersPage, err := tsdk.ThingsByChannel(tc.channelID, tc.page, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, membersPage.Things, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, membersPage.Things))
+		if tc.err == nil {
+			ok := repoCall1.Parent.AssertCalled(t, "Members", mock.Anything, tc.channelID, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Members was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	thing := sdk.Thing{
+		Name:        "thingname",
+		Tags:        []string{"tag1", "tag2"},
+		Credentials: sdk.Credentials{Identity: "clientidentity", Secret: generateUUID(t)},
+		Metadata:    validMetadata,
+		Status:      mfclients.EnabledStatus.String(),
+	}
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc     string
+		token    string
+		thingID  string
+		response sdk.Thing
+		err      errors.SDKError
+	}{
+		{
+			desc:     "view thing successfully",
+			response: thing,
+			token:    adminToken,
+			thingID:  generateUUID(t),
+			err:      nil,
+		},
+		{
+			desc:     "view thing with an invalid token",
+			response: sdk.Thing{},
+			token:    invalidToken,
+			thingID:  generateUUID(t),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:     "view thing with valid token and invalid thing id",
+			response: sdk.Thing{},
+			token:    adminToken,
+			thingID:  mocks.WrongID,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrNotFound, http.StatusNotFound),
+		},
+		{
+			desc:     "view thing with an invalid token and invalid thing id",
+			response: sdk.Thing{},
+			token:    invalidToken,
+			thingID:  mocks.WrongID,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.thingID).Return(convertThing(tc.response), tc.err)
+		rClient, err := tsdk.Thing(tc.thingID, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, rClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rClient))
+		if tc.err == nil {
+			ok := repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, tc.thingID)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+		}
+		repoCall1.Unset()
+		repoCall.Unset()
+	}
+}
+
+func TestUpdateThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	thing := sdk.Thing{
+		ID:          generateUUID(t),
+		Name:        "clientname",
+		Credentials: sdk.Credentials{Secret: generateUUID(t)},
+		Metadata:    validMetadata,
+		Status:      mfclients.EnabledStatus.String(),
+	}
+
+	thing1 := thing
+	thing1.Name = "Updated client"
+
+	thing2 := thing
+	thing2.Metadata = sdk.Metadata{"role": "test"}
+	thing2.ID = invalidIdentity
+
+	cases := []struct {
+		desc     string
+		thing    sdk.Thing
+		response sdk.Thing
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "update thing name with valid token",
+			thing:    thing1,
+			response: thing1,
+			token:    adminToken,
+			err:      nil,
+		},
+		{
+			desc:     "update thing name with invalid token",
+			thing:    thing1,
+			response: sdk.Thing{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:     "update thing name with invalid id",
+			thing:    thing2,
+			response: sdk.Thing{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("Update", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		uClient, err := tsdk.UpdateThing(tc.thing, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateThingAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateThingAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "Update", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Update was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestUpdateThingTags(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	thing := sdk.Thing{
+		ID:          generateUUID(t),
+		Name:        "clientname",
+		Tags:        []string{"tag1", "tag2"},
+		Credentials: sdk.Credentials{Secret: generateUUID(t)},
+		Status:      mfclients.EnabledStatus.String(),
+	}
+
+	thing1 := thing
+	thing1.Tags = []string{"updatedTag1", "updatedTag2"}
+
+	thing2 := thing
+	thing2.ID = invalidIdentity
+
+	cases := []struct {
+		desc     string
+		thing    sdk.Thing
+		response sdk.Thing
+		token    string
+		err      error
+	}{
+		{
+			desc:     "update thing name with valid token",
+			thing:    thing,
+			response: thing1,
+			token:    adminToken,
+			err:      nil,
+		},
+		{
+			desc:     "update thing name with invalid token",
+			thing:    thing1,
+			response: sdk.Thing{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:     "update thing name with invalid id",
+			thing:    thing2,
+			response: sdk.Thing{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("UpdateTags", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		uClient, err := tsdk.UpdateThingTags(tc.thing, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateThingAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateThingAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "UpdateTags", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("UpdateTags was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestUpdateThingSecret(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	user.ID = generateUUID(t)
+	rthing := thing
+	rthing.Credentials.Secret, _ = phasher.Hash(user.Credentials.Secret)
+
+	cases := []struct {
+		desc      string
+		oldSecret string
+		newSecret string
+		token     string
+		response  sdk.Thing
+		err       error
+	}{
+		{
+			desc:      "update thing secret with valid token",
+			oldSecret: thing.Credentials.Secret,
+			newSecret: "newSecret",
+			token:     adminToken,
+			response:  rthing,
+			err:       nil,
+		},
+		{
+			desc:      "update thing secret with invalid token",
+			oldSecret: thing.Credentials.Secret,
+			newSecret: "newPassword",
+			token:     "non-existent",
+			response:  sdk.Thing{},
+			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:      "update thing secret with wrong old secret",
+			oldSecret: "oldSecret",
+			newSecret: "newSecret",
+			token:     adminToken,
+			response:  sdk.Thing{},
+			err:       errors.NewSDKErrorWithStatus(apiutil.ErrInvalidSecret, http.StatusBadRequest),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("UpdateSecret", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		uClient, err := tsdk.UpdateThingSecret(tc.oldSecret, tc.newSecret, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
+		if tc.err == nil {
+			ok := repoCall1.Parent.AssertCalled(t, "UpdateSecret", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("UpdateSecret was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestUpdateThingOwner(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	thing = sdk.Thing{
+		ID:          generateUUID(t),
+		Name:        "clientname",
+		Tags:        []string{"tag1", "tag2"},
+		Credentials: sdk.Credentials{Identity: "clientidentity", Secret: generateUUID(t)},
+		Metadata:    validMetadata,
+		Status:      mfclients.EnabledStatus.String(),
+		Owner:       "owner",
+	}
+
+	thing2 := thing
+	thing2.ID = invalidIdentity
+
+	cases := []struct {
+		desc     string
+		thing    sdk.Thing
+		response sdk.Thing
+		token    string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "update thing name with valid token",
+			thing:    thing,
+			response: thing,
+			token:    adminToken,
+			err:      nil,
+		},
+		{
+			desc:     "update thing name with invalid token",
+			thing:    thing2,
+			response: sdk.Thing{},
+			token:    invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+		{
+			desc:     "update thing name with invalid id",
+			thing:    thing2,
+			response: sdk.Thing{},
+			token:    adminToken,
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("UpdateOwner", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		uClient, err := tsdk.UpdateThingOwner(tc.thing, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateThingAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateThingAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "UpdateOwner", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("UpdateOwner was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestEnableThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	enabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: generateUUID(t)}, Status: mfclients.EnabledStatus.String()}
+	disabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: generateUUID(t)}, Status: mfclients.DisabledStatus.String()}
+	endisabledThing1 := disabledThing1
+	endisabledThing1.Status = mfclients.EnabledStatus.String()
+	endisabledThing1.ID = testsutil.GenerateUUID(t, idProvider)
+
+	cases := []struct {
+		desc     string
+		id       string
+		token    string
+		thing    sdk.Thing
+		response sdk.Thing
+		err      errors.SDKError
+	}{
+		{
+			desc:     "enable disabled thing",
+			id:       disabledThing1.ID,
+			token:    adminToken,
+			thing:    disabledThing1,
+			response: endisabledThing1,
+			err:      nil,
+		},
+		{
+			desc:     "enable enabled thing",
+			id:       enabledThing1.ID,
+			token:    adminToken,
+			thing:    enabledThing1,
+			response: sdk.Thing{},
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedEnable, http.StatusInternalServerError),
+		},
+		{
+			desc:     "enable non-existing thing",
+			id:       mocks.WrongID,
+			token:    adminToken,
+			thing:    sdk.Thing{},
+			response: sdk.Thing{},
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedEnable, http.StatusNotFound),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertThing(tc.thing), tc.err)
+		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		eClient, err := tsdk.EnableThing(tc.id, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, eClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, eClient))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateThingAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateThingAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, tc.id)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+			ok = repoCall2.Parent.AssertCalled(t, "ChangeStatus", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("ChangeStatus was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+	}
+
+	cases2 := []struct {
+		desc     string
+		token    string
+		status   string
+		metadata sdk.Metadata
+		response sdk.ThingsPage
+		size     uint64
+	}{
+		{
+			desc:   "list enabled clients",
+			status: mfclients.EnabledStatus.String(),
+			size:   2,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{enabledThing1, endisabledThing1},
+			},
+		},
+		{
+			desc:   "list disabled clients",
+			status: mfclients.DisabledStatus.String(),
+			size:   1,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{disabledThing1},
+			},
+		},
+		{
+			desc:   "list enabled and disabled clients",
+			status: mfclients.AllStatus.String(),
+			size:   3,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{enabledThing1, disabledThing1, endisabledThing1},
+			},
+		},
+	}
+
+	for _, tc := range cases2 {
+		pm := sdk.PageMetadata{
+			Total:  100,
+			Offset: 0,
+			Limit:  100,
+			Status: tc.status,
+		}
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertThingsPage(tc.response), nil)
+		clientsPage, err := tsdk.Things(pm, adminToken)
+		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+		size := uint64(len(clientsPage.Things))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestDisableThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	enabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: generateUUID(t)}, Status: mfclients.EnabledStatus.String()}
+	disabledThing1 := sdk.Thing{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: generateUUID(t)}, Status: mfclients.DisabledStatus.String()}
+	disenabledThing1 := enabledThing1
+	disenabledThing1.Status = mfclients.DisabledStatus.String()
+	disenabledThing1.ID = testsutil.GenerateUUID(t, idProvider)
+
+	cases := []struct {
+		desc     string
+		id       string
+		token    string
+		thing    sdk.Thing
+		response sdk.Thing
+		err      errors.SDKError
+	}{
+		{
+			desc:     "disable enabled thing",
+			id:       enabledThing1.ID,
+			token:    adminToken,
+			thing:    enabledThing1,
+			response: disenabledThing1,
+			err:      nil,
+		},
+		{
+			desc:     "disable disabled thing",
+			id:       disabledThing1.ID,
+			token:    adminToken,
+			thing:    disabledThing1,
+			response: sdk.Thing{},
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedDisable, http.StatusInternalServerError),
+		},
+		{
+			desc:     "disable non-existing thing",
+			id:       mocks.WrongID,
+			thing:    sdk.Thing{},
+			token:    adminToken,
+			response: sdk.Thing{},
+			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedDisable, http.StatusNotFound),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertThing(tc.thing), tc.err)
+		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertThing(tc.response), tc.err)
+		dThing, err := tsdk.DisableThing(tc.id, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, dThing, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, dThing))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "EvaluateThingAccess", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("EvaluateThingAccess was not called on %s", tc.desc))
+			ok = repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, tc.id)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+			ok = repoCall2.Parent.AssertCalled(t, "ChangeStatus", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("ChangeStatus was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall2.Unset()
+	}
+
+	cases2 := []struct {
+		desc     string
+		token    string
+		status   string
+		metadata sdk.Metadata
+		response sdk.ThingsPage
+		size     uint64
+	}{
+		{
+			desc:   "list enabled things",
+			status: mfclients.EnabledStatus.String(),
+			size:   2,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{enabledThing1, disenabledThing1},
+			},
+		},
+		{
+			desc:   "list disabled things",
+			status: mfclients.DisabledStatus.String(),
+			size:   1,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{disabledThing1},
+			},
+		},
+		{
+			desc:   "list enabled and disabled things",
+			status: mfclients.AllStatus.String(),
+			size:   3,
+			response: sdk.ThingsPage{
+				Things: []sdk.Thing{enabledThing1, disabledThing1, disenabledThing1},
+			},
+		},
+	}
+
+	for _, tc := range cases2 {
+		pm := sdk.PageMetadata{
+			Total:  100,
+			Offset: 0,
+			Limit:  100,
+			Status: tc.status,
+		}
+		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
+		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertThingsPage(tc.response), nil)
+		page, err := tsdk.Things(pm, adminToken)
+		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+		size := uint64(len(page.Things))
+		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
+func TestIdentify(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	thing = sdk.Thing{
+		ID:          generateUUID(t),
+		Name:        "clientname",
+		Credentials: sdk.Credentials{Identity: "clientidentity", Secret: generateUUID(t)},
+		Status:      mfclients.EnabledStatus.String(),
+	}
+
+	cases := []struct {
+		desc     string
+		secret   string
+		response string
+		err      errors.SDKError
+	}{
+		{
+			desc:     "identify thing successfully",
+			response: thing.ID,
+			secret:   thing.Credentials.Secret,
+			err:      nil,
+		},
+		{
+			desc:     "identify thing with an invalid token",
+			response: "",
+			secret:   invalidToken,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := cRepo.On("RetrieveBySecret", mock.Anything, mock.Anything).Return(convertThing(thing), tc.err)
+		id, err := tsdk.IdentifyThing(tc.secret)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, id, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, id))
+		if tc.err == nil {
+			ok := repoCall.Parent.AssertCalled(t, "RetrieveBySecret", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("RetrieveBySecret was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestShareThing(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	gRepo := new(gmocks.GroupRepository)
+	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
+	thingCache := mocks.NewCache()
+	policiesCache := pmocks.NewCache()
+
+	pRepo := new(pmocks.PolicyRepository)
+	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+
+	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ts := newThingsServer(svc, psvc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		ThingsURL: ts.URL,
+	}
+	tsdk := sdk.NewSDK(conf)
+
+	cases := []struct {
+		desc    string
+		thingID string
+		groupID string
+		userID  string
+		token   string
+		err     errors.SDKError
+	}{
+		{
+			desc:    "share thing with valid token",
+			thingID: generateUUID(t),
+			groupID: generateUUID(t),
+			userID:  generateUUID(t),
+			token:   adminToken,
+			err:     nil,
+		},
+		{
+			desc:    "share thing with invalid token",
+			thingID: generateUUID(t),
+			groupID: generateUUID(t),
+			userID:  generateUUID(t),
+			token:   invalidToken,
+			err:     errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall1 := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		repoCall3 := pRepo.On("Retrieve", mock.Anything, mock.Anything).Return(policies.PolicyPage{}, nil)
+		repoCall4 := pRepo.On("Save", mock.Anything, mock.Anything).Return(policies.Policy{}, nil)
+		err := tsdk.ShareThing(tc.thingID, tc.groupID, tc.userID, []string{"c_list", "c_delete"}, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			ok := repoCall4.Parent.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("Save was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+		repoCall1.Unset()
+		repoCall3.Unset()
+		repoCall4.Unset()
+	}
+}

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -31,7 +31,6 @@ var (
 	adminID      = generateUUID(&testing.T{})
 	users        = map[string]string{adminToken: adminID}
 	ID           = testsutil.GenerateUUID(&testing.T{}, idProvider)
-	tadminPolicy = mocks.MockSubjectSet{Object: ID, Relation: clients.AdminRelationKey}
 	uadminPolicy = cmocks.SubjectSet{Subject: ID, Relation: clients.AdminRelationKey}
 )
 

--- a/pkg/sdk/go/tokens_test.go
+++ b/pkg/sdk/go/tokens_test.go
@@ -1,0 +1,155 @@
+package sdk_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/mainflux/mainflux/internal/apiutil"
+	"github.com/mainflux/mainflux/pkg/errors"
+	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"github.com/mainflux/mainflux/users/clients"
+	"github.com/mainflux/mainflux/users/clients/mocks"
+	"github.com/mainflux/mainflux/users/jwt"
+	pmocks "github.com/mainflux/mainflux/users/policies/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestIssueToken(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	svc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	ts := newClientServer(svc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	client := sdk.User{
+		ID: generateUUID(t),
+		Credentials: sdk.Credentials{
+			Identity: "valid@example.com",
+			Secret:   "secret",
+		},
+		Status: sdk.EnabledStatus,
+	}
+	rClient := client
+	rClient.Credentials.Secret, _ = phasher.Hash(client.Credentials.Secret)
+
+	wrongClient := client
+	wrongClient.Credentials.Secret, _ = phasher.Hash("wrong")
+
+	cases := []struct {
+		desc     string
+		client   sdk.User
+		dbClient sdk.User
+		err      errors.SDKError
+	}{
+		{
+			desc:     "issue token for a new user",
+			client:   client,
+			dbClient: rClient,
+			err:      nil,
+		},
+		{
+			desc:   "issue token for an empty user",
+			client: sdk.User{},
+			err:    errors.NewSDKErrorWithStatus(apiutil.ErrMissingIdentity, http.StatusInternalServerError),
+		},
+		{
+			desc: "issue token for invalid secret",
+			client: sdk.User{
+				Credentials: sdk.Credentials{
+					Identity: "invalid",
+					Secret:   "secret",
+				},
+			},
+			dbClient: wrongClient,
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+	}
+	for _, tc := range cases {
+		repoCall := cRepo.On("RetrieveByIdentity", mock.Anything, mock.Anything).Return(convertClient(tc.dbClient), tc.err)
+		token, err := mfsdk.CreateToken(tc.client)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			assert.NotEmpty(t, token, fmt.Sprintf("%s: expected token, got empty", tc.desc))
+			ok := repoCall.Parent.AssertCalled(t, "RetrieveByIdentity", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByIdentity was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}
+
+func TestRefreshToken(t *testing.T) {
+	cRepo := new(mocks.ClientRepository)
+	pRepo := new(pmocks.PolicyRepository)
+	tokenizer := jwt.NewTokenRepo([]byte(secret), accessDuration, refreshDuration)
+
+	svc := clients.NewService(cRepo, pRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	ts := newClientServer(svc)
+	defer ts.Close()
+
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mfsdk := sdk.NewSDK(conf)
+
+	user := sdk.User{
+		ID:   generateUUID(t),
+		Name: "validtoken",
+		Credentials: sdk.Credentials{
+			Identity: "validtoken",
+			Secret:   "secret",
+		},
+		Status: sdk.EnabledStatus,
+	}
+	rUser := user
+	rUser.Credentials.Secret, _ = phasher.Hash(user.Credentials.Secret)
+
+	repoCall := cRepo.On("RetrieveByIdentity", context.Background(), user.Credentials.Identity).Return(convertClient(rUser), nil)
+	token, err := svc.IssueToken(context.Background(), user.Credentials.Identity, user.Credentials.Secret)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("Create token expected nil got %s\n", err))
+	ok := repoCall.Parent.AssertCalled(t, "RetrieveByIdentity", context.Background(), user.Credentials.Identity)
+	assert.True(t, ok, "RetrieveByIdentity was not called on creating token")
+	repoCall.Unset()
+
+	cases := []struct {
+		desc  string
+		token string
+		err   errors.SDKError
+	}{
+		{
+			desc:  "refresh token for a valid refresh token",
+			token: token.RefreshToken,
+			err:   nil,
+		},
+		{
+			desc:  "refresh token for a valid access token",
+			token: token.AccessToken,
+			err:   errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
+		},
+		{
+			desc:  "refresh token for an empty token",
+			token: "",
+			err:   errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusInternalServerError),
+		},
+	}
+	for _, tc := range cases {
+		repoCall := cRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(convertClient(user), tc.err)
+		_, err := mfsdk.RefreshToken(tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		if tc.err == nil {
+			assert.NotEmpty(t, token, fmt.Sprintf("%s: expected token, got empty", tc.desc))
+			ok := repoCall.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, mock.Anything)
+			assert.True(t, ok, fmt.Sprintf("RetrieveByID was not called on %s", tc.desc))
+		}
+		repoCall.Unset()
+	}
+}

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -50,7 +50,7 @@ func TestCreateClient(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 	token := testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), svc, cRepo, phasher)
 
 	cases := []struct {
@@ -169,7 +169,7 @@ func TestCreateClient(t *testing.T) {
 	}
 	for _, tc := range cases {
 		repoCall := cRepo.On("Save", mock.Anything, mock.Anything).Return(tc.response, tc.err)
-		rClient, err := clientSDK.CreateUser(tc.client, tc.token)
+		rClient, err := mfsdk.CreateUser(tc.client, tc.token)
 		tc.response.ID = rClient.ID
 		tc.response.Owner = rClient.Owner
 		tc.response.CreatedAt = rClient.CreatedAt
@@ -198,7 +198,7 @@ func TestListClients(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	for i := 10; i < 100; i++ {
 		cl := sdk.User{
@@ -361,7 +361,7 @@ func TestListClients(t *testing.T) {
 		repoCall := pRepo.On("Evaluate", mock.Anything, mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
 		repoCall1 := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(errors.ErrAuthorization)
 		repoCall2 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(mfclients.ClientsPage{Page: convertClientPage(pm), Clients: convertClients(tc.response)}, tc.err)
-		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
+		page, err := mfsdk.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		repoCall.Unset()
@@ -382,7 +382,7 @@ func TestListMembers(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	var nClients = uint64(10)
 	var aClients = []sdk.User{}
@@ -498,7 +498,7 @@ func TestListMembers(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("Members", mock.Anything, tc.groupID, mock.Anything).Return(mfclients.MembersPage{Members: convertClients(tc.response)}, tc.err)
-		membersPage, err := clientSDK.Members(tc.groupID, tc.page, tc.token)
+		membersPage, err := mfsdk.Members(tc.groupID, tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, membersPage.Members, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, membersPage.Members))
 		if tc.err == nil {
@@ -531,7 +531,7 @@ func TestClient(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc     string
@@ -574,7 +574,7 @@ func TestClient(t *testing.T) {
 		repoCall := pRepo.On("Evaluate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall2 := cRepo.On("RetrieveByID", mock.Anything, tc.clientID).Return(convertClient(tc.response), tc.err)
-		rClient, err := clientSDK.User(tc.clientID, tc.token)
+		rClient, err := mfsdk.User(tc.clientID, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, rClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rClient))
 		if tc.err == nil {
@@ -608,7 +608,7 @@ func TestProfile(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	cases := []struct {
 		desc     string
@@ -632,7 +632,7 @@ func TestProfile(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := cRepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		rClient, err := clientSDK.UserProfile(tc.token)
+		rClient, err := mfsdk.UserProfile(tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, rClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, rClient))
 		if tc.err == nil {
@@ -655,7 +655,7 @@ func TestUpdateClient(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user = sdk.User{
 		ID:          generateUUID(t),
@@ -721,7 +721,7 @@ func TestUpdateClient(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("Update", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		uClient, err := clientSDK.UpdateUser(tc.client, tc.token)
+		uClient, err := mfsdk.UpdateUser(tc.client, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -747,7 +747,7 @@ func TestUpdateClientTags(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user = sdk.User{
 		ID:          generateUUID(t),
@@ -813,7 +813,7 @@ func TestUpdateClientTags(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("UpdateTags", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		uClient, err := clientSDK.UpdateUserTags(tc.client, tc.token)
+		uClient, err := mfsdk.UpdateUserTags(tc.client, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -839,7 +839,7 @@ func TestUpdateClientIdentity(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user = sdk.User{
 		ID:          generateUUID(t),
@@ -903,7 +903,7 @@ func TestUpdateClientIdentity(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("UpdateIdentity", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		uClient, err := clientSDK.UpdateUserIdentity(tc.client, tc.token)
+		uClient, err := mfsdk.UpdateUserIdentity(tc.client, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -929,7 +929,7 @@ func TestUpdateClientSecret(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user.ID = generateUUID(t)
 	rclient := user
@@ -978,7 +978,7 @@ func TestUpdateClientSecret(t *testing.T) {
 		repoCall := cRepo.On("RetrieveByID", mock.Anything, user.ID).Return(convertClient(tc.response), tc.err)
 		repoCall1 := cRepo.On("RetrieveByIdentity", mock.Anything, user.Credentials.Identity).Return(convertClient(tc.response), tc.err)
 		repoCall2 := cRepo.On("UpdateSecret", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		uClient, err := clientSDK.UpdatePassword(tc.oldSecret, tc.newSecret, tc.token)
+		uClient, err := mfsdk.UpdatePassword(tc.oldSecret, tc.newSecret, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -1007,7 +1007,7 @@ func TestUpdateClientOwner(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	user = sdk.User{
 		ID:          generateUUID(t),
@@ -1070,7 +1070,7 @@ func TestUpdateClientOwner(t *testing.T) {
 	for _, tc := range cases {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("UpdateOwner", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		uClient, err := clientSDK.UpdateUserOwner(tc.client, tc.token)
+		uClient, err := mfsdk.UpdateUserOwner(tc.client, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, uClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, uClient))
 		if tc.err == nil {
@@ -1096,7 +1096,7 @@ func TestEnableClient(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	enabledClient1 := sdk.User{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: "password"}, Status: mfclients.EnabledStatus.String()}
 	disabledClient1 := sdk.User{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: "password"}, Status: mfclients.DisabledStatus.String()}
@@ -1142,7 +1142,7 @@ func TestEnableClient(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertClient(tc.client), tc.err)
 		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		eClient, err := clientSDK.EnableUser(tc.id, tc.token)
+		eClient, err := mfsdk.EnableUser(tc.id, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, eClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, eClient))
 		if tc.err == nil {
@@ -1201,7 +1201,7 @@ func TestEnableClient(t *testing.T) {
 		}
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
-		clientsPage, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
+		clientsPage, err := mfsdk.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(clientsPage.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))
@@ -1222,7 +1222,7 @@ func TestDisableClient(t *testing.T) {
 	conf := sdk.Config{
 		UsersURL: ts.URL,
 	}
-	clientSDK := sdk.NewSDK(conf)
+	mfsdk := sdk.NewSDK(conf)
 
 	enabledClient1 := sdk.User{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client1@example.com", Secret: "password"}, Status: mfclients.EnabledStatus.String()}
 	disabledClient1 := sdk.User{ID: testsutil.GenerateUUID(t, idProvider), Credentials: sdk.Credentials{Identity: "client3@example.com", Secret: "password"}, Status: mfclients.DisabledStatus.String()}
@@ -1268,7 +1268,7 @@ func TestDisableClient(t *testing.T) {
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveByID", mock.Anything, tc.id).Return(convertClient(tc.client), tc.err)
 		repoCall2 := cRepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(convertClient(tc.response), tc.err)
-		dClient, err := clientSDK.DisableUser(tc.id, tc.token)
+		dClient, err := mfsdk.DisableUser(tc.id, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, dClient, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, dClient))
 		if tc.err == nil {
@@ -1327,7 +1327,7 @@ func TestDisableClient(t *testing.T) {
 		}
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("RetrieveAll", mock.Anything, mock.Anything).Return(convertClientsPage(tc.response), nil)
-		page, err := clientSDK.Users(pm, generateValidToken(t, svc, cRepo))
+		page, err := mfsdk.Users(pm, generateValidToken(t, svc, cRepo))
 		assert.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		size := uint64(len(page.Users))
 		assert.Equal(t, tc.size, size, fmt.Sprintf("%s: expected size %d got %d\n", tc.desc, tc.size, size))

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -82,6 +82,21 @@ func TestCreateClient(t *testing.T) {
 			err:      errors.NewSDKErrorWithStatus(errors.ErrMalformedEntity, http.StatusBadRequest),
 		},
 		{
+			desc: "register a user that can't be marshalled",
+			client: sdk.User{
+				Credentials: sdk.Credentials{
+					Identity: "user@example.com",
+					Secret:   "12345678",
+				},
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.User{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
+		{
 			desc: "register user with invalid identity",
 			client: sdk.User{
 				Credentials: sdk.Credentials{
@@ -686,6 +701,21 @@ func TestUpdateClient(t *testing.T) {
 			token:    generateValidToken(t, svc, cRepo),
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
 		},
+		{
+			desc: "update a user that can't be marshalled",
+			client: sdk.User{
+				Credentials: sdk.Credentials{
+					Identity: "user@example.com",
+					Secret:   "12345678",
+				},
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.User{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
 	}
 
 	for _, tc := range cases {
@@ -762,6 +792,22 @@ func TestUpdateClientTags(t *testing.T) {
 			token:    generateValidToken(t, svc, cRepo),
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
 		},
+		{
+			desc: "update a user that can't be marshalled",
+			client: sdk.User{
+				ID: generateUUID(t),
+				Credentials: sdk.Credentials{
+					Identity: "user@example.com",
+					Secret:   "12345678",
+				},
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.User{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
+		},
 	}
 
 	for _, tc := range cases {
@@ -835,6 +881,22 @@ func TestUpdateClientIdentity(t *testing.T) {
 			response: sdk.User{},
 			token:    generateValidToken(t, svc, cRepo),
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+		{
+			desc: "update a user that can't be marshalled",
+			client: sdk.User{
+				ID: generateUUID(t),
+				Credentials: sdk.Credentials{
+					Identity: "user@example.com",
+					Secret:   "12345678",
+				},
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.User{},
+			token:    generateValidToken(t, svc, cRepo),
+			err:      errors.NewSDKErrorWithStatus(fmt.Errorf("json: unsupported type: chan int"), http.StatusInternalServerError),
 		},
 	}
 
@@ -987,6 +1049,21 @@ func TestUpdateClientOwner(t *testing.T) {
 			response: sdk.User{},
 			token:    generateValidToken(t, svc, cRepo),
 			err:      errors.NewSDKErrorWithStatus(sdk.ErrFailedUpdate, http.StatusInternalServerError),
+		},
+		{
+			desc: "update a user that can't be marshalled",
+			client: sdk.User{
+				Credentials: sdk.Credentials{
+					Identity: "user@example.com",
+					Secret:   "12345678",
+				},
+				Metadata: map[string]interface{}{
+					"test": make(chan int),
+				},
+			},
+			response: sdk.User{},
+			token:    token,
+			err:      errors.NewSDKError(fmt.Errorf("json: unsupported type: chan int")),
 		},
 	}
 

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -44,7 +44,7 @@ func newService(tokens map[string]string) (clients.Service, *mocks.ClientReposit
 	adminPolicy := mocks.MockSubjectSet{Object: ID, Relation: clients.AdminRelationKey}
 	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	thingCache := mocks.NewCache()
-	policiesCache := pmocks.NewChannelCache()
+	policiesCache := pmocks.NewCache()
 	idProvider := uuid.NewMock()
 	cRepo := new(mocks.ClientRepository)
 	gRepo := new(gmocks.GroupRepository)

--- a/things/groups/service_test.go
+++ b/things/groups/service_test.go
@@ -47,7 +47,7 @@ func newService(tokens map[string]string) (groups.Service, *gmocks.GroupReposito
 
 	gRepo := new(gmocks.GroupRepository)
 	pRepo := new(pmocks.PolicyRepository)
-	policiesCache := pmocks.NewChannelCache()
+	policiesCache := pmocks.NewCache()
 
 	psvc := policies.NewService(auth, pRepo, policiesCache, idProvider)
 

--- a/things/policies/mocks/channels.go
+++ b/things/policies/mocks/channels.go
@@ -10,19 +10,19 @@ import (
 	"github.com/mainflux/mainflux/things/policies"
 )
 
-type channelCacheMock struct {
+type cacheMock struct {
 	mu       sync.Mutex
 	policies map[string]string
 }
 
-// NewChannelCache returns mock cache instance.
-func NewChannelCache() policies.Cache {
-	return &channelCacheMock{
+// NewCache returns mock cache instance.
+func NewCache() policies.Cache {
+	return &cacheMock{
 		policies: make(map[string]string),
 	}
 }
 
-func (ccm *channelCacheMock) Put(_ context.Context, policy policies.Policy) error {
+func (ccm *cacheMock) Put(_ context.Context, policy policies.Policy) error {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
 
@@ -30,7 +30,7 @@ func (ccm *channelCacheMock) Put(_ context.Context, policy policies.Policy) erro
 	return nil
 }
 
-func (ccm *channelCacheMock) Get(_ context.Context, policy policies.Policy) (policies.Policy, error) {
+func (ccm *cacheMock) Get(_ context.Context, policy policies.Policy) (policies.Policy, error) {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
 	actions := ccm.policies[fmt.Sprintf("%s:%s", policy.Subject, policy.Object)]
@@ -46,7 +46,7 @@ func (ccm *channelCacheMock) Get(_ context.Context, policy policies.Policy) (pol
 	return policies.Policy{}, errors.ErrNotFound
 }
 
-func (ccm *channelCacheMock) Remove(_ context.Context, policy policies.Policy) error {
+func (ccm *cacheMock) Remove(_ context.Context, policy policies.Policy) error {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
 

--- a/things/policies/service_test.go
+++ b/things/policies/service_test.go
@@ -31,7 +31,7 @@ func newService(tokens map[string]string) (policies.Service, *pmocks.PolicyRepos
 	adminPolicy := mocks.MockSubjectSet{Object: "things", Relation: clients.AdminRelationKey}
 	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	idProvider := uuid.NewMock()
-	policiesCache := pmocks.NewChannelCache()
+	policiesCache := pmocks.NewCache()
 	pRepo := new(pmocks.PolicyRepository)
 	uRepo := new(umocks.PolicyRepository)
 

--- a/users/clients/mocks/authn.go
+++ b/users/clients/mocks/authn.go
@@ -56,7 +56,7 @@ func (svc authServiceMock) Issue(ctx context.Context, in *policies.IssueReq, opt
 func (svc authServiceMock) Authorize(ctx context.Context, req *policies.AuthorizeReq, _ ...grpc.CallOption) (r *policies.AuthorizeRes, err error) {
 	for _, policy := range svc.authz[req.GetSub()] {
 		for _, r := range policy.Relation {
-			if r == req.GetAct() && policy.Subject == req.GetSub() {
+			if r == req.GetAct() && policy.Subject == req.GetObj() {
 				return &policies.AuthorizeRes{Authorized: true}, nil
 			}
 		}

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -119,8 +119,8 @@ func (svc service) IssueToken(ctx context.Context, identity, secret string) (jwt
 	return svc.tokens.Issue(ctx, claims)
 }
 
-func (svc service) RefreshToken(ctx context.Context, accessToken string) (jwt.Token, error) {
-	claims, err := svc.tokens.Parse(ctx, accessToken)
+func (svc service) RefreshToken(ctx context.Context, refreshToken string) (jwt.Token, error) {
+	claims, err := svc.tokens.Parse(ctx, refreshToken)
 	if err != nil {
 		return jwt.Token{}, errors.Wrap(errors.ErrAuthentication, err)
 	}


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?

Adds SDK Tests while fixing some minor errors for example
- On thing `Identify` on `HTTP` endpoint pass `secret` as header rather than body

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
To be merged after #1811 