### PR TITLE
NOISSUE - Fix Length of Arguments Required on Assigning Members To a Group

### DIFF
--- a/cli/groups.go
+++ b/cli/groups.go
@@ -171,7 +171,7 @@ var cmdGroups = []cobra.Command{
 			"Usage:\n" +
 			"\tmainflux-cli groups unassign <member_id> <group_id> $USERTOKEN\n",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 4 {
+			if len(args) != 3 {
 				logUsage(cmd.Use)
 				return
 			}


### PR DESCRIPTION
### What does this do?
Fixes the length of arguments required on assigning members to a group

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A