### PR TITLE
MF-703 - Reliably Publish Event Messages to Redis

### DIFF
--- a/bootstrap/redis/producer/events.go
+++ b/bootstrap/redis/producer/events.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mainflux/mainflux/bootstrap"
+	"github.com/mainflux/mainflux/internal/clients/redis"
 )
 
 const (
@@ -32,19 +33,15 @@ const (
 	certUpdate = "cert.update"
 )
 
-type event interface {
-	encode() (map[string]interface{}, error)
-}
-
 var (
-	_ event = (*configEvent)(nil)
-	_ event = (*removeConfigEvent)(nil)
-	_ event = (*bootstrapEvent)(nil)
-	_ event = (*changeStateEvent)(nil)
-	_ event = (*updateConnectionsEvent)(nil)
-	_ event = (*updateCertEvent)(nil)
-	_ event = (*listConfigsEvent)(nil)
-	_ event = (*removeHandlerEvent)(nil)
+	_ redis.Event = (*configEvent)(nil)
+	_ redis.Event = (*removeConfigEvent)(nil)
+	_ redis.Event = (*bootstrapEvent)(nil)
+	_ redis.Event = (*changeStateEvent)(nil)
+	_ redis.Event = (*updateConnectionsEvent)(nil)
+	_ redis.Event = (*updateCertEvent)(nil)
+	_ redis.Event = (*listConfigsEvent)(nil)
+	_ redis.Event = (*removeHandlerEvent)(nil)
 )
 
 type configEvent struct {
@@ -52,7 +49,7 @@ type configEvent struct {
 	operation string
 }
 
-func (ce configEvent) encode() (map[string]interface{}, error) {
+func (ce configEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"state":     ce.State.String(),
 		"operation": ce.operation,
@@ -99,7 +96,7 @@ type removeConfigEvent struct {
 	mfThing string
 }
 
-func (rce removeConfigEvent) encode() (map[string]interface{}, error) {
+func (rce removeConfigEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  rce.mfThing,
 		"operation": configRemove,
@@ -113,7 +110,7 @@ type listConfigsEvent struct {
 	partialMatch map[string]string
 }
 
-func (rce listConfigsEvent) encode() (map[string]interface{}, error) {
+func (rce listConfigsEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"offset":    rce.offset,
 		"limit":     rce.limit,
@@ -145,7 +142,7 @@ type bootstrapEvent struct {
 	success    bool
 }
 
-func (be bootstrapEvent) encode() (map[string]interface{}, error) {
+func (be bootstrapEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"external_id": be.externalID,
 		"success":     be.success,
@@ -194,7 +191,7 @@ type changeStateEvent struct {
 	state   bootstrap.State
 }
 
-func (cse changeStateEvent) encode() (map[string]interface{}, error) {
+func (cse changeStateEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  cse.mfThing,
 		"state":     cse.state.String(),
@@ -207,7 +204,7 @@ type updateConnectionsEvent struct {
 	mfChannels []string
 }
 
-func (uce updateConnectionsEvent) encode() (map[string]interface{}, error) {
+func (uce updateConnectionsEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":  uce.mfThing,
 		"channels":  fmt.Sprintf("[%s]", strings.Join(uce.mfChannels, ", ")),
@@ -219,7 +216,7 @@ type updateCertEvent struct {
 	thingKey, clientCert, clientKey, caCert string
 }
 
-func (uce updateCertEvent) encode() (map[string]interface{}, error) {
+func (uce updateCertEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_key":   uce.thingKey,
 		"client_cert": uce.clientCert,
@@ -234,7 +231,7 @@ type removeHandlerEvent struct {
 	operation string
 }
 
-func (rhe removeHandlerEvent) encode() (map[string]interface{}, error) {
+func (rhe removeHandlerEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"config_id": rhe.id,
 		"operation": rhe.operation,
@@ -245,7 +242,7 @@ type updateChannelHandlerEvent struct {
 	bootstrap.Channel
 }
 
-func (uche updateChannelHandlerEvent) encode() (map[string]interface{}, error) {
+func (uche updateChannelHandlerEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation": channelUpdateHandler,
 	}
@@ -272,7 +269,7 @@ type disconnectThingEvent struct {
 	channelID string
 }
 
-func (dte disconnectThingEvent) encode() (map[string]interface{}, error) {
+func (dte disconnectThingEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":   dte.thingID,
 		"channel_id": dte.channelID,

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
 	mfredis "github.com/mainflux/mainflux/internal/clients/redis"
-	"github.com/mainflux/mainflux/pkg/errors"
 )
 
 const (
@@ -49,8 +48,8 @@ func (es *eventStore) Add(ctx context.Context, token string, cfg bootstrap.Confi
 		saved, configCreate,
 	}
 
-	if err1 := es.Publish(ctx, ev); err1 != nil {
-		return saved, errors.Wrap(err, err1)
+	if err := es.Publish(ctx, ev); err != nil {
+		return saved, err
 	}
 
 	return saved, err
@@ -65,8 +64,8 @@ func (es *eventStore) View(ctx context.Context, token, id string) (bootstrap.Con
 		cfg, configList,
 	}
 
-	if err1 := es.Publish(ctx, ev); err1 != nil {
-		return cfg, errors.Wrap(err, err1)
+	if err := es.Publish(ctx, ev); err != nil {
+		return cfg, err
 	}
 
 	return cfg, err
@@ -97,7 +96,11 @@ func (es eventStore) UpdateCert(ctx context.Context, token, thingKey, clientCert
 		caCert:     caCert,
 	}
 
-	return es.Publish(ctx, ev)
+	if err := es.Publish(ctx, ev); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
 }
 
 func (es *eventStore) UpdateConnections(ctx context.Context, token, id string, connections []string) error {
@@ -126,8 +129,8 @@ func (es *eventStore) List(ctx context.Context, token string, filter bootstrap.F
 		partialMatch: filter.PartialMatch,
 	}
 
-	if err1 := es.Publish(ctx, ev); err1 != nil {
-		return bp, errors.Wrap(err, err1)
+	if err := es.Publish(ctx, ev); err != nil {
+		return bp, err
 	}
 
 	return bp, nil
@@ -158,11 +161,11 @@ func (es *eventStore) Bootstrap(ctx context.Context, externalKey, externalID str
 		ev.success = false
 	}
 
-	if err1 := es.Publish(ctx, ev); err1 != nil {
-		return cfg, err1
+	if err := es.Publish(ctx, ev); err != nil {
+		return cfg, err
 	}
 
-	return cfg, err
+	return cfg, nil
 }
 
 func (es *eventStore) ChangeState(ctx context.Context, token, id string, state bootstrap.State) error {

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -165,7 +165,7 @@ func (es *eventStore) Bootstrap(ctx context.Context, externalKey, externalID str
 		return cfg, err
 	}
 
-	return cfg, nil
+	return cfg, err
 }
 
 func (es *eventStore) ChangeState(ctx context.Context, token, id string, state bootstrap.State) error {

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -222,8 +222,8 @@ func (es *eventStore) DisconnectThingHandler(ctx context.Context, channelID, thi
 	}
 
 	ev := disconnectThingEvent{
-		channelID,
 		thingID,
+		channelID,
 	}
 
 	return es.Publish(ctx, ev)

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -5,6 +5,7 @@ package producer
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
@@ -12,27 +13,33 @@ import (
 )
 
 const (
-	streamID  = "mainflux.bootstrap"
-	streamLen = 1000
+	streamID                       = "mainflux.bootstrap"
+	streamLen                      = 1000
+	checkUnpublishedEventsInterval = 1 * time.Minute
 )
 
 var _ bootstrap.Service = (*eventStore)(nil)
 
 type eventStore struct {
-	svc    bootstrap.Service
-	client *redis.Client
+	svc               bootstrap.Service
+	client            *redis.Client
+	unpublishedEvents []*redis.XAddArgs
 }
 
 // NewEventStoreMiddleware returns wrapper around bootstrap service that sends
 // events to event store.
-func NewEventStoreMiddleware(svc bootstrap.Service, client *redis.Client) bootstrap.Service {
-	return eventStore{
+func NewEventStoreMiddleware(ctx context.Context, svc bootstrap.Service, client *redis.Client) bootstrap.Service {
+	es := &eventStore{
 		svc:    svc,
 		client: client,
 	}
+
+	go es.startPublishingRoutine(ctx)
+
+	return es
 }
 
-func (es eventStore) Add(ctx context.Context, token string, cfg bootstrap.Config) (bootstrap.Config, error) {
+func (es *eventStore) Add(ctx context.Context, token string, cfg bootstrap.Config) (bootstrap.Config, error) {
 	saved, err := es.svc.Add(ctx, token, cfg)
 	if err != nil {
 		return saved, err
@@ -42,14 +49,14 @@ func (es eventStore) Add(ctx context.Context, token string, cfg bootstrap.Config
 		saved, configCreate,
 	}
 
-	if err1 := es.add(ctx, ev); err1 != nil {
+	if err1 := es.publish(ctx, ev); err1 != nil {
 		return saved, errors.Wrap(err, err1)
 	}
 
 	return saved, err
 }
 
-func (es eventStore) View(ctx context.Context, token, id string) (bootstrap.Config, error) {
+func (es *eventStore) View(ctx context.Context, token, id string) (bootstrap.Config, error) {
 	cfg, err := es.svc.View(ctx, token, id)
 	if err != nil {
 		return cfg, err
@@ -58,14 +65,14 @@ func (es eventStore) View(ctx context.Context, token, id string) (bootstrap.Conf
 		cfg, configList,
 	}
 
-	if err1 := es.add(ctx, ev); err1 != nil {
+	if err1 := es.publish(ctx, ev); err1 != nil {
 		return cfg, errors.Wrap(err, err1)
 	}
 
 	return cfg, err
 }
 
-func (es eventStore) Update(ctx context.Context, token string, cfg bootstrap.Config) error {
+func (es *eventStore) Update(ctx context.Context, token string, cfg bootstrap.Config) error {
 	if err := es.svc.Update(ctx, token, cfg); err != nil {
 		return err
 	}
@@ -74,13 +81,13 @@ func (es eventStore) Update(ctx context.Context, token string, cfg bootstrap.Con
 		cfg, configUpdate,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
 func (es eventStore) UpdateCert(ctx context.Context, token, thingKey, clientCert, clientKey, caCert string) (bootstrap.Config, error) {
 	cfg, err := es.svc.UpdateCert(ctx, token, thingKey, clientCert, clientKey, caCert)
 	if err != nil {
-		return bootstrap.Config{}, err
+		return cfg, err
 	}
 
 	ev := updateCertEvent{
@@ -90,10 +97,10 @@ func (es eventStore) UpdateCert(ctx context.Context, token, thingKey, clientCert
 		caCert:     caCert,
 	}
 
-	return cfg, es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) UpdateConnections(ctx context.Context, token, id string, connections []string) error {
+func (es *eventStore) UpdateConnections(ctx context.Context, token, id string, connections []string) error {
 	if err := es.svc.UpdateConnections(ctx, token, id, connections); err != nil {
 		return err
 	}
@@ -103,10 +110,10 @@ func (es eventStore) UpdateConnections(ctx context.Context, token, id string, co
 		mfChannels: connections,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) List(ctx context.Context, token string, filter bootstrap.Filter, offset, limit uint64) (bootstrap.ConfigsPage, error) {
+func (es *eventStore) List(ctx context.Context, token string, filter bootstrap.Filter, offset, limit uint64) (bootstrap.ConfigsPage, error) {
 	bp, err := es.svc.List(ctx, token, filter, offset, limit)
 	if err != nil {
 		return bp, err
@@ -119,14 +126,14 @@ func (es eventStore) List(ctx context.Context, token string, filter bootstrap.Fi
 		partialMatch: filter.PartialMatch,
 	}
 
-	if err1 := es.add(ctx, ev); err1 != nil {
+	if err1 := es.publish(ctx, ev); err1 != nil {
 		return bp, errors.Wrap(err, err1)
 	}
 
 	return bp, nil
 }
 
-func (es eventStore) Remove(ctx context.Context, token, id string) error {
+func (es *eventStore) Remove(ctx context.Context, token, id string) error {
 	if err := es.svc.Remove(ctx, token, id); err != nil {
 		return err
 	}
@@ -135,10 +142,10 @@ func (es eventStore) Remove(ctx context.Context, token, id string) error {
 		mfThing: id,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) Bootstrap(ctx context.Context, externalKey, externalID string, secure bool) (bootstrap.Config, error) {
+func (es *eventStore) Bootstrap(ctx context.Context, externalKey, externalID string, secure bool) (bootstrap.Config, error) {
 	cfg, err := es.svc.Bootstrap(ctx, externalKey, externalID, secure)
 
 	ev := bootstrapEvent{
@@ -151,14 +158,14 @@ func (es eventStore) Bootstrap(ctx context.Context, externalKey, externalID stri
 		ev.success = false
 	}
 
-	if err1 := es.add(ctx, ev); err1 != nil {
+	if err1 := es.publish(ctx, ev); err1 != nil {
 		return cfg, err1
 	}
 
 	return cfg, err
 }
 
-func (es eventStore) ChangeState(ctx context.Context, token, id string, state bootstrap.State) error {
+func (es *eventStore) ChangeState(ctx context.Context, token, id string, state bootstrap.State) error {
 	if err := es.svc.ChangeState(ctx, token, id, state); err != nil {
 		return err
 	}
@@ -168,10 +175,10 @@ func (es eventStore) ChangeState(ctx context.Context, token, id string, state bo
 		state:   state,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) RemoveConfigHandler(ctx context.Context, id string) error {
+func (es *eventStore) RemoveConfigHandler(ctx context.Context, id string) error {
 	if err := es.svc.RemoveConfigHandler(ctx, id); err != nil {
 		return err
 	}
@@ -181,10 +188,10 @@ func (es eventStore) RemoveConfigHandler(ctx context.Context, id string) error {
 		operation: configHandlerRemove,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) RemoveChannelHandler(ctx context.Context, id string) error {
+func (es *eventStore) RemoveChannelHandler(ctx context.Context, id string) error {
 	if err := es.svc.RemoveChannelHandler(ctx, id); err != nil {
 		return err
 	}
@@ -194,10 +201,10 @@ func (es eventStore) RemoveChannelHandler(ctx context.Context, id string) error 
 		operation: channelHandlerRemove,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) UpdateChannelHandler(ctx context.Context, channel bootstrap.Channel) error {
+func (es *eventStore) UpdateChannelHandler(ctx context.Context, channel bootstrap.Channel) error {
 	if err := es.svc.UpdateChannelHandler(ctx, channel); err != nil {
 		return err
 	}
@@ -206,10 +213,10 @@ func (es eventStore) UpdateChannelHandler(ctx context.Context, channel bootstrap
 		channel,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
+func (es *eventStore) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
 	if err := es.svc.DisconnectThingHandler(ctx, channelID, thingID); err != nil {
 		return err
 	}
@@ -219,10 +226,18 @@ func (es eventStore) DisconnectThingHandler(ctx context.Context, channelID, thin
 		thingID,
 	}
 
-	return es.add(ctx, ev)
+	return es.publish(ctx, ev)
 }
 
-func (es eventStore) add(ctx context.Context, ev event) error {
+func (es *eventStore) checkRedisConnection(ctx context.Context) error {
+	// A timeout is used to avoid blocking the main thread
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	return es.client.Ping(ctx).Err()
+}
+
+func (es *eventStore) publish(ctx context.Context, ev event) error {
 	values, err := ev.encode()
 	if err != nil {
 		return err
@@ -234,5 +249,28 @@ func (es eventStore) add(ctx context.Context, ev event) error {
 		Values:       values,
 	}
 
+	if err := es.checkRedisConnection(ctx); err != nil {
+		es.unpublishedEvents = append(es.unpublishedEvents, record)
+		return nil
+	}
+
 	return es.client.XAdd(ctx, record).Err()
+}
+
+func (es *eventStore) startPublishingRoutine(ctx context.Context) {
+	ticker := time.NewTicker(checkUnpublishedEventsInterval)
+	for {
+		select {
+		case <-ticker.C:
+			if err := es.checkRedisConnection(ctx); err == nil {
+				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
+					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
+						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
+					}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -5,6 +5,7 @@ package producer
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -24,6 +25,7 @@ type eventStore struct {
 	svc               bootstrap.Service
 	client            *redis.Client
 	unpublishedEvents []*redis.XAddArgs
+	mu                sync.Mutex
 }
 
 // NewEventStoreMiddleware returns wrapper around bootstrap service that sends
@@ -263,11 +265,13 @@ func (es *eventStore) startPublishingRoutine(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := es.checkRedisConnection(ctx); err == nil {
+				es.mu.Lock()
 				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
 					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
 						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
 					}
 				}
+				es.mu.Unlock()
 			}
 		case <-ctx.Done():
 			return

--- a/bootstrap/redis/producer/streams.go
+++ b/bootstrap/redis/producer/streams.go
@@ -5,7 +5,6 @@ package producer
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/mainflux/mainflux/bootstrap"
@@ -14,9 +13,8 @@ import (
 )
 
 const (
-	streamID                       = "mainflux.bootstrap"
-	streamLen                      = 1000
-	checkUnpublishedEventsInterval = 1 * time.Minute
+	streamID  = "mainflux.bootstrap"
+	streamLen = 1000
 )
 
 var _ bootstrap.Service = (*eventStore)(nil)

--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -116,7 +116,7 @@ func TestAdd(t *testing.T) {
 
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	var channels []string
 	for _, ch := range config.Channels {
@@ -190,8 +190,8 @@ func TestView(t *testing.T) {
 
 	svcConfig, svcErr := svc.View(context.Background(), validToken, saved.ThingID)
 
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
-	esConfig, esErr := svc.View(context.Background(), validToken, saved.ThingID)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
+	esConfig, esErr := svc.View(context.Background(), validToken, saved.MFThing)
 
 	assert.Equal(t, svcConfig, esConfig, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", svcConfig, esConfig))
 	assert.Equal(t, svcErr, esErr, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", svcErr, esErr))
@@ -204,7 +204,7 @@ func TestUpdate(t *testing.T) {
 	users := mocks.NewAuthClient(map[string]string{validToken: email})
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	c := config
 
@@ -287,7 +287,7 @@ func TestUpdateConnections(t *testing.T) {
 	users := mocks.NewAuthClient(map[string]string{validToken: email})
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	saved, err := svc.Add(context.Background(), validToken, config)
 	require.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
@@ -357,7 +357,7 @@ func TestList(t *testing.T) {
 	limit := uint64(10)
 	svcConfigs, svcErr := svc.List(context.Background(), validToken, bootstrap.Filter{}, offset, limit)
 
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 	esConfigs, esErr := svc.List(context.Background(), validToken, bootstrap.Filter{}, offset, limit)
 	assert.Equal(t, svcConfigs, esConfigs)
 	assert.Equal(t, svcErr, esErr)
@@ -370,7 +370,7 @@ func TestRemove(t *testing.T) {
 	users := mocks.NewAuthClient(map[string]string{validToken: email})
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	c := config
 
@@ -434,7 +434,7 @@ func TestBootstrap(t *testing.T) {
 	users := mocks.NewAuthClient(map[string]string{validToken: email})
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	c := config
 
@@ -503,7 +503,7 @@ func TestChangeState(t *testing.T) {
 	users := mocks.NewAuthClient(map[string]string{validToken: email})
 	server := newThingsServer(newThingsService(users))
 	svc := newService(users, server.URL)
-	svc = producer.NewEventStoreMiddleware(svc, redisClient)
+	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
 
 	c := config
 

--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -626,9 +626,9 @@ func TestBootstrap(t *testing.T) {
 		},
 		{
 			desc:        "bootstrap with an error",
-			externalID:  saved.ExternalID,
-			externalKey: "external_id1",
-			err:         bootstrap.ErrExternalKey,
+			externalID:  "external_id1",
+			externalKey: "external_id",
+			err:         bootstrap.ErrBootstrap,
 			event: map[string]interface{}{
 				"external_id": "external_id",
 				"success":     "0",

--- a/bootstrap/redis/producer/streams_test.go
+++ b/bootstrap/redis/producer/streams_test.go
@@ -201,7 +201,7 @@ func TestView(t *testing.T) {
 	svcConfig, svcErr := svc.View(context.Background(), validToken, saved.ThingID)
 
 	svc = producer.NewEventStoreMiddleware(context.Background(), svc, redisClient)
-	esConfig, esErr := svc.View(context.Background(), validToken, saved.MFThing)
+	esConfig, esErr := svc.View(context.Background(), validToken, saved.ThingID)
 
 	assert.Equal(t, svcConfig, esConfig, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", svcConfig, esConfig))
 	assert.Equal(t, svcErr, esErr, fmt.Sprintf("event sourcing changed service behavior: expected %v got %v", svcErr, esErr))
@@ -254,9 +254,9 @@ func TestUpdate(t *testing.T) {
 				"channels":    "[1, 2]",
 				"external_id": "external_id",
 				"thing_id":    "1",
-				"owner":          email,
-				"state":          "0",
-				"occurred_at":    time.Now().UnixNano(),
+				"owner":       email,
+				"state":       "0",
+				"occurred_at": time.Now().UnixNano(),
 			},
 		},
 		{
@@ -383,14 +383,14 @@ func TestUpdateCert(t *testing.T) {
 	}{
 		{
 			desc:       "update cert successfully",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      validToken,
 			clientCert: "clientCert",
 			clientKey:  "clientKey",
 			caCert:     "caCert",
 			err:        nil,
 			event: map[string]interface{}{
-				"thing_key":   saved.MFKey,
+				"thing_key":   saved.ThingKey,
 				"client_cert": "clientCert",
 				"client_key":  "clientKey",
 				"ca_cert":     "caCert",
@@ -399,7 +399,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "invalid token",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      "invalidToken",
 			clientCert: "clientCert",
 			clientKey:  "clientKey",
@@ -419,7 +419,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "empty client certificate",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      validToken,
 			clientCert: "",
 			clientKey:  "clientKey",
@@ -429,7 +429,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "empty client key",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      validToken,
 			clientCert: "clientCert",
 			clientKey:  "",
@@ -439,7 +439,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "empty CA certificate",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      validToken,
 			clientCert: "clientCert",
 			clientKey:  "clientKey",
@@ -449,7 +449,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "update cert with invalid token",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      "invalidToken",
 			clientCert: "clientCert",
 			clientKey:  "clientKey",
@@ -469,14 +469,14 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:       "successful update without CA certificate",
-			id:         saved.MFThing,
+			id:         saved.ThingID,
 			token:      validToken,
 			clientCert: "clientCert",
 			clientKey:  "clientKey",
 			caCert:     "",
 			err:        nil,
 			event: map[string]interface{}{
-				"thing_key":   saved.MFKey,
+				"thing_key":   saved.ThingKey,
 				"client_cert": "clientCert",
 				"client_key":  "clientKey",
 				"ca_cert":     "caCert",
@@ -488,7 +488,7 @@ func TestUpdateCert(t *testing.T) {
 
 	lastID := "0"
 	for _, tc := range cases {
-		err := svc.UpdateCert(context.Background(), tc.token, tc.id, tc.clientCert, tc.clientKey, tc.caCert)
+		_, err := svc.UpdateCert(context.Background(), tc.token, tc.id, tc.clientCert, tc.clientKey, tc.caCert)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 
 		streams := redisClient.XRead(context.Background(), &redis.XReadArgs{

--- a/cmd/mqtt/main.go
+++ b/cmd/mqtt/main.go
@@ -154,7 +154,7 @@ func main() {
 	}
 	defer ec.Close()
 
-	es := mqttredis.NewEventStore(ec, cfg.Instance)
+	es := mqttredis.NewEventStore(ctx, ec, cfg.Instance)
 
 	tc, tcHandler, err := thingsClient.Setup()
 	if err != nil {

--- a/internal/clients/redis/producer.go
+++ b/internal/clients/redis/producer.go
@@ -55,6 +55,8 @@ func (es *eventStore) Publish(ctx context.Context, event Event) error {
 	if err != nil {
 		return err
 	}
+	values["occurred_at"] = time.Now().UnixNano()
+
 	record := &redis.XAddArgs{
 		Stream:       es.streamID,
 		MaxLenApprox: es.streamLen,

--- a/internal/clients/redis/producer.go
+++ b/internal/clients/redis/producer.go
@@ -69,6 +69,8 @@ func (es *eventStore) Publish(ctx context.Context, event Event) error {
 
 func (es *eventStore) StartPublishingRoutine(ctx context.Context) {
 	ticker := time.NewTicker(checkUnpublishedEventsInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ticker.C:
@@ -86,6 +88,7 @@ func (es *eventStore) StartPublishingRoutine(ctx context.Context) {
 		}
 	}
 }
+
 func (es *eventStore) checkRedisConnection(ctx context.Context) error {
 	// A timeout is used to avoid blocking the main thread
 	ctx, cancel := context.WithTimeout(ctx, checkRedisConnectionInterval)

--- a/internal/clients/redis/producer.go
+++ b/internal/clients/redis/producer.go
@@ -1,0 +1,95 @@
+// Copyright (c) Mainflux
+// SPDX-License-Identifier: Apache-2.0
+
+package redis
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+const (
+	checkUnpublishedEventsInterval = 1 * time.Minute
+	checkRedisConnectionInterval   = 100 * time.Millisecond
+)
+
+// Event represents redis event.
+type Event interface {
+	// Encode encodes event to map.
+	Encode() (map[string]interface{}, error)
+}
+
+// Publisher specifies redis event publishing API.
+type Publisher interface {
+	// Publishes event to redis stream.
+	Publish(ctx context.Context, event Event) error
+
+	// StartPublishingRoutine starts routine that checks for unpublished events
+	// and publishes them to redis stream.
+	StartPublishingRoutine(ctx context.Context)
+}
+
+type eventStore struct {
+	client            *redis.Client
+	unpublishedEvents []*redis.XAddArgs
+	streamID          string
+	streamLen         int64
+	mu                sync.Mutex
+}
+
+func NewEventStore(client *redis.Client, streamID string, streamLen int64) Publisher {
+	return &eventStore{
+		client:    client,
+		streamID:  streamID,
+		streamLen: streamLen,
+	}
+}
+
+func (es *eventStore) Publish(ctx context.Context, event Event) error {
+	values, err := event.Encode()
+	if err != nil {
+		return err
+	}
+	record := &redis.XAddArgs{
+		Stream:       es.streamID,
+		MaxLenApprox: es.streamLen,
+		Values:       values,
+	}
+
+	if err := es.checkRedisConnection(ctx); err != nil {
+		es.unpublishedEvents = append(es.unpublishedEvents, record)
+		return nil
+	}
+
+	return es.client.XAdd(ctx, record).Err()
+}
+
+func (es *eventStore) StartPublishingRoutine(ctx context.Context) {
+	ticker := time.NewTicker(checkUnpublishedEventsInterval)
+	for {
+		select {
+		case <-ticker.C:
+			if err := es.checkRedisConnection(ctx); err == nil {
+				es.mu.Lock()
+				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
+					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
+						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
+					}
+				}
+				es.mu.Unlock()
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+func (es *eventStore) checkRedisConnection(ctx context.Context) error {
+	// A timeout is used to avoid blocking the main thread
+	ctx, cancel := context.WithTimeout(ctx, checkRedisConnectionInterval)
+	defer cancel()
+
+	return es.client.Ping(ctx).Err()
+}

--- a/mqtt/redis/events.go
+++ b/mqtt/redis/events.go
@@ -3,12 +3,10 @@
 
 package redis
 
-type event interface {
-	Encode() map[string]interface{}
-}
+import "github.com/mainflux/mainflux/internal/clients/redis"
 
 var (
-	_ event = (*mqttEvent)(nil)
+	_ redis.Event = (*mqttEvent)(nil)
 )
 
 type mqttEvent struct {
@@ -17,10 +15,10 @@ type mqttEvent struct {
 	instance  string
 }
 
-func (me mqttEvent) Encode() map[string]interface{} {
+func (me mqttEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"thing_id":   me.clientID,
 		"event_type": me.eventType,
 		"instance":   me.instance,
-	}
+	}, nil
 }

--- a/mqtt/redis/streams.go
+++ b/mqtt/redis/streams.go
@@ -5,16 +5,14 @@ package redis
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	mfredis "github.com/mainflux/mainflux/internal/clients/redis"
 )
 
 const (
-	streamID                       = "mainflux.mqtt"
-	streamLen                      = 1000
-	checkUnpublishedEventsInterval = 1 * time.Minute
+	streamID  = "mainflux.mqtt"
+	streamLen = 1000
 )
 
 type EventStore interface {

--- a/mqtt/redis/streams.go
+++ b/mqtt/redis/streams.go
@@ -5,6 +5,7 @@ package redis
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -26,6 +27,7 @@ type eventStore struct {
 	client            *redis.Client
 	instance          string
 	unpublishedEvents []*redis.XAddArgs
+	mu                sync.Mutex
 }
 
 // NewEventStore returns wrapper around mProxy service that sends
@@ -86,11 +88,13 @@ func (es *eventStore) startPublishingRoutine(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := es.checkRedisConnection(ctx); err == nil {
+				es.mu.Lock()
 				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
 					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
 						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
 					}
 				}
+				es.mu.Unlock()
 			}
 		case <-ctx.Done():
 			return

--- a/things/clients/redis/events.go
+++ b/things/clients/redis/events.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mainflux/mainflux/internal/clients/redis"
 	mfclients "github.com/mainflux/mainflux/pkg/clients"
 )
 
@@ -23,18 +24,14 @@ const (
 	clientIdentify    = clientPrefix + "identify"
 )
 
-type event interface {
-	Encode() (map[string]interface{}, error)
-}
-
 var (
-	_ event = (*createClientEvent)(nil)
-	_ event = (*updateClientEvent)(nil)
-	_ event = (*removeClientEvent)(nil)
-	_ event = (*viewClientEvent)(nil)
-	_ event = (*listClientEvent)(nil)
-	_ event = (*listClientByGroupEvent)(nil)
-	_ event = (*identifyClientEvent)(nil)
+	_ redis.Event = (*createClientEvent)(nil)
+	_ redis.Event = (*updateClientEvent)(nil)
+	_ redis.Event = (*removeClientEvent)(nil)
+	_ redis.Event = (*viewClientEvent)(nil)
+	_ redis.Event = (*listClientEvent)(nil)
+	_ redis.Event = (*listClientByGroupEvent)(nil)
+	_ redis.Event = (*identifyClientEvent)(nil)
 )
 
 type createClientEvent struct {

--- a/things/clients/redis/streams.go
+++ b/things/clients/redis/streams.go
@@ -5,7 +5,6 @@ package redis
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	mfredis "github.com/mainflux/mainflux/internal/clients/redis"
@@ -14,9 +13,8 @@ import (
 )
 
 const (
-	streamID                       = "mainflux.things"
-	streamLen                      = 1000
-	checkUnpublishedEventsInterval = 1 * time.Minute
+	streamID  = "mainflux.things"
+	streamLen = 1000
 )
 
 var _ clients.Service = (*eventStore)(nil)

--- a/things/clients/redis/streams.go
+++ b/things/clients/redis/streams.go
@@ -5,6 +5,7 @@ package redis
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	mfclients "github.com/mainflux/mainflux/pkg/clients"
@@ -12,27 +13,33 @@ import (
 )
 
 const (
-	streamID  = "mainflux.things"
-	streamLen = 1000
+	streamID                       = "mainflux.things"
+	streamLen                      = 1000
+	checkUnpublishedEventsInterval = 1 * time.Minute
 )
 
 var _ clients.Service = (*eventStore)(nil)
 
 type eventStore struct {
-	svc    clients.Service
-	client *redis.Client
+	svc               clients.Service
+	client            *redis.Client
+	unpublishedEvents []*redis.XAddArgs
 }
 
 // NewEventStoreMiddleware returns wrapper around things service that sends
 // events to event store.
-func NewEventStoreMiddleware(svc clients.Service, client *redis.Client) clients.Service {
-	return eventStore{
+func NewEventStoreMiddleware(ctx context.Context, svc clients.Service, client *redis.Client) clients.Service {
+	es := &eventStore{
 		svc:    svc,
 		client: client,
 	}
+
+	go es.startPublishingRoutine(ctx)
+
+	return es
 }
 
-func (es eventStore) CreateThings(ctx context.Context, token string, thing ...mfclients.Client) ([]mfclients.Client, error) {
+func (es *eventStore) CreateThings(ctx context.Context, token string, thing ...mfclients.Client) ([]mfclients.Client, error) {
 	sths, err := es.svc.CreateThings(ctx, token, thing...)
 	if err != nil {
 		return sths, err
@@ -42,23 +49,14 @@ func (es eventStore) CreateThings(ctx context.Context, token string, thing ...mf
 		event := createClientEvent{
 			th,
 		}
-		values, err := event.Encode()
-		if err != nil {
-			return sths, err
-		}
-		record := &redis.XAddArgs{
-			Stream: streamID,
-			MaxLen: streamLen,
-			Values: values,
-		}
-		if err := es.client.XAdd(ctx, record).Err(); err != nil {
+		if err := es.publish(ctx, event); err != nil {
 			return sths, err
 		}
 	}
 	return sths, nil
 }
 
-func (es eventStore) UpdateClient(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
+func (es *eventStore) UpdateClient(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
 	cli, err := es.svc.UpdateClient(ctx, token, thing)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -67,7 +65,7 @@ func (es eventStore) UpdateClient(ctx context.Context, token string, thing mfcli
 	return es.update(ctx, "", cli)
 }
 
-func (es eventStore) UpdateClientOwner(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
+func (es *eventStore) UpdateClientOwner(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
 	cli, err := es.svc.UpdateClientOwner(ctx, token, thing)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -76,7 +74,7 @@ func (es eventStore) UpdateClientOwner(ctx context.Context, token string, thing 
 	return es.update(ctx, "owner", cli)
 }
 
-func (es eventStore) UpdateClientTags(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
+func (es *eventStore) UpdateClientTags(ctx context.Context, token string, thing mfclients.Client) (mfclients.Client, error) {
 	cli, err := es.svc.UpdateClientTags(ctx, token, thing)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -85,7 +83,7 @@ func (es eventStore) UpdateClientTags(ctx context.Context, token string, thing m
 	return es.update(ctx, "tags", cli)
 }
 
-func (es eventStore) UpdateClientSecret(ctx context.Context, token, id, key string) (mfclients.Client, error) {
+func (es *eventStore) UpdateClientSecret(ctx context.Context, token, id, key string) (mfclients.Client, error) {
 	cli, err := es.svc.UpdateClientSecret(ctx, token, id, key)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -94,27 +92,18 @@ func (es eventStore) UpdateClientSecret(ctx context.Context, token, id, key stri
 	return es.update(ctx, "secret", cli)
 }
 
-func (es eventStore) update(ctx context.Context, operation string, cli mfclients.Client) (mfclients.Client, error) {
+func (es *eventStore) update(ctx context.Context, operation string, cli mfclients.Client) (mfclients.Client, error) {
 	event := updateClientEvent{
 		cli, operation,
 	}
-	values, err := event.Encode()
-	if err != nil {
-		return cli, err
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       values,
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+	if err := es.publish(ctx, event); err != nil {
 		return cli, err
 	}
 
 	return cli, nil
 }
 
-func (es eventStore) ViewClient(ctx context.Context, token, id string) (mfclients.Client, error) {
+func (es *eventStore) ViewClient(ctx context.Context, token, id string) (mfclients.Client, error) {
 	cli, err := es.svc.ViewClient(ctx, token, id)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -122,23 +111,14 @@ func (es eventStore) ViewClient(ctx context.Context, token, id string) (mfclient
 	event := viewClientEvent{
 		cli,
 	}
-	values, err := event.Encode()
-	if err != nil {
-		return cli, err
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       values,
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+	if err := es.publish(ctx, event); err != nil {
 		return cli, err
 	}
 
 	return cli, nil
 }
 
-func (es eventStore) ListClients(ctx context.Context, token string, pm mfclients.Page) (mfclients.ClientsPage, error) {
+func (es *eventStore) ListClients(ctx context.Context, token string, pm mfclients.Page) (mfclients.ClientsPage, error) {
 	cp, err := es.svc.ListClients(ctx, token, pm)
 	if err != nil {
 		return mfclients.ClientsPage{}, err
@@ -146,23 +126,14 @@ func (es eventStore) ListClients(ctx context.Context, token string, pm mfclients
 	event := listClientEvent{
 		pm,
 	}
-	values, err := event.Encode()
-	if err != nil {
-		return cp, err
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       values,
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+	if err := es.publish(ctx, event); err != nil {
 		return cp, err
 	}
 
 	return cp, nil
 }
 
-func (es eventStore) ListClientsByGroup(ctx context.Context, token, chID string, pm mfclients.Page) (mfclients.MembersPage, error) {
+func (es *eventStore) ListClientsByGroup(ctx context.Context, token, chID string, pm mfclients.Page) (mfclients.MembersPage, error) {
 	cp, err := es.svc.ListClientsByGroup(ctx, token, chID, pm)
 	if err != nil {
 		return mfclients.MembersPage{}, err
@@ -170,23 +141,14 @@ func (es eventStore) ListClientsByGroup(ctx context.Context, token, chID string,
 	event := listClientByGroupEvent{
 		pm, chID,
 	}
-	values, err := event.Encode()
-	if err != nil {
-		return cp, err
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       values,
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+	if err := es.publish(ctx, event); err != nil {
 		return cp, err
 	}
 
 	return cp, nil
 }
 
-func (es eventStore) EnableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
+func (es *eventStore) EnableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
 	cli, err := es.svc.EnableClient(ctx, token, id)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -195,7 +157,7 @@ func (es eventStore) EnableClient(ctx context.Context, token, id string) (mfclie
 	return es.delete(ctx, cli)
 }
 
-func (es eventStore) DisableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
+func (es *eventStore) DisableClient(ctx context.Context, token, id string) (mfclients.Client, error) {
 	cli, err := es.svc.DisableClient(ctx, token, id)
 	if err != nil {
 		return mfclients.Client{}, err
@@ -204,30 +166,21 @@ func (es eventStore) DisableClient(ctx context.Context, token, id string) (mfcli
 	return es.delete(ctx, cli)
 }
 
-func (es eventStore) delete(ctx context.Context, cli mfclients.Client) (mfclients.Client, error) {
+func (es *eventStore) delete(ctx context.Context, cli mfclients.Client) (mfclients.Client, error) {
 	event := removeClientEvent{
 		id:        cli.ID,
 		updatedAt: cli.UpdatedAt,
 		updatedBy: cli.UpdatedBy,
 		status:    cli.Status.String(),
 	}
-	values, err := event.Encode()
-	if err != nil {
-		return cli, err
-	}
-	record := &redis.XAddArgs{
-		Stream:       streamID,
-		MaxLenApprox: streamLen,
-		Values:       values,
-	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
+	if err := es.publish(ctx, event); err != nil {
 		return cli, err
 	}
 
 	return cli, nil
 }
 
-func (es eventStore) Identify(ctx context.Context, key string) (string, error) {
+func (es *eventStore) Identify(ctx context.Context, key string) (string, error) {
 	thingID, err := es.svc.Identify(ctx, key)
 	if err != nil {
 		return "", err
@@ -235,18 +188,54 @@ func (es eventStore) Identify(ctx context.Context, key string) (string, error) {
 	event := identifyClientEvent{
 		thingID: thingID,
 	}
+
+	if err := es.publish(ctx, event); err != nil {
+		return thingID, err
+	}
+	return thingID, nil
+}
+
+func (es *eventStore) checkRedisConnection(ctx context.Context) error {
+	// A timeout is used to avoid blocking the main thread
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	return es.client.Ping(ctx).Err()
+}
+
+func (es *eventStore) publish(ctx context.Context, event event) error {
 	values, err := event.Encode()
 	if err != nil {
-		return thingID, err
+		return err
 	}
 	record := &redis.XAddArgs{
 		Stream:       streamID,
 		MaxLenApprox: streamLen,
 		Values:       values,
 	}
-	if err := es.client.XAdd(ctx, record).Err(); err != nil {
-		return thingID, err
+
+	if err := es.checkRedisConnection(ctx); err != nil {
+		es.unpublishedEvents = append(es.unpublishedEvents, record)
+		return nil
 	}
 
-	return thingID, nil
+	return es.client.XAdd(ctx, record).Err()
+}
+
+func (es *eventStore) startPublishingRoutine(ctx context.Context) {
+	ticker := time.NewTicker(checkUnpublishedEventsInterval)
+	for {
+		select {
+		case <-ticker.C:
+			if err := es.checkRedisConnection(ctx); err == nil {
+				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
+					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
+						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
+					}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/things/groups/redis/events.go
+++ b/things/groups/redis/events.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/mainflux/mainflux/internal/clients/redis"
 	mfgroups "github.com/mainflux/mainflux/pkg/groups"
 )
 
@@ -20,17 +21,13 @@ const (
 	groupListMemberships = groupPrefix + "list_by_group"
 )
 
-type event interface {
-	Encode() (map[string]interface{}, error)
-}
-
 var (
-	_ event = (*createGroupEvent)(nil)
-	_ event = (*updateGroupEvent)(nil)
-	_ event = (*removeGroupEvent)(nil)
-	_ event = (*viewGroupEvent)(nil)
-	_ event = (*listGroupEvent)(nil)
-	_ event = (*listGroupMembershipEvent)(nil)
+	_ redis.Event = (*createGroupEvent)(nil)
+	_ redis.Event = (*updateGroupEvent)(nil)
+	_ redis.Event = (*removeGroupEvent)(nil)
+	_ redis.Event = (*viewGroupEvent)(nil)
+	_ redis.Event = (*listGroupEvent)(nil)
+	_ redis.Event = (*listGroupMembershipEvent)(nil)
 )
 
 type createGroupEvent struct {

--- a/things/groups/redis/streams.go
+++ b/things/groups/redis/streams.go
@@ -5,7 +5,6 @@ package redis
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	mfredis "github.com/mainflux/mainflux/internal/clients/redis"
@@ -14,9 +13,8 @@ import (
 )
 
 const (
-	streamID                       = "mainflux.things"
-	streamLen                      = 1000
-	checkUnpublishedEventsInterval = 1 * time.Minute
+	streamID  = "mainflux.things"
+	streamLen = 1000
 )
 
 var _ groups.Service = (*eventStore)(nil)

--- a/things/groups/redis/streams.go
+++ b/things/groups/redis/streams.go
@@ -5,6 +5,7 @@ package redis
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -24,6 +25,7 @@ type eventStore struct {
 	svc               groups.Service
 	client            *redis.Client
 	unpublishedEvents []*redis.XAddArgs
+	mu                sync.Mutex
 }
 
 // NewEventStoreMiddleware returns wrapper around things service that sends
@@ -182,11 +184,13 @@ func (es *eventStore) startPublishingRoutine(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := es.checkRedisConnection(ctx); err == nil {
+				es.mu.Lock()
 				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
 					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
 						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
 					}
 				}
+				es.mu.Unlock()
 			}
 		case <-ctx.Done():
 			return

--- a/things/policies/redis/events.go
+++ b/things/policies/redis/events.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mainflux/mainflux/internal/clients/redis"
 	"github.com/mainflux/mainflux/things/policies"
 )
 
@@ -19,14 +20,10 @@ const (
 	policyDelete = policyPrefix + "delete"
 )
 
-type event interface {
-	Encode() (map[string]interface{}, error)
-}
-
 var (
-	_ event = (*policyEvent)(nil)
-	_ event = (*authorizeEvent)(nil)
-	_ event = (*listPoliciesEvent)(nil)
+	_ redis.Event = (*policyEvent)(nil)
+	_ redis.Event = (*authorizeEvent)(nil)
+	_ redis.Event = (*listPoliciesEvent)(nil)
 )
 
 type policyEvent struct {

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -5,7 +5,6 @@ package redis
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 	mfredis "github.com/mainflux/mainflux/internal/clients/redis"
@@ -13,9 +12,8 @@ import (
 )
 
 const (
-	streamID                       = "mainflux.things"
-	streamLen                      = 1000
-	checkUnpublishedEventsInterval = 1 * time.Minute
+	streamID  = "mainflux.things"
+	streamLen = 1000
 )
 
 var _ policies.Service = (*eventStore)(nil)

--- a/things/policies/redis/streams.go
+++ b/things/policies/redis/streams.go
@@ -5,6 +5,7 @@ package redis
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -23,6 +24,7 @@ type eventStore struct {
 	svc               policies.Service
 	client            *redis.Client
 	unpublishedEvents []*redis.XAddArgs
+	mu                sync.Mutex
 }
 
 // NewEventStoreMiddleware returns wrapper around policy service that sends
@@ -147,11 +149,13 @@ func (es *eventStore) startPublishingRoutine(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := es.checkRedisConnection(ctx); err == nil {
+				es.mu.Lock()
 				for i := len(es.unpublishedEvents) - 1; i >= 0; i-- {
 					if err := es.client.XAdd(ctx, es.unpublishedEvents[i]).Err(); err == nil {
 						es.unpublishedEvents = append(es.unpublishedEvents[:i], es.unpublishedEvents[i+1:]...)
 					}
 				}
+				es.mu.Unlock()
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
### What does this do?
I have introduced a mechanism for storing unpublished events and implementing retries. We use memory to save unpublished events when the Redis server is unavailable. Then, we periodically attempt to publish the stored events when the Redis server becomes available again.

1. When an event needs to be published, check if the Redis server is reachable. Added a `100ms` timeout so stop retrying to connect to Redis when it is down
2. If the Redis server is reachable, publish the event.
3. If the Redis server is unreachable, store the event in memory using slice.
4. Periodically check the connection to the Redis server, after every minute, and retry publishing the stored events when the connection is re-established.
5. Once an event is successfully published, remove it from memory.

### Which issue(s) does this PR fix/relate to?
Resolves #703 

### List any changes that modify/break current functionality
added `100ms` timeout to check if Redis is reachable

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
Tested by pausing the `es-redis` container and resuming it after doing some operations using the `e2e` tool.