### PR TITLE
NOISSUE - Invalidate Auth Cache When Adding Already Existing Thing Policy

### DIFF
--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -123,6 +123,11 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) (Polic
 
 		p.UpdatedAt = time.Now()
 		p.UpdatedBy = userID
+
+		if err := svc.policyCache.Remove(ctx, p); err != nil {
+			return Policy{}, err
+		}
+
 		return svc.policies.Update(ctx, p)
 	}
 


### PR DESCRIPTION
### What does this do?
Invalidates auth cache when adding a policy that already exists i.e updating the policy

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A