### PR TITLE
NOISSUE - Copy SSL Certs From Alpine on Building `docker_dev` Images

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,5 @@
 FROM scratch
 ARG SVC
 COPY mainflux-$SVC /exe
+COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/exe"]


### PR DESCRIPTION
### What does this do?
It copies SSL certificate from tthe alpine docker image when creating the mainflux `docker_dev` images
We have 3 options:
- ignore the error and leave it as it is
- copy certificates from local machines. This has a challenge as the certificates are stored in different paths from Windows to Unix
- copy certificates from a light weight docker image. This is the approach I used

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
There are no changes that modify the functionality

### Have you included tests for your changes?
No tests as it is a docker file change

### Did you document any new/modified functionality?
No documentation

### Notes
Before with the error
```bash
{"level":"info","message":"Successfully connected to auth grpc server without TLS","ts":"2023-06-30T12:10:42.60905563Z"}
{"level":"info","message":"things-policies service http server listening at :9000 without TLS","ts":"2023-06-30T12:10:42.642514384Z"}
{"level":"info","message":"things service gRPC server listening at :7000 without TLS","ts":"2023-06-30T12:10:42.646643585Z"}
{"level":"warn","message":"failed to obtain service public IP address for sending Mainflux usage telemetry with error: Get \"https://checkip.amazonaws.com/\": tls: failed to verify certificate: x509: certificate signed by unknown authority","ts":"2023-06-30T12:10:42.965893551Z"}
{"level":"warn","message":"failed to obtain service public IP address for sending Mainflux usage telemetry with error: Get \"https://ipinfo.io/ip\": tls: failed to verify certificate: x509: certificate signed by unknown authority","ts":"2023-06-30T12:10:42.997615834Z"}
{"level":"warn","message":"failed to obtain service public IP address for sending Mainflux usage telemetry with error: Get \"https://api.ipify.org/\": tls: failed to verify certificate: x509: certificate signed by unknown authority","ts":"2023-06-30T12:10:44.972303728Z"}
```

After fixing the error
```
{"level":"info","message":"Successfully connected to auth grpc server without TLS","ts":"2023-06-30T12:41:06.66898252Z"}
{"level":"info","message":"things-policies service http server listening at :9000 without TLS","ts":"2023-06-30T12:41:06.670221731Z"}
{"level":"info","message":"things service gRPC server listening at :7000 without TLS","ts":"2023-06-30T12:41:06.67043923Z"}
```