### PR TITLE
NOISSUE - Fix SEND_TELEMETRY Env Var

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -119,6 +119,9 @@ MF_COAP_ADAPTER_PORT=5683
 MF_WS_ADAPTER_LOG_LEVEL=debug
 MF_WS_ADAPTER_PORT=8186
 
+### Call home
+MF_SEND_TELEMETRY=true
+
 ## Addons Services
 ### Bootstrap
 MF_BOOTSTRAP_LOG_LEVEL=debug
@@ -378,6 +381,3 @@ MF_GRAFANA_ADMIN_PASSWORD=mainflux
 
 # Docker image tag
 MF_RELEASE_TAG=latest
-
-# Call Home
-MF_SEND_TELEMETRY = true


### PR DESCRIPTION
### What does this do?
Fixes telemetry env vars by removing spaces in between and adds it to core services

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
The error before was 
```bash
.env:123: command not found: MF_SEND_TELEMETRY
```