### PR TITLE
NOISSUE - Check For Subject During Policy Addition

### DIFF
--- a/bootstrap/mocks/policies.go
+++ b/bootstrap/mocks/policies.go
@@ -30,7 +30,7 @@ func NewPoliciesService(auth upolicies.AuthServiceClient) tpolicies.Service {
 	}
 }
 
-func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token, client string, p tpolicies.Policy) (tpolicies.Policy, error) {
+func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token string, external bool, p tpolicies.Policy) (tpolicies.Policy, error) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 

--- a/bootstrap/mocks/policies.go
+++ b/bootstrap/mocks/policies.go
@@ -30,7 +30,7 @@ func NewPoliciesService(auth upolicies.AuthServiceClient) tpolicies.Service {
 	}
 }
 
-func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token string, p tpolicies.Policy) (tpolicies.Policy, error) {
+func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token, client string, p tpolicies.Policy) (tpolicies.Policy, error) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 

--- a/certs/mocks/policies.go
+++ b/certs/mocks/policies.go
@@ -30,7 +30,7 @@ func NewPoliciesService(auth upolicies.AuthServiceClient) tpolicies.Service {
 	}
 }
 
-func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token, client string, p tpolicies.Policy) (tpolicies.Policy, error) {
+func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token string, external bool, p tpolicies.Policy) (tpolicies.Policy, error) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 

--- a/certs/mocks/policies.go
+++ b/certs/mocks/policies.go
@@ -30,7 +30,7 @@ func NewPoliciesService(auth upolicies.AuthServiceClient) tpolicies.Service {
 	}
 }
 
-func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token string, p tpolicies.Policy) (tpolicies.Policy, error) {
+func (svc *mainfluxPolicies) AddPolicy(ctx context.Context, token, client string, p tpolicies.Policy) (tpolicies.Policy, error) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 

--- a/certs/service_test.go
+++ b/certs/service_test.go
@@ -46,12 +46,14 @@ const (
 	instanceID        = "5de9b29a-feb9-11ed-be56-0242ac120002"
 )
 
+var adminRelationKeys = []string{"c_update", "c_list", "c_delete", "c_share"}
+
 func newService(tokens map[string]string) (certs.Service, error) {
 	ac := bsmocks.NewAuthClient(map[string]string{token: email})
 
 	server := newThingsServer(newThingsService(ac))
 
-	policies := []thmocks.MockSubjectSet{{Object: "token", Relation: clients.AdminRelationKey}}
+	policies := []thmocks.MockSubjectSet{{Object: "token", Relation: adminRelationKeys}}
 	auth := thmocks.NewAuthService(tokens, map[string][]thmocks.MockSubjectSet{token: policies})
 
 	config := mfsdk.Config{

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	adminToken   = "token"
-	userToken    = "userToken"
-	adminID      = generateUUID(&testing.T{})
-	userID       = generateUUID(&testing.T{})
-	users        = map[string]string{adminToken: adminID, userToken: userID}
-	uadminPolicy = cmocks.SubjectSet{Subject: adminID, Relation: clients.AdminRelationKey}
+	adminToken        = "token"
+	userToken         = "userToken"
+	adminID           = generateUUID(&testing.T{})
+	userID            = generateUUID(&testing.T{})
+	users             = map[string]string{adminToken: adminID, userToken: userID}
+	adminRelationKeys = []string{"c_update", "c_list", "c_delete", "c_share"}
+	uadminPolicy      = cmocks.SubjectSet{Subject: adminID, Relation: adminRelationKeys}
 )
 
 func newThingsServer(svc clients.Service, psvc policies.Service) *httptest.Server {

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -1416,14 +1416,6 @@ func TestShareThing(t *testing.T) {
 			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusForbidden),
 			repoErr:   errors.ErrAuthorization,
 		},
-		{
-			desc:      "share thing with invalid token for unauthorized user",
-			channelID: generateUUID(t),
-			thingID:   thingID,
-			token:     invalidToken,
-			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
-			repoErr:   errors.ErrAuthorization,
-		},
 	}
 
 	for _, tc := range cases {

--- a/readers/api/endpoint_test.go
+++ b/readers/api/endpoint_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mainflux/mainflux/readers"
 	"github.com/mainflux/mainflux/readers/api"
 	"github.com/mainflux/mainflux/readers/mocks"
-	"github.com/mainflux/mainflux/things/clients"
 	tpolicies "github.com/mainflux/mainflux/things/policies"
 	authmocks "github.com/mainflux/mainflux/users/clients/mocks"
 	upolicies "github.com/mainflux/mainflux/users/policies"
@@ -46,7 +45,8 @@ var (
 	vd          = "dataValue"
 	sum float64 = 42
 
-	idProvider = uuid.New()
+	idProvider        = uuid.New()
+	adminRelationKeys = []string{"c_update", "c_list", "c_delete", "c_share"}
 )
 
 func newServer(repo readers.MessageRepository, tc tpolicies.AuthServiceClient, ac upolicies.AuthServiceClient) *httptest.Server {
@@ -132,7 +132,7 @@ func TestReadAll(t *testing.T) {
 
 	thSvc := mocks.NewThingsService(map[string]string{email: chanID})
 	mockAuthzDB := map[string][]authmocks.SubjectSet{}
-	mockAuthzDB["token"] = append(mockAuthzDB[email], authmocks.SubjectSet{Subject: "token", Relation: clients.AdminRelationKey})
+	mockAuthzDB["token"] = append(mockAuthzDB[email], authmocks.SubjectSet{Subject: "token", Relation: adminRelationKeys})
 
 	usrSvc := authmocks.NewAuthService(map[string]string{userToken: email}, mockAuthzDB)
 

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	MyKey = "mine"
+	myKey = "mine"
 
 	thingsObjectKey = "things"
 
@@ -24,13 +24,9 @@ const (
 	updateRelationKey = "c_update"
 	listRelationKey   = "c_list"
 	deleteRelationKey = "c_delete"
-	shareRelationKey  = "c_share"
 
-	groupEntityType  = "group"
 	clientEntityType = "client"
 )
-
-var AdminRelationKey = []string{updateRelationKey, listRelationKey, deleteRelationKey, shareRelationKey}
 
 type service struct {
 	uauth       upolicies.AuthServiceClient
@@ -107,12 +103,12 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 	// If the user is admin, fetch all things from database.
 	case nil:
 		switch {
-		case pm.SharedBy == MyKey && pm.Owner == MyKey:
+		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = ""
 			pm.Owner = ""
-		case pm.SharedBy == MyKey && pm.Owner != MyKey:
+		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = userID
-		case pm.Owner == MyKey && pm.SharedBy != MyKey:
+		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = userID
 		}
 
@@ -121,12 +117,12 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 		// If user provides 'sharedby' key, fetch things from policies. Otherwise,
 		// fetch things from the database based on thing's 'owner' field.
 		switch {
-		case pm.SharedBy == MyKey && pm.Owner == MyKey:
+		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = userID
-		case pm.SharedBy == MyKey && pm.Owner != MyKey:
+		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = userID
 			pm.Owner = ""
-		case pm.Owner == MyKey && pm.SharedBy != MyKey:
+		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = userID
 		default:
 			pm.Owner = userID

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -21,10 +21,12 @@ const (
 	updateRelationKey = "c_update"
 	listRelationKey   = "c_list"
 	deleteRelationKey = "c_delete"
+	shareRelationKey  = "c_share"
+	groupEntityType   = "group"
 	clientEntityType  = "client"
 )
 
-var AdminRelationKey = []string{updateRelationKey, listRelationKey, deleteRelationKey}
+var AdminRelationKey = []string{updateRelationKey, listRelationKey, deleteRelationKey, shareRelationKey}
 
 type service struct {
 	uauth       upolicies.AuthServiceClient

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -16,14 +16,18 @@ import (
 )
 
 const (
-	MyKey             = "mine"
-	thingsObjectKey   = "things"
+	MyKey = "mine"
+
+	thingsObjectKey = "things"
+
+	addRelationKey    = "g_add"
 	updateRelationKey = "c_update"
 	listRelationKey   = "c_list"
 	deleteRelationKey = "c_delete"
 	shareRelationKey  = "c_share"
-	groupEntityType   = "group"
-	clientEntityType  = "client"
+
+	groupEntityType  = "group"
+	clientEntityType = "client"
 )
 
 var AdminRelationKey = []string{updateRelationKey, listRelationKey, deleteRelationKey, shareRelationKey}

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -37,14 +37,16 @@ var (
 		Metadata:    validCMetadata,
 		Status:      mfclients.EnabledStatus,
 	}
-	inValidToken   = "invalidToken"
-	withinDuration = 5 * time.Second
-	adminEmail     = "admin@example.com"
-	token          = "token"
+	inValidToken      = "invalidToken"
+	withinDuration    = 5 * time.Second
+	adminEmail        = "admin@example.com"
+	token             = "token"
+	myKey             = "mine"
+	adminRelationKeys = []string{"c_update", "c_list", "c_delete", "c_share"}
 )
 
 func newService(tokens map[string]string) (clients.Service, *mocks.Repository, *pmocks.Repository) {
-	adminPolicy := mocks.MockSubjectSet{Object: ID, Relation: clients.AdminRelationKey}
+	adminPolicy := mocks.MockSubjectSet{Object: ID, Relation: adminRelationKeys}
 	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	thingCache := mocks.NewCache()
 	policiesCache := pmocks.NewCache()
@@ -385,7 +387,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Status:   mfclients.EnabledStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -404,7 +406,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Name:     "TestListClients3",
 				Status:   mfclients.EnabledStatus,
 			},
@@ -424,7 +426,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Name:     "notpresentclient",
 				Status:   mfclients.EnabledStatus,
 			},
@@ -444,7 +446,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Status: mfclients.EnabledStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -463,7 +465,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Name:   "TestListClients3",
 				Status: mfclients.AllStatus,
 			},
@@ -483,7 +485,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Name:   "notpresentclient",
 				Status: mfclients.AllStatus,
 			},
@@ -503,8 +505,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				Owner:    clients.MyKey,
-				SharedBy: clients.MyKey,
+				Owner:    myKey,
+				SharedBy: myKey,
 				Status:   mfclients.AllStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -523,8 +525,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
-				Owner:    clients.MyKey,
+				SharedBy: myKey,
+				Owner:    myKey,
 				Name:     "TestListClients3",
 				Status:   mfclients.AllStatus,
 			},
@@ -544,8 +546,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
-				Owner:    clients.MyKey,
+				SharedBy: myKey,
+				Owner:    myKey,
 				Name:     "notpresentclient",
 				Status:   mfclients.AllStatus,
 			},

--- a/things/groups/service.go
+++ b/things/groups/service.go
@@ -17,11 +17,13 @@ import (
 )
 
 const (
-	thingsObjectKey   = "things"
+	thingsObjectKey = "things"
+
 	updateRelationKey = "g_update"
 	listRelationKey   = "g_list"
 	deleteRelationKey = "g_delete"
-	entityType        = "group"
+
+	entityType = "group"
 )
 
 type service struct {

--- a/things/policies/api/http/endpoints.go
+++ b/things/policies/api/http/endpoints.go
@@ -63,7 +63,7 @@ func connectEndpoint(svc policies.Service) endpoint.Endpoint {
 			Object:  cr.Object,
 			Actions: cr.Actions,
 		}
-		policy, err := svc.AddPolicy(ctx, cr.token, policy)
+		policy, err := svc.AddPolicy(ctx, cr.token, policies.ThingClient, policy)
 		if err != nil {
 			return nil, err
 		}
@@ -90,10 +90,11 @@ func connectThingsEndpoint(svc policies.Service) endpoint.Endpoint {
 					Object:  cid,
 					Actions: cr.Actions,
 				}
-				p, err := svc.AddPolicy(ctx, cr.token, policy)
+				p, err := svc.AddPolicy(ctx, cr.token, policies.ThingClient, policy)
 				if err != nil {
 					return listPolicyRes{}, err
 				}
+
 				pols.Policies = append(pols.Policies, p)
 			}
 		}

--- a/things/policies/api/http/endpoints.go
+++ b/things/policies/api/http/endpoints.go
@@ -63,7 +63,7 @@ func connectEndpoint(svc policies.Service) endpoint.Endpoint {
 			Object:  cr.Object,
 			Actions: cr.Actions,
 		}
-		policy, err := svc.AddPolicy(ctx, cr.token, policies.ThingClient, policy)
+		policy, err := svc.AddPolicy(ctx, cr.token, cr.External, policy)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func connectThingsEndpoint(svc policies.Service) endpoint.Endpoint {
 					Object:  cid,
 					Actions: cr.Actions,
 				}
-				p, err := svc.AddPolicy(ctx, cr.token, policies.ThingClient, policy)
+				p, err := svc.AddPolicy(ctx, cr.token, cr.External, policy)
 				if err != nil {
 					return listPolicyRes{}, err
 				}

--- a/things/policies/api/http/requests.go
+++ b/things/policies/api/http/requests.go
@@ -9,10 +9,12 @@ import (
 )
 
 type createPolicyReq struct {
-	token   string
-	Subject string   `json:"subject,omitempty"`
-	Object  string   `json:"object,omitempty"`
-	Actions []string `json:"actions,omitempty"`
+	token    string
+	Owner    string   `json:"owner,omitempty"`
+	Subject  string   `json:"subject,omitempty"`
+	Object   string   `json:"object,omitempty"`
+	Actions  []string `json:"actions,omitempty"`
+	External bool     `json:"external,omitempty"`
 }
 
 func (req createPolicyReq) validate() error {
@@ -27,9 +29,11 @@ func (req createPolicyReq) validate() error {
 
 type createPoliciesReq struct {
 	token    string
+	Owner    string   `json:"owner,omitempty"`
 	Subjects []string `json:"subjects,omitempty"`
 	Objects  []string `json:"objects,omitempty"`
 	Actions  []string `json:"actions,omitempty"`
+	External bool     `json:"external,omitempty"`
 }
 
 func (req createPoliciesReq) validate() error {

--- a/things/policies/api/logging.go
+++ b/things/policies/api/logging.go
@@ -36,16 +36,16 @@ func (lm *loggingMiddleware) Authorize(ctx context.Context, ar policies.AccessRe
 	return lm.svc.Authorize(ctx, ar)
 }
 
-func (lm *loggingMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policy policies.Policy, err error) {
+func (lm *loggingMiddleware) AddPolicy(ctx context.Context, token string, external bool, p policies.Policy) (policy policies.Policy, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method add_policy for %s with id %s using token %s took %s to complete", client, p.Subject, token, time.Since(begin))
+		message := fmt.Sprintf("Method add_policy for client with id %s using token %s took %s to complete", p.Subject, token, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
 		}
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
-	return lm.svc.AddPolicy(ctx, token, client, p)
+	return lm.svc.AddPolicy(ctx, token, external, p)
 }
 
 func (lm *loggingMiddleware) UpdatePolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {

--- a/things/policies/api/logging.go
+++ b/things/policies/api/logging.go
@@ -36,16 +36,16 @@ func (lm *loggingMiddleware) Authorize(ctx context.Context, ar policies.AccessRe
 	return lm.svc.Authorize(ctx, ar)
 }
 
-func (lm *loggingMiddleware) AddPolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {
+func (lm *loggingMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policy policies.Policy, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method add_policy for client with id %s using token %s took %s to complete", p.Subject, token, time.Since(begin))
+		message := fmt.Sprintf("Method add_policy for %s with id %s using token %s took %s to complete", client, p.Subject, token, time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
 		}
 		lm.logger.Info(fmt.Sprintf("%s without errors.", message))
 	}(time.Now())
-	return lm.svc.AddPolicy(ctx, token, p)
+	return lm.svc.AddPolicy(ctx, token, client, p)
 }
 
 func (lm *loggingMiddleware) UpdatePolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {

--- a/things/policies/api/metrics.go
+++ b/things/policies/api/metrics.go
@@ -28,12 +28,12 @@ func MetricsMiddleware(svc policies.Service, counter metrics.Counter, latency me
 	}
 }
 
-func (ms *metricsMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policy policies.Policy, err error) {
+func (ms *metricsMiddleware) AddPolicy(ctx context.Context, token string, external bool, p policies.Policy) (policy policies.Policy, err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "add_policy").Add(1)
 		ms.latency.With("method", "add_policy").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return ms.svc.AddPolicy(ctx, token, client, p)
+	return ms.svc.AddPolicy(ctx, token, external, p)
 }
 
 func (ms *metricsMiddleware) UpdatePolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {

--- a/things/policies/api/metrics.go
+++ b/things/policies/api/metrics.go
@@ -28,12 +28,12 @@ func MetricsMiddleware(svc policies.Service, counter metrics.Counter, latency me
 	}
 }
 
-func (ms *metricsMiddleware) AddPolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {
+func (ms *metricsMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policy policies.Policy, err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "add_policy").Add(1)
 		ms.latency.With("method", "add_policy").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return ms.svc.AddPolicy(ctx, token, p)
+	return ms.svc.AddPolicy(ctx, token, client, p)
 }
 
 func (ms *metricsMiddleware) UpdatePolicy(ctx context.Context, token string, p policies.Policy) (policy policies.Policy, err error) {

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -81,7 +81,8 @@ type Service interface {
 	// AddPolicy creates a policy for the given subject, so that, after
 	// AddPolicy, `subject` has a `relation` on `object`. Returns a non-nil
 	// error in case of failures.
-	AddPolicy(ctx context.Context, token string, p Policy) (Policy, error)
+	// The client can be a thing or a user.
+	AddPolicy(ctx context.Context, token, client string, p Policy) (Policy, error)
 
 	// DeletePolicy removes a policy.
 	DeletePolicy(ctx context.Context, token string, p Policy) error

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -81,8 +81,9 @@ type Service interface {
 	// AddPolicy creates a policy for the given subject, so that, after
 	// AddPolicy, `subject` has a `relation` on `object`. Returns a non-nil
 	// error in case of failures.
-	// The client can be a thing or a user.
-	AddPolicy(ctx context.Context, token, client string, p Policy) (Policy, error)
+	// External is used to check if the policy subject is from external source i.e
+	// if it is true then the subject is `userID` else it is `thingID`.
+	AddPolicy(ctx context.Context, token string, external bool, p Policy) (Policy, error)
 
 	// DeletePolicy removes a policy.
 	DeletePolicy(ctx context.Context, token string, p Policy) error

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -54,8 +54,8 @@ func (es *eventStore) Authorize(ctx context.Context, ar policies.AccessRequest) 
 	return policy, nil
 }
 
-func (es *eventStore) AddPolicy(ctx context.Context, token string, policy policies.Policy) (policies.Policy, error) {
-	policy, err := es.svc.AddPolicy(ctx, token, policy)
+func (es eventStore) AddPolicy(ctx context.Context, token, client string, policy policies.Policy) (policies.Policy, error) {
+	policy, err := es.svc.AddPolicy(ctx, token, client, policy)
 	if err != nil {
 		return policy, err
 	}

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -54,8 +54,8 @@ func (es *eventStore) Authorize(ctx context.Context, ar policies.AccessRequest) 
 	return policy, nil
 }
 
-func (es eventStore) AddPolicy(ctx context.Context, token, client string, policy policies.Policy) (policies.Policy, error) {
-	policy, err := es.svc.AddPolicy(ctx, token, client, policy)
+func (es eventStore) AddPolicy(ctx context.Context, token string, external bool, policy policies.Policy) (policies.Policy, error) {
+	policy, err := es.svc.AddPolicy(ctx, token, external, policy)
 	if err != nil {
 		return policy, err
 	}

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -13,14 +13,21 @@ import (
 )
 
 const (
-	ReadAction        = "m_read"
-	WriteAction       = "m_write"
-	addPolicyAction   = "g_add"
+	// messaging policy actions.
+	ReadAction  = "m_read"
+	WriteAction = "m_write"
+
+	// add policy actions to check if the client is admin.
+	addPolicyAction = "g_add"
+
 	sharePolicyAction = "c_share"
-	ClientEntityType  = "client"
-	GroupEntityType   = "group"
-	ThingEntityType   = "thing"
-	thingsObjectKey   = "things"
+
+	// entity types.
+	ClientEntityType = "client"
+	GroupEntityType  = "group"
+	ThingEntityType  = "thing"
+
+	thingsObjectKey = "things"
 )
 
 var (

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -26,6 +26,9 @@ const (
 var (
 	// ErrInvalidEntityType indicates that the entity type is invalid.
 	ErrInvalidEntityType = errors.New("invalid entity type")
+
+	// ErrInvalidClient indicates that the client is invalid.
+	ErrInvalidClient = errors.New("invalid client")
 )
 
 type service struct {
@@ -173,7 +176,7 @@ func (svc service) checkSubject(ctx context.Context, userID string, external boo
 
 		return errors.ErrAuthorization
 	default:
-		return errors.New("invalid client")
+		return ErrInvalidClient
 	}
 }
 

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -115,6 +115,9 @@ func (svc service) AddPolicy(ctx context.Context, token string, external bool, p
 	if err := p.validate(); err != nil {
 		return Policy{}, err
 	}
+	if external {
+		p.Actions = upolicies.AddListAction(p.Actions)
+	}
 
 	p.OwnerID = userID
 	p.CreatedAt = time.Now()

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -30,13 +30,8 @@ const (
 	thingsObjectKey = "things"
 )
 
-var (
-	// ErrInvalidEntityType indicates that the entity type is invalid.
-	ErrInvalidEntityType = errors.New("invalid entity type")
-
-	// ErrInvalidClient indicates that the client is invalid.
-	ErrInvalidClient = errors.New("invalid client")
-)
+// ErrInvalidEntityType indicates that the entity type is invalid.
+var ErrInvalidEntityType = errors.New("invalid entity type")
 
 type service struct {
 	auth        upolicies.AuthServiceClient
@@ -174,17 +169,13 @@ func (svc service) checkSubject(ctx context.Context, userID string, external boo
 		if _, err := svc.policies.EvaluateThingAccess(ctx, ar); err != nil {
 			return err
 		}
-
-		return nil
 	case true:
 		if err := svc.usersAuthorize(ctx, userID, p.Subject, sharePolicyAction, ClientEntityType); err != nil {
 			return err
 		}
-
-		return nil
-	default:
-		return ErrInvalidClient
 	}
+
+	return nil
 }
 
 func (svc service) UpdatePolicy(ctx context.Context, token string, p Policy) (Policy, error) {

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -13,16 +13,16 @@ import (
 )
 
 const (
-	// messaging policy actions.
+	// Messaging policy actions.
 	ReadAction  = "m_read"
 	WriteAction = "m_write"
 
-	// add policy actions to check if the client is admin.
+	// Add policy actions to check if the client is admin.
 	addPolicyAction = "g_add"
 
 	sharePolicyAction = "c_share"
 
-	// entity types.
+	// Entity types.
 	ClientEntityType = "client"
 	GroupEntityType  = "group"
 	ThingEntityType  = "thing"
@@ -51,7 +51,7 @@ func NewService(auth upolicies.AuthServiceClient, p Repository, ccache Cache, id
 }
 
 func (svc service) Authorize(ctx context.Context, ar AccessRequest) (Policy, error) {
-	// fetch from cache first
+	// Fetch from cache first.
 	policy := Policy{
 		Subject: ar.Subject,
 		Object:  ar.Object,
@@ -69,7 +69,7 @@ func (svc service) Authorize(ctx context.Context, ar AccessRequest) (Policy, err
 		return Policy{}, err
 	}
 
-	// fetch from repo as a fallback if not found in cache
+	// Fetch from repo as a fallback if not found in cache.
 	switch ar.Entity {
 	case GroupEntityType:
 		policy, err = svc.policies.EvaluateGroupAccess(ctx, ar)
@@ -122,7 +122,7 @@ func (svc service) AddPolicy(ctx context.Context, token string, external bool, p
 	p.OwnerID = userID
 	p.CreatedAt = time.Now()
 
-	// incase the policy exists, use these for update.
+	// Incase the policy exists, use these for update.
 	p.UpdatedAt = time.Now()
 	p.UpdatedBy = userID
 
@@ -211,12 +211,12 @@ func (svc service) ListPolicies(ctx context.Context, token string, pm Page) (Pol
 	if err := pm.Validate(); err != nil {
 		return PolicyPage{}, err
 	}
-	// If the user is admin, return all policies
+	// If the user is admin, return all policies.
 	if err := svc.checkAdmin(ctx, userID); err == nil {
 		return svc.policies.Retrieve(ctx, pm)
 	}
 
-	// If the user is not admin, return only the policies that they created
+	// If the user is not admin, return only the policies that they created.
 	pm.OwnerID = userID
 
 	return svc.policies.Retrieve(ctx, pm)
@@ -268,7 +268,7 @@ func (svc service) identify(ctx context.Context, token string) (string, error) {
 }
 
 func (svc service) checkAdmin(ctx context.Context, id string) error {
-	// for checking admin rights policy object, action and entity type are not important
+	// For checking admin rights policy object, action and entity type are not important.
 	return svc.usersAuthorize(ctx, id, thingsObjectKey, addPolicyAction, GroupEntityType)
 }
 

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -171,17 +171,17 @@ func (svc service) checkSubject(ctx context.Context, userID string, external boo
 	switch external {
 	case false:
 		ar := AccessRequest{Subject: userID, Object: p.Subject, Action: sharePolicyAction}
-		if _, err := svc.policies.EvaluateThingAccess(ctx, ar); err == nil {
-			return nil
+		if _, err := svc.policies.EvaluateThingAccess(ctx, ar); err != nil {
+			return err
 		}
 
-		return errors.ErrAuthorization
+		return nil
 	case true:
-		if err := svc.usersAuthorize(ctx, userID, p.Subject, sharePolicyAction, ClientEntityType); err == nil {
-			return nil
+		if err := svc.usersAuthorize(ctx, userID, p.Subject, sharePolicyAction, ClientEntityType); err != nil {
+			return err
 		}
 
-		return errors.ErrAuthorization
+		return nil
 	default:
 		return ErrInvalidClient
 	}

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -166,16 +166,13 @@ func (svc service) AddPolicy(ctx context.Context, token string, external bool, p
 //   - The user is the owner of the user
 //   - The user has `c_share` action on the user
 func (svc service) checkSubject(ctx context.Context, userID string, external bool, p Policy) error {
-	switch external {
-	case false:
-		ar := AccessRequest{Subject: userID, Object: p.Subject, Action: sharePolicyAction}
-		if _, err := svc.policies.EvaluateThingAccess(ctx, ar); err != nil {
-			return err
-		}
-	case true:
-		if err := svc.usersAuthorize(ctx, userID, p.Subject, sharePolicyAction, ClientEntityType); err != nil {
-			return err
-		}
+	if external {
+		return svc.usersAuthorize(ctx, userID, p.Subject, sharePolicyAction, ClientEntityType)
+	}
+
+	ar := AccessRequest{Subject: userID, Object: p.Subject, Action: sharePolicyAction}
+	if _, err := svc.policies.EvaluateThingAccess(ctx, ar); err != nil {
+		return err
 	}
 
 	return nil

--- a/things/policies/service_test.go
+++ b/things/policies/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mainflux/mainflux/internal/testsutil"
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/mainflux/mainflux/pkg/uuid"
-	"github.com/mainflux/mainflux/things/clients"
 	"github.com/mainflux/mainflux/things/clients/mocks"
 	"github.com/mainflux/mainflux/things/policies"
 	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
@@ -23,15 +22,16 @@ import (
 )
 
 var (
-	idProvider    = uuid.New()
-	inValidToken  = "invalidToken"
-	memberActions = []string{"g_list"}
-	adminEmail    = "admin@example.com"
-	token         = "token"
+	idProvider        = uuid.New()
+	inValidToken      = "invalidToken"
+	memberActions     = []string{"g_list"}
+	adminEmail        = "admin@example.com"
+	token             = "token"
+	adminRelationKeys = []string{"c_update", "c_list", "c_delete", "c_share"}
 )
 
 func newService(tokens map[string]string) (policies.Service, *pmocks.Repository, *umocks.Repository) {
-	adminPolicy := mocks.MockSubjectSet{Object: "things", Relation: clients.AdminRelationKey}
+	adminPolicy := mocks.MockSubjectSet{Object: "things", Relation: adminRelationKeys}
 	auth := mocks.NewAuthService(tokens, map[string][]mocks.MockSubjectSet{adminEmail: {adminPolicy}})
 	idProvider := uuid.NewMock()
 	policiesCache := pmocks.NewCache()

--- a/things/policies/service_test.go
+++ b/things/policies/service_test.go
@@ -122,7 +122,7 @@ func TestAddPolicy(t *testing.T) {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, tc.err)
 		repoCall1 := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, tc.err)
 		repoCall2 := pRepo.On("Save", context.Background(), mock.Anything).Return(tc.policy, tc.err)
-		_, err := svc.AddPolicy(context.Background(), tc.token, tc.policy)
+		_, err := svc.AddPolicy(context.Background(), tc.token, policies.ThingClient, tc.policy)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		if err == nil {
 			tc.policy.Subject = tc.token

--- a/things/policies/service_test.go
+++ b/things/policies/service_test.go
@@ -122,7 +122,7 @@ func TestAddPolicy(t *testing.T) {
 		repoCall := pRepo.On("EvaluateGroupAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, tc.err)
 		repoCall1 := pRepo.On("EvaluateThingAccess", mock.Anything, mock.Anything).Return(policies.Policy{}, tc.err)
 		repoCall2 := pRepo.On("Save", context.Background(), mock.Anything).Return(tc.policy, tc.err)
-		_, err := svc.AddPolicy(context.Background(), tc.token, policies.ThingClient, tc.policy)
+		_, err := svc.AddPolicy(context.Background(), tc.token, false, tc.policy)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		if err == nil {
 			tc.policy.Subject = tc.token

--- a/things/policies/tracing/tracing.go
+++ b/things/policies/tracing/tracing.go
@@ -37,16 +37,16 @@ func (tm *tracingMiddleware) Authorize(ctx context.Context, ar policies.AccessRe
 }
 
 // AddPolicy traces the "AddPolicy" operation of the wrapped policies.Service.
-func (tm *tracingMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policies.Policy, error) {
+func (tm *tracingMiddleware) AddPolicy(ctx context.Context, token string, external bool, p policies.Policy) (policies.Policy, error) {
 	ctx, span := tm.tracer.Start(ctx, "svc_connect", trace.WithAttributes(
-		attribute.String("client", client),
+		attribute.Bool("is_external", external),
 		attribute.String("subject", p.Subject),
 		attribute.String("object", p.Object),
 		attribute.StringSlice("actions", p.Actions),
 	))
 	defer span.End()
 
-	return tm.psvc.AddPolicy(ctx, token, client, p)
+	return tm.psvc.AddPolicy(ctx, token, external, p)
 }
 
 // UpdatePolicy traces the "UpdatePolicy" operation of the wrapped policies.Service.

--- a/things/policies/tracing/tracing.go
+++ b/things/policies/tracing/tracing.go
@@ -37,15 +37,16 @@ func (tm *tracingMiddleware) Authorize(ctx context.Context, ar policies.AccessRe
 }
 
 // AddPolicy traces the "AddPolicy" operation of the wrapped policies.Service.
-func (tm *tracingMiddleware) AddPolicy(ctx context.Context, token string, p policies.Policy) (policies.Policy, error) {
+func (tm *tracingMiddleware) AddPolicy(ctx context.Context, token, client string, p policies.Policy) (policies.Policy, error) {
 	ctx, span := tm.tracer.Start(ctx, "svc_connect", trace.WithAttributes(
+		attribute.String("client", client),
 		attribute.String("subject", p.Subject),
 		attribute.String("object", p.Object),
 		attribute.StringSlice("actions", p.Actions),
 	))
 	defer span.End()
 
-	return tm.psvc.AddPolicy(ctx, token, p)
+	return tm.psvc.AddPolicy(ctx, token, client, p)
 }
 
 // UpdatePolicy traces the "UpdatePolicy" operation of the wrapped policies.Service.

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -17,12 +17,15 @@ import (
 )
 
 const (
-	MyKey             = "mine"
-	clientsObjectKey  = "clients"
+	MyKey = "mine"
+
+	clientsObjectKey = "clients"
+
 	updateRelationKey = "c_update"
 	listRelationKey   = "c_list"
 	deleteRelationKey = "c_delete"
-	entityType        = "client"
+
+	entityType = "client"
 )
 
 var (

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	MyKey = "mine"
+	myKey = "mine"
 
 	clientsObjectKey = "clients"
 
@@ -170,24 +170,24 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 	// If the user is admin, fetch all users from database.
 	case nil:
 		switch {
-		case pm.SharedBy == MyKey && pm.Owner == MyKey:
+		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = ""
 			pm.Owner = ""
-		case pm.SharedBy == MyKey && pm.Owner != MyKey:
+		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = id
-		case pm.Owner == MyKey && pm.SharedBy != MyKey:
+		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = id
 		}
 
 	// If the user is not admin, fetch users that they own or are shared with them.
 	default:
 		switch {
-		case pm.SharedBy == MyKey && pm.Owner == MyKey:
+		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = id
-		case pm.SharedBy == MyKey && pm.Owner != MyKey:
+		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = id
 			pm.Owner = ""
-		case pm.Owner == MyKey && pm.SharedBy != MyKey:
+		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = id
 		default:
 			pm.Owner = id

--- a/users/clients/service_test.go
+++ b/users/clients/service_test.go
@@ -43,6 +43,7 @@ var (
 	passRegex       = regexp.MustCompile("^.{8,}$")
 	accessDuration  = time.Minute * 1
 	refreshDuration = time.Minute * 10
+	myKey = "mine"
 )
 
 func TestRegisterClient(t *testing.T) {
@@ -395,7 +396,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Status:   mfclients.EnabledStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -414,7 +415,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Name:     "TestListClients3",
 				Status:   mfclients.EnabledStatus,
 			},
@@ -434,7 +435,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
+				SharedBy: myKey,
 				Name:     "notpresentclient",
 				Status:   mfclients.EnabledStatus,
 			},
@@ -454,7 +455,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Status: mfclients.EnabledStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -473,7 +474,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Name:   "TestListClients3",
 				Status: mfclients.AllStatus,
 			},
@@ -493,7 +494,7 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset: 6,
 				Limit:  nClients,
-				Owner:  clients.MyKey,
+				Owner:  myKey,
 				Name:   "notpresentclient",
 				Status: mfclients.AllStatus,
 			},
@@ -513,8 +514,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				Owner:    clients.MyKey,
-				SharedBy: clients.MyKey,
+				Owner:    myKey,
+				SharedBy: myKey,
 				Status:   mfclients.AllStatus,
 			},
 			response: mfclients.ClientsPage{
@@ -533,8 +534,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
-				Owner:    clients.MyKey,
+				SharedBy: myKey,
+				Owner:    myKey,
 				Name:     "TestListClients3",
 				Status:   mfclients.AllStatus,
 			},
@@ -554,8 +555,8 @@ func TestListClients(t *testing.T) {
 			page: mfclients.Page{
 				Offset:   6,
 				Limit:    nClients,
-				SharedBy: clients.MyKey,
-				Owner:    clients.MyKey,
+				SharedBy: myKey,
+				Owner:    myKey,
 				Name:     "notpresentclient",
 				Status:   mfclients.AllStatus,
 			},

--- a/users/groups/service.go
+++ b/users/groups/service.go
@@ -18,10 +18,13 @@ import (
 
 // Possible token types are access and refresh tokens.
 const (
-	RefreshToken      = "refresh"
-	AccessToken       = "access"
-	MyKey             = "mine"
-	groupsObjectKey   = "groups"
+	RefreshToken = "refresh"
+	AccessToken  = "access"
+
+	MyKey = "mine"
+
+	groupsObjectKey = "groups"
+
 	updateRelationKey = "g_update"
 	listRelationKey   = "g_list"
 	deleteRelationKey = "g_delete"

--- a/users/policies/policies.go
+++ b/users/policies/policies.go
@@ -30,7 +30,10 @@ import (
 // Message policies
 //  9. m_write - write a message
 //  10. m_read - read a message
-var PolicyTypes = []string{"g_add", "g_delete", "g_update", "g_list", "c_delete", "c_update", "c_list", "m_write", "m_read"}
+//
+// Sharing policies
+//  11. c_share - share a client
+var PolicyTypes = []string{"g_add", "g_delete", "g_update", "g_list", "c_delete", "c_update", "c_list", "m_write", "m_read", "c_share"}
 
 // Policy represents an argument struct for making a policy related function calls.
 type Policy struct {

--- a/users/policies/policies.go
+++ b/users/policies/policies.go
@@ -167,12 +167,12 @@ func ValidateAction(act string) bool {
 
 }
 
-// addListAction adds list actions to the actions slice if c_ or g_ actions are present.
+// AddListAction adds list actions to the actions slice if c_ or g_ actions are present.
 //
 // 1. If c_<anything> actions are present, add c_list and g_list actions to the actions slice.
 //
 // 2. If g_<anything> actions are present, add g_list action to the actions slice.
-func addListAction(actions []string) []string {
+func AddListAction(actions []string) []string {
 	hasCAction := false
 	hasGAction := false
 

--- a/users/policies/policies.go
+++ b/users/policies/policies.go
@@ -32,7 +32,7 @@ import (
 //  10. m_read - read a message
 //
 // Sharing policies
-//  11. c_share - share a client
+//  11. c_share - share a client - allows a user to add another user to a group.
 var PolicyTypes = []string{"g_add", "g_delete", "g_update", "g_list", "c_delete", "c_update", "c_list", "m_write", "m_read", "c_share"}
 
 // Policy represents an argument struct for making a policy related function calls.

--- a/users/policies/postgres/policies_test.go
+++ b/users/policies/postgres/policies_test.go
@@ -328,7 +328,7 @@ func TestPoliciesUpdate(t *testing.T) {
 				OwnerID: policy.OwnerID,
 				Subject: client.ID,
 				Object:  group.ID,
-				Actions: []string{"c_update"},
+				Actions: []string{""},
 			},
 			err: nil,
 		},

--- a/users/policies/postgres/policies_test.go
+++ b/users/policies/postgres/policies_test.go
@@ -29,11 +29,17 @@ func TestPoliciesSave(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	repo := ppostgres.NewRepository(database)
 	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
 
-	uid := testsutil.GenerateUUID(t, idProvider)
+	group := mfgroups.Group{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "policy-save",
+	}
+	group, err := grepo.Save(context.Background(), group)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	client := mfclients.Client{
-		ID:   uid,
+		ID:   testsutil.GenerateUUID(t, idProvider),
 		Name: "policy-save@example.com",
 		Credentials: mfclients.Credentials{
 			Identity: "policy-save@example.com",
@@ -46,8 +52,6 @@ func TestPoliciesSave(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	client = clients[0]
 
-	uid = testsutil.GenerateUUID(t, idProvider)
-
 	cases := []struct {
 		desc   string
 		policy policies.Policy
@@ -58,7 +62,7 @@ func TestPoliciesSave(t *testing.T) {
 			policy: policies.Policy{
 				OwnerID: client.ID,
 				Subject: client.ID,
-				Object:  uid,
+				Object:  group.ID,
 				Actions: []string{"c_delete"},
 			},
 			err: nil,
@@ -68,7 +72,7 @@ func TestPoliciesSave(t *testing.T) {
 			policy: policies.Policy{
 				OwnerID: client.ID,
 				Subject: client.ID,
-				Object:  uid,
+				Object:  group.ID,
 				Actions: []string{"c_delete"},
 			},
 			err: nil,
@@ -174,11 +178,17 @@ func TestPoliciesRetrieve(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	repo := ppostgres.NewRepository(database)
 	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
 
-	uid := testsutil.GenerateUUID(t, idProvider)
+	group := mfgroups.Group{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "policy-save",
+	}
+	group, err := grepo.Save(context.Background(), group)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	client := mfclients.Client{
-		ID:   uid,
+		ID:   testsutil.GenerateUUID(t, idProvider),
 		Name: "single-policy-retrieval@example.com",
 		Credentials: mfclients.Credentials{
 			Identity: "single-policy-retrieval@example.com",
@@ -191,13 +201,10 @@ func TestPoliciesRetrieve(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	client = clients[0]
 
-	uid, err = idProvider.ID()
-	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-
 	policy := policies.Policy{
 		OwnerID: client.ID,
 		Subject: client.ID,
-		Object:  uid,
+		Object:  group.ID,
 		Actions: []string{"c_delete"},
 	}
 
@@ -209,7 +216,7 @@ func TestPoliciesRetrieve(t *testing.T) {
 		Object  string
 		err     error
 	}{
-		"retrieve existing policy":     {uid, uid, nil},
+		"retrieve existing policy":     {client.ID, group.ID, nil},
 		"retrieve non-existing policy": {"unknown", "unknown", nil},
 	}
 
@@ -227,12 +234,17 @@ func TestPoliciesUpdate(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	repo := ppostgres.NewRepository(database)
 	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
 
-	cid := testsutil.GenerateUUID(t, idProvider)
-	pid := testsutil.GenerateUUID(t, idProvider)
+	group := mfgroups.Group{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "policy-save",
+	}
+	group, err := grepo.Save(context.Background(), group)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	client := mfclients.Client{
-		ID:   cid,
+		ID:   testsutil.GenerateUUID(t, idProvider),
 		Name: "policy-update@example.com",
 		Credentials: mfclients.Credentials{
 			Identity: "policy-update@example.com",
@@ -241,13 +253,13 @@ func TestPoliciesUpdate(t *testing.T) {
 		Status: mfclients.EnabledStatus,
 	}
 
-	_, err := crepo.Save(context.Background(), client)
+	_, err = crepo.Save(context.Background(), client)
 	require.Nil(t, err, fmt.Sprintf("unexpected error during saving client: %s", err))
 
 	policy := policies.Policy{
-		OwnerID: cid,
-		Subject: cid,
-		Object:  pid,
+		OwnerID: testsutil.GenerateUUID(t, idProvider),
+		Subject: client.ID,
+		Object:  group.ID,
 		Actions: []string{"c_delete"},
 	}
 	err = repo.Save(context.Background(), policy)
@@ -262,64 +274,45 @@ func TestPoliciesUpdate(t *testing.T) {
 		{
 			desc: "update policy successfully",
 			policy: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
+				Subject: client.ID,
+				Object:  group.ID,
 				Actions: []string{"c_update"},
 			},
 			resp: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
+				OwnerID: policy.OwnerID,
+				Subject: client.ID,
+				Object:  group.ID,
 				Actions: []string{"c_update"},
-			},
-			err: nil,
-		},
-		{
-			desc: "update policy with missing owner id",
-			policy: policies.Policy{
-				OwnerID: "",
-				Subject: cid,
-				Object:  pid,
-				Actions: []string{"c_delete"},
-			},
-			resp: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
-				Actions: []string{"c_delete"},
 			},
 			err: nil,
 		},
 		{
 			desc: "update policy with missing subject",
 			policy: policies.Policy{
-				OwnerID: cid,
 				Subject: "",
-				Object:  pid,
+				Object:  group.ID,
 				Actions: []string{"c_add"},
 			},
 			resp: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
-				Actions: []string{"c_delete"},
+				OwnerID: policy.OwnerID,
+				Subject: client.ID,
+				Object:  group.ID,
+				Actions: []string{"c_update"},
 			},
 			err: nil,
 		},
 		{
 			desc: "update policy with missing object",
 			policy: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
+				Subject: client.ID,
 				Object:  "",
 				Actions: []string{"c_add"},
 			},
 			resp: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
-				Actions: []string{"c_delete"},
+				OwnerID: policy.OwnerID,
+				Subject: client.ID,
+				Object:  group.ID,
+				Actions: []string{"c_update"},
 			},
 
 			err: nil,
@@ -327,16 +320,15 @@ func TestPoliciesUpdate(t *testing.T) {
 		{
 			desc: "update policy with missing action",
 			policy: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
+				Subject: client.ID,
+				Object:  group.ID,
 				Actions: []string{""},
 			},
 			resp: policies.Policy{
-				OwnerID: cid,
-				Subject: cid,
-				Object:  pid,
-				Actions: []string{""},
+				OwnerID: policy.OwnerID,
+				Subject: client.ID,
+				Object:  group.ID,
+				Actions: []string{"c_update"},
 			},
 			err: nil,
 		},
@@ -360,6 +352,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	repo := ppostgres.NewRepository(database)
 	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
 
 	var nPolicies = uint64(10)
 
@@ -389,21 +382,30 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	clientB = clientsB[0]
 
+	grps := []string{}
 	for i := uint64(0); i < nPolicies; i++ {
-		obj := fmt.Sprintf("TestRetrieveAll%d@example.com", i)
+		group := mfgroups.Group{
+			ID:   testsutil.GenerateUUID(t, idProvider),
+			Name: fmt.Sprintf("policy-retrievalall-%d", i),
+		}
+		group, err := grepo.Save(context.Background(), group)
+		require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+		grps = append(grps, group.ID)
+
 		if i%2 == 0 {
 			policy := policies.Policy{
 				OwnerID: clientA.ID,
 				Subject: clientA.ID,
-				Object:  obj,
+				Object:  group.ID,
 				Actions: []string{"c_delete"},
 			}
 			err = repo.Save(context.Background(), policy)
 			require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 		}
 		policy := policies.Policy{
+			OwnerID: clientB.ID,
 			Subject: clientB.ID,
-			Object:  obj,
+			Object:  group.ID,
 			Actions: []string{"c_add", "c_update"},
 		}
 		err = repo.Save(context.Background(), policy)
@@ -435,7 +437,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Offset:  0,
 				Limit:   nPolicies,
 				Total:   nPolicies,
-				OwnerID: clientB.ID,
+				OwnerID: "wrong",
 			},
 			size: 0,
 		},
@@ -463,9 +465,9 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Offset: 0,
 				Limit:  nPolicies,
 				Total:  nPolicies,
-				Object: "TestRetrieveAll1@example.com",
+				Object: grps[0],
 			},
-			size: 1,
+			size: 2,
 		},
 		"retrieve policies by wrong Object": {
 			pm: policies.Page{
@@ -520,7 +522,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Limit:   nPolicies,
 				Total:   nPolicies,
 				OwnerID: clientA.ID,
-				Subject: "wrongSubject",
+				Subject: "wrong",
 			},
 			size: 0,
 		},
@@ -529,7 +531,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Offset:  0,
 				Limit:   nPolicies,
 				Total:   nPolicies,
-				OwnerID: clientB.ID,
+				OwnerID: "wrong",
 			},
 			size: 0,
 		},
@@ -539,7 +541,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Limit:   nPolicies,
 				Total:   nPolicies,
 				OwnerID: clientA.ID,
-				Object:  "TestRetrieveAll2@example.com",
+				Object:  grps[0],
 			},
 			size: 1,
 		},
@@ -548,8 +550,8 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Offset:  0,
 				Limit:   nPolicies,
 				Total:   nPolicies,
-				OwnerID: clientB.ID,
-				Object:  "TestRetrieveAll1@example.com",
+				OwnerID: "wrong",
+				Object:  grps[0],
 			},
 			size: 0,
 		},
@@ -559,7 +561,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Limit:   nPolicies,
 				Total:   nPolicies,
 				OwnerID: clientA.ID,
-				Object:  "TestRetrieveAll45@example.com",
+				Object:  "wrong",
 			},
 			size: 0,
 		},
@@ -568,8 +570,8 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Offset:  0,
 				Limit:   nPolicies,
 				Total:   nPolicies,
-				OwnerID: clientB.ID,
-				Object:  "TestRetrieveAll45@example.com",
+				OwnerID: "wrong",
+				Object:  "wrong",
 			},
 			size: 0,
 		},
@@ -599,7 +601,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Limit:   nPolicies,
 				Total:   nPolicies,
 				OwnerID: clientA.ID,
-				Action:  "wrongAction",
+				Action:  "wrong",
 			},
 			size: 0,
 		},
@@ -609,7 +611,7 @@ func TestPoliciesRetrievalAll(t *testing.T) {
 				Limit:   nPolicies,
 				Total:   nPolicies,
 				OwnerID: clientB.ID,
-				Action:  "wrongAction",
+				Action:  "wrong",
 			},
 			size: 0,
 		},
@@ -626,6 +628,14 @@ func TestPoliciesDelete(t *testing.T) {
 	t.Cleanup(func() { testsutil.CleanUpDB(t, db) })
 	repo := ppostgres.NewRepository(database)
 	crepo := cpostgres.NewRepository(database)
+	grepo := gpostgres.NewRepository(database)
+
+	group := mfgroups.Group{
+		ID:   testsutil.GenerateUUID(t, idProvider),
+		Name: "policy-save",
+	}
+	group, err := grepo.Save(context.Background(), group)
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	client := mfclients.Client{
 		ID:   testsutil.GenerateUUID(t, idProvider),
@@ -637,15 +647,14 @@ func TestPoliciesDelete(t *testing.T) {
 		Status: mfclients.EnabledStatus,
 	}
 
-	subject, err := crepo.Save(context.Background(), client)
+	clients, err := crepo.Save(context.Background(), client)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-
-	objectID := testsutil.GenerateUUID(t, idProvider)
+	client = clients[0]
 
 	policy := policies.Policy{
-		OwnerID: subject[0].ID,
-		Subject: subject[0].ID,
-		Object:  objectID,
+		OwnerID: client.ID,
+		Subject: client.ID,
+		Object:  group.ID,
 		Actions: []string{"c_delete"},
 	}
 
@@ -658,9 +667,9 @@ func TestPoliciesDelete(t *testing.T) {
 		err     error
 	}{
 		"delete non-existing policy":                      {"unknown", "unknown", nil},
-		"delete non-existing policy with correct subject": {subject[0].ID, "unknown", nil},
-		"delete non-existing policy with correct object":  {"unknown", objectID, nil},
-		"delete existing policy":                          {subject[0].ID, objectID, nil},
+		"delete non-existing policy with correct subject": {client.ID, "unknown", nil},
+		"delete non-existing policy with correct object":  {"unknown", group.ID, nil},
+		"delete existing policy":                          {client.ID, group.ID, nil},
 	}
 
 	for desc, tc := range cases {
@@ -672,9 +681,9 @@ func TestPoliciesDelete(t *testing.T) {
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 	}
 	pm := policies.Page{
-		OwnerID: subject[0].ID,
-		Subject: subject[0].ID,
-		Object:  objectID,
+		OwnerID: client.ID,
+		Subject: client.ID,
+		Object:  group.ID,
 		Action:  "c_delete",
 	}
 	policyPage, err := repo.RetrieveAll(context.Background(), pm)

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -64,7 +64,7 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) error 
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	p.Actions = addListAction(p.Actions)
+	p.Actions = AddListAction(p.Actions)
 
 	p.OwnerID = id
 	p.CreatedAt = time.Now()

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -55,6 +55,7 @@ func Migration() *migrate.MemoryMigrationSource {
 						updated_at  TIMESTAMP,
 						updated_by  VARCHAR(254),
 						FOREIGN KEY (subject) REFERENCES clients (id) ON DELETE CASCADE ON UPDATE CASCADE,
+						FOREIGN KEY (object) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
 						PRIMARY KEY (subject, object)
 					)`,
 				},


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?
On `things` services check if the subject is a `thing` or a `user`.

1. If the subject is a thing, check the following:
  - The user adding the policy is the owner of the thing
  - The user adding the policy has `c_share` action on the thing

2. If the subject is a user, check the following:
  - The user adding the policy is the owner of the user
  - The user adding the policy has `c_share` action on the user
  
### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
- Ensures that the `object` column in the `policies` table references the `id` column of the `groups` table.
- Check for `subject` in addition to checking for `object`

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
To be merged after https://github.com/mainflux/mainflux/pull/1825