### PR TITLE
NOISSUE - List Members or Memberships To Include Ownership Rights

### DIFF
--- a/things/clients/postgres/clients.go
+++ b/things/clients/postgres/clients.go
@@ -165,9 +165,9 @@ func (repo clientRepo) Members(ctx context.Context, groupID string, pm mfclients
 	}
 
 	aq := ""
-	// If not admin, the client needs to have a g_list action on the group
+	// If not admin, the client needs to have a g_list action on the group or they are the owner.
 	if pm.Subject != "" {
-		aq = fmt.Sprintf("AND EXISTS (SELECT 1 FROM policies WHERE policies.subject = '%s' AND policies.object = :group_id AND '%s'=ANY(actions))", pm.Subject, pm.Action)
+		aq = `AND EXISTS (SELECT 1 FROM policies WHERE policies.subject = :subject AND policies.object = :group_id AND :action=ANY(actions)) OR c.owner_id = :subject`
 	}
 
 	q := fmt.Sprintf(`SELECT c.id, c.name, c.tags, c.metadata, c.identity, c.secret, c.status, c.created_at FROM clients c
@@ -406,26 +406,26 @@ func pageQuery(pm mfclients.Page) (string, error) {
 		query = append(query, fmt.Sprintf("id IN ('%s')", strings.Join(pm.IDs, "','")))
 	}
 	if pm.Name != "" {
-		query = append(query, fmt.Sprintf("c.name = '%s'", pm.Name))
+		query = append(query, "c.name = :name")
 	}
 	if pm.Tag != "" {
-		query = append(query, fmt.Sprintf("'%s' = ANY(c.tags)", pm.Tag))
+		query = append(query, ":tag = ANY(c.tags)")
 	}
 	if pm.Status != mfclients.AllStatus {
-		query = append(query, fmt.Sprintf("c.status = %d", pm.Status))
+		query = append(query, "c.status = :status")
 	}
 	// For listing clients that the specified client owns but not sharedby
 	if pm.Owner != "" && pm.SharedBy == "" {
-		query = append(query, fmt.Sprintf("c.owner_id = '%s'", pm.Owner))
+		query = append(query, "c.owner_id = :owner_id")
 	}
 
 	// For listing clients that the specified client owns and that are shared with the specified client
 	if pm.Owner != "" && pm.SharedBy != "" {
-		query = append(query, fmt.Sprintf("(c.owner_id = '%s' OR c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = '%s' AND '%s'=ANY(actions))))", pm.Owner, pm.SharedBy, pm.Action))
+		query = append(query, "(c.owner_id = :owner_id OR c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :actions=ANY(actions))))")
 	}
 	// For listing clients that the specified client is shared with
 	if pm.SharedBy != "" && pm.Owner == "" {
-		query = append(query, fmt.Sprintf("c.owner_id != '%s' AND (c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = '%s' AND '%s'=ANY(actions))))", pm.SharedBy, pm.SharedBy, pm.Action))
+		query = append(query, "c.owner_id != :shared_by AND (c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :actions=ANY(actions))))")
 	}
 	if len(query) > 0 {
 		emq = fmt.Sprintf("WHERE %s", strings.Join(query, " AND "))
@@ -448,6 +448,10 @@ func toDBClientsPage(pm mfclients.Page) (dbClientsPage, error) {
 		Limit:    pm.Limit,
 		Status:   pm.Status,
 		Tag:      pm.Tag,
+		Identity: pm.Identity,
+		SharedBy: pm.SharedBy,
+		Subject:  pm.Subject,
+		Action:   pm.Action,
 	}, nil
 }
 
@@ -462,4 +466,7 @@ type dbClientsPage struct {
 	Total    uint64           `db:"total"`
 	Limit    uint64           `db:"limit"`
 	Offset   uint64           `db:"offset"`
+	SharedBy string           `db:"shared_by"`
+	Subject  string           `db:"subject"`
+	Action   string           `db:"action"`
 }

--- a/things/clients/postgres/clients.go
+++ b/things/clients/postgres/clients.go
@@ -421,11 +421,11 @@ func pageQuery(pm mfclients.Page) (string, error) {
 
 	// For listing clients that the specified client owns and that are shared with the specified client
 	if pm.Owner != "" && pm.SharedBy != "" {
-		query = append(query, "(c.owner_id = :owner_id OR c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :actions=ANY(actions))))")
+		query = append(query, "(c.owner_id = :owner_id OR c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :action=ANY(actions))))")
 	}
 	// For listing clients that the specified client is shared with
 	if pm.SharedBy != "" && pm.Owner == "" {
-		query = append(query, "c.owner_id != :shared_by AND (c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :actions=ANY(actions))))")
+		query = append(query, "c.owner_id != :shared_by AND (c.id IN (SELECT subject FROM policies WHERE object IN (SELECT object FROM policies WHERE subject = :shared_by AND :action=ANY(actions))))")
 	}
 	if len(query) > 0 {
 		emq = fmt.Sprintf("WHERE %s", strings.Join(query, " AND "))

--- a/things/clients/postgres/clients_test.go
+++ b/things/clients/postgres/clients_test.go
@@ -212,7 +212,7 @@ func TestClientsRetrieveAll(t *testing.T) {
 	prepo := ppostgres.NewRepository(database)
 
 	var nClients = uint64(200)
-	var ownerID string
+	var ownerID = testsutil.GenerateUUID(t, idProvider)
 
 	meta := mfclients.Metadata{
 		"admin": "true",
@@ -240,9 +240,6 @@ func TestClientsRetrieveAll(t *testing.T) {
 			},
 			Metadata: mfclients.Metadata{},
 			Status:   mfclients.EnabledStatus,
-		}
-		if i == 1 {
-			ownerID = client.ID
 		}
 		if i%10 == 0 {
 			client.Owner = ownerID
@@ -374,11 +371,11 @@ func TestClientsRetrieveAll(t *testing.T) {
 				Owner:  ownerID,
 				Status: mfclients.AllStatus,
 			},
-			response: []mfclients.Client{expectedClients[10], expectedClients[20], expectedClients[30], expectedClients[40], expectedClients[50], expectedClients[60],
+			response: []mfclients.Client{expectedClients[0], expectedClients[10], expectedClients[20], expectedClients[30], expectedClients[40], expectedClients[50], expectedClients[60],
 				expectedClients[70], expectedClients[80], expectedClients[90], expectedClients[100], expectedClients[110], expectedClients[120], expectedClients[130],
 				expectedClients[140], expectedClients[150], expectedClients[160], expectedClients[170], expectedClients[180], expectedClients[190],
 			},
-			size: 19,
+			size: 20,
 		},
 		"retrieve clients by wrong owner": {
 			pm: mfclients.Page{
@@ -390,6 +387,33 @@ func TestClientsRetrieveAll(t *testing.T) {
 			},
 			response: []mfclients.Client{},
 			size:     0,
+		},
+		"retrieve all clients shared by": {
+			pm: mfclients.Page{
+				Offset:   0,
+				Limit:    nClients,
+				Total:    nClients,
+				SharedBy: expectedClients[0].ID,
+				Action:   "c_list",
+				Status:   mfclients.AllStatus,
+			},
+			response: expectedClients,
+			size:     nClients,
+		},
+		"retrieve all clients shared by and owned by": {
+			pm: mfclients.Page{
+				Offset:   0,
+				Limit:    nClients,
+				Total:    nClients,
+				SharedBy: ownerID,
+				Owner:    ownerID,
+				Status:   mfclients.AllStatus,
+			},
+			response: []mfclients.Client{expectedClients[0], expectedClients[10], expectedClients[20], expectedClients[30], expectedClients[40], expectedClients[50], expectedClients[60],
+				expectedClients[70], expectedClients[80], expectedClients[90], expectedClients[100], expectedClients[110], expectedClients[120], expectedClients[130],
+				expectedClients[140], expectedClients[150], expectedClients[160], expectedClients[170], expectedClients[180], expectedClients[190],
+			},
+			size: 20,
 		},
 		"retrieve all clients by disabled status": {
 			pm: mfclients.Page{

--- a/things/clients/postgres/clients_test.go
+++ b/things/clients/postgres/clients_test.go
@@ -456,6 +456,78 @@ func TestClientsRetrieveAll(t *testing.T) {
 	}
 }
 
+func TestGroupsMembers(t *testing.T) {
+	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
+	postgres.NewDatabase(db, tracer)
+	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
+	prepo := ppostgres.NewRepository(database)
+
+	clientA := mfclients.Client{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "client-memberships",
+		Credentials: mfclients.Credentials{
+			Secret: testsutil.GenerateUUID(t, idProvider),
+		},
+		Metadata: mfclients.Metadata{},
+		Status:   mfclients.EnabledStatus,
+	}
+	clientB := mfclients.Client{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "client-memberships",
+		Credentials: mfclients.Credentials{
+			Identity: "client-memberships2@example.com",
+			Secret:   testsutil.GenerateUUID(t, idProvider),
+		},
+		Metadata: mfclients.Metadata{},
+		Status:   mfclients.EnabledStatus,
+	}
+	group := mfgroups.Group{
+		ID:       testsutil.GenerateUUID(t, idProvider),
+		Name:     "group-membership",
+		Metadata: mfclients.Metadata{},
+		Status:   mfclients.EnabledStatus,
+	}
+
+	policyA := policies.Policy{
+		Subject: clientA.ID,
+		Object:  group.ID,
+		Actions: []string{"g_list"},
+	}
+	policyB := policies.Policy{
+		Subject: clientB.ID,
+		Object:  group.ID,
+		Actions: []string{"g_list"},
+	}
+
+	_, err := crepo.Save(context.Background(), clientA)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("save client: expected %v got %s\n", nil, err))
+	_, err = crepo.Save(context.Background(), clientB)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("save client: expected %v got %s\n", nil, err))
+	_, err = grepo.Save(context.Background(), group)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("save group: expected %v got %s\n", nil, err))
+	_, err = prepo.Save(context.Background(), policyA)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("save policy: expected %v got %s\n", nil, err))
+	_, err = prepo.Save(context.Background(), policyB)
+	assert.True(t, errors.Contains(err, nil), fmt.Sprintf("save policy: expected %v got %s\n", nil, err))
+
+	cases := map[string]struct {
+		ID  string
+		err error
+	}{
+		"retrieve members for existing group":     {group.ID, nil},
+		"retrieve members for non-existing group": {wrongID, nil},
+	}
+
+	for desc, tc := range cases {
+		mp, err := crepo.Members(context.Background(), tc.ID, mfclients.Page{Total: 10, Offset: 0, Limit: 10, Status: mfclients.AllStatus, Subject: clientB.ID, Action: "g_list"})
+		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
+		if tc.ID == group.ID {
+			assert.ElementsMatch(t, mp.Members, []mfclients.Client{clientA, clientB}, fmt.Sprintf("%s: expected %v got %v\n", desc, []mfclients.Client{clientA, clientB}, mp.Members))
+		}
+	}
+}
+
 func TestClientsUpdateMetadata(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	postgres.NewDatabase(db, tracer)

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -1156,7 +1156,6 @@ func TestListMembers(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		fmt.Println(tc.desc)
 		repoCall1 := cRepo.On("Members", context.Background(), tc.groupID, tc.page).Return(tc.response, tc.err)
 		page, err := svc.ListClientsByGroup(context.Background(), tc.token, tc.groupID, tc.page)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -1034,7 +1034,8 @@ func TestListMembers(t *testing.T) {
 
 	var nClients = uint64(10)
 	var aClients = []mfclients.Client{}
-	for i := uint64(1); i < nClients; i++ {
+	owner := testsutil.GenerateUUID(t, idProvider)
+	for i := uint64(0); i < nClients; i++ {
 		identity := fmt.Sprintf("member_%d@example.com", i)
 		client := mfclients.Client{
 			ID:   testsutil.GenerateUUID(t, idProvider),
@@ -1045,6 +1046,9 @@ func TestListMembers(t *testing.T) {
 			},
 			Tags:     []string{"tag1", "tag2"},
 			Metadata: mfclients.Metadata{"role": "client"},
+		}
+		if i%3 == 0 {
+			client.Owner = owner
 		}
 		aClients = append(aClients, client)
 	}
@@ -1063,9 +1067,9 @@ func TestListMembers(t *testing.T) {
 			token:   validToken,
 			groupID: testsutil.GenerateUUID(t, idProvider),
 			page: mfclients.Page{
-				Subject: adminEmail,
-				Owner:   adminEmail,
+				Subject: testsutil.GenerateUUID(t, idProvider),
 				Action:  "g_list",
+				Owner:   adminEmail,
 			},
 			response: mfclients.MembersPage{
 				Page: mfclients.Page{
@@ -1085,9 +1089,9 @@ func TestListMembers(t *testing.T) {
 				Offset:  6,
 				Limit:   nClients,
 				Status:  mfclients.AllStatus,
-				Subject: adminEmail,
-				Owner:   adminEmail,
+				Subject: testsutil.GenerateUUID(t, idProvider),
 				Action:  "g_list",
+				Owner:   adminEmail,
 			},
 			response: mfclients.MembersPage{
 				Page: mfclients.Page{
@@ -1101,7 +1105,7 @@ func TestListMembers(t *testing.T) {
 			token:   inValidToken,
 			groupID: testsutil.GenerateUUID(t, idProvider),
 			page: mfclients.Page{
-				Subject: adminEmail,
+				Subject: testsutil.GenerateUUID(t, idProvider),
 				Action:  "g_list",
 				Owner:   adminEmail,
 			},
@@ -1119,7 +1123,7 @@ func TestListMembers(t *testing.T) {
 			token:   validToken,
 			groupID: mocks.WrongID,
 			page: mfclients.Page{
-				Subject: adminEmail,
+				Subject: mocks.WrongID,
 				Action:  "g_list",
 				Owner:   adminEmail,
 			},
@@ -1132,9 +1136,27 @@ func TestListMembers(t *testing.T) {
 			},
 			err: errors.ErrNotFound,
 		},
+		{
+			desc:    "list clients for an owner",
+			token:   validToken,
+			groupID: testsutil.GenerateUUID(t, idProvider),
+			page: mfclients.Page{
+				Subject: owner,
+				Action:  "g_list",
+				Owner:   adminEmail,
+			},
+			response: mfclients.MembersPage{
+				Page: mfclients.Page{
+					Total: 4,
+				},
+				Members: []mfclients.Client{aClients[0], aClients[3], aClients[6], aClients[9]},
+			},
+			err: nil,
+		},
 	}
 
 	for _, tc := range cases {
+		fmt.Println(tc.desc)
 		repoCall1 := cRepo.On("Members", context.Background(), tc.groupID, tc.page).Return(tc.response, tc.err)
 		page, err := svc.ListClientsByGroup(context.Background(), tc.token, tc.groupID, tc.page)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))

--- a/things/groups/postgres/groups.go
+++ b/things/groups/postgres/groups.go
@@ -139,9 +139,9 @@ func (repo grepo) Memberships(ctx context.Context, clientID string, gm mfgroups.
 		g.metadata, g.created_at, g.updated_at, g.updated_by, g.status FROM groups g`
 	}
 	aq := ""
-	// If not admin, the client needs to have a g_list action on the group
+	// If not admin, the client needs to have a g_list action on the group or they are the owner.
 	if gm.Subject != "" {
-		aq = "AND policies.object IN (SELECT object FROM policies WHERE subject = :subject AND :action=ANY(actions))"
+		aq = `AND policies.object IN (SELECT object FROM policies WHERE subject = :subject AND :action=ANY(actions)) OR g.owner_id = :subject`
 	}
 	q = fmt.Sprintf(`%s INNER JOIN policies ON g.id=policies.object %s AND policies.subject = :client_id %s 
 					ORDER BY g.updated_at LIMIT :limit OFFSET :offset;`, q, query, aq)

--- a/things/groups/service_test.go
+++ b/things/groups/service_test.go
@@ -637,10 +637,14 @@ func TestListMemberships(t *testing.T) {
 
 	var nGroups = uint64(100)
 	var aGroups = []mfgroups.Group{}
+	owner := testsutil.GenerateUUID(t, idProvider)
 	for i := uint64(1); i < nGroups; i++ {
 		group := mfgroups.Group{
 			Name:     fmt.Sprintf("membership_%d@example.com", i),
 			Metadata: mfclients.Metadata{"role": "group"},
+		}
+		if i%3 == 0 {
+			group.Owner = owner
 		}
 		aGroups = append(aGroups, group)
 	}
@@ -735,6 +739,27 @@ func TestListMemberships(t *testing.T) {
 				},
 			},
 			err: errors.ErrNotFound,
+		},
+		{
+			desc:     "list clients with an owner",
+			token:    token,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: mfgroups.GroupsPage{
+				Page: mfgroups.Page{
+					Offset:  0,
+					Total:   nGroups,
+					Limit:   nGroups,
+					Status:  mfclients.AllStatus,
+					Subject: owner,
+					Action:  "g_list",
+				},
+			},
+			response: mfgroups.MembershipsPage{
+				Page: mfgroups.Page{
+					Total: 4,
+				},
+				Memberships: []mfgroups.Group{aGroups[0], aGroups[3], aGroups[6], aGroups[9]},
+			},
 		},
 	}
 

--- a/users/clients/postgres/clients.go
+++ b/users/clients/postgres/clients.go
@@ -177,9 +177,9 @@ func (repo clientRepo) Members(ctx context.Context, groupID string, pm mfclients
 	}
 
 	aq := ""
-	// If not admin, the client needs to have a g_list action on the group
+	// If not admin, the client needs to have a g_list action on the group or they are the owner.
 	if pm.Subject != "" {
-		aq = `AND EXISTS (SELECT 1 FROM policies WHERE policies.subject = :subject AND :action=ANY(actions))`
+		aq = `AND EXISTS (SELECT 1 FROM policies WHERE policies.subject = :subject AND :action=ANY(actions)) OR c.owner_id = :subject`
 	}
 	q := fmt.Sprintf(`SELECT c.id, c.name, c.tags, c.metadata, c.identity, c.status,
 		c.created_at, c.updated_at FROM clients c

--- a/users/clients/service_test.go
+++ b/users/clients/service_test.go
@@ -1199,7 +1199,8 @@ func TestListMembers(t *testing.T) {
 
 	var nClients = uint64(10)
 	var aClients = []mfclients.Client{}
-	for i := uint64(1); i < nClients; i++ {
+	owner := testsutil.GenerateUUID(t, idProvider)
+	for i := uint64(0); i < nClients; i++ {
 		identity := fmt.Sprintf("member_%d@example.com", i)
 		client := mfclients.Client{
 			ID:   testsutil.GenerateUUID(t, idProvider),
@@ -1210,6 +1211,9 @@ func TestListMembers(t *testing.T) {
 			},
 			Tags:     []string{"tag1", "tag2"},
 			Metadata: mfclients.Metadata{"role": "client"},
+		}
+		if i%3 == 0 {
+			client.Owner = owner
 		}
 		aClients = append(aClients, client)
 	}
@@ -1293,6 +1297,22 @@ func TestListMembers(t *testing.T) {
 				},
 			},
 			err: errors.ErrNotFound,
+		},
+		{
+			desc:    "list clients for an owner",
+			token:   validToken,
+			groupID: testsutil.GenerateUUID(t, idProvider),
+			page: mfclients.Page{
+				Subject: owner,
+				Action:  "g_list",
+			},
+			response: mfclients.MembersPage{
+				Page: mfclients.Page{
+					Total: 4,
+				},
+				Members: []mfclients.Client{aClients[0], aClients[3], aClients[6], aClients[9]},
+			},
+			err: nil,
 		},
 	}
 

--- a/users/groups/postgres/groups.go
+++ b/users/groups/postgres/groups.go
@@ -153,9 +153,9 @@ func (repo groupRepository) Memberships(ctx context.Context, clientID string, gm
 		g.metadata, g.created_at, g.updated_at, g.updated_by, g.status FROM groups g`
 	}
 	aq := ""
-	// If not admin, the client needs to have a g_list action on the group
+	// If not admin, the client needs to have a g_list action on the group or they are the owner.
 	if gm.Subject != "" {
-		aq = `AND policies.object IN (SELECT object FROM policies WHERE subject = :subject AND :action=ANY(actions))`
+		aq = `AND policies.object IN (SELECT object FROM policies WHERE subject = :subject AND :action=ANY(actions)) OR g.owner_id = :subject`
 	}
 	q = fmt.Sprintf(`%s INNER JOIN policies ON g.id=policies.object %s AND policies.subject = :client_id %s
 			ORDER BY g.updated_at LIMIT :limit OFFSET :offset;`, q, query, aq)

--- a/users/groups/service_test.go
+++ b/users/groups/service_test.go
@@ -695,10 +695,14 @@ func TestListMemberships(t *testing.T) {
 
 	var nGroups = uint64(100)
 	var aGroups = []mfgroups.Group{}
+	owner := testsutil.GenerateUUID(t, idProvider)
 	for i := uint64(1); i < nGroups; i++ {
 		group := mfgroups.Group{
 			Name:     fmt.Sprintf("membership_%d@example.com", i),
 			Metadata: mfclients.Metadata{"role": "group"},
+		}
+		if i%3 == 0 {
+			group.Owner = owner
 		}
 		aGroups = append(aGroups, group)
 	}
@@ -791,6 +795,27 @@ func TestListMemberships(t *testing.T) {
 				},
 			},
 			err: errors.ErrNotFound,
+		},
+		{
+			desc:     "list clients with an owner",
+			token:    validToken,
+			clientID: testsutil.GenerateUUID(t, idProvider),
+			page: mfgroups.GroupsPage{
+				Page: mfgroups.Page{
+					Offset:  0,
+					Total:   nGroups,
+					Limit:   nGroups,
+					Status:  mfclients.AllStatus,
+					Subject: owner,
+					Action:  "g_list",
+				},
+			},
+			response: mfgroups.MembershipsPage{
+				Page: mfgroups.Page{
+					Total: 4,
+				},
+				Memberships: []mfgroups.Group{aGroups[0], aGroups[3], aGroups[6], aGroups[9]},
+			},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>
### What does this do?
When listing members of a certain group or memberships of a certain client to include ownership rights to. If I am the owner I am able to list the members or memberships
Adds prevention to SQL injection too

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
To be merged after https://github.com/mainflux/mainflux/pull/1818