### PR TITLE
NOISSUE - Fix List Users Shared With Me and Mine

### DIFF
--- a/users/clients/postgres/clients.go
+++ b/users/clients/postgres/clients.go
@@ -439,7 +439,7 @@ func pageQuery(pm mfclients.Page) (string, error) {
 
 	// For listing clients that the specified client owns and that are shared with the specified client
 	if pm.Owner != "" && pm.SharedBy != "" {
-		query = append(query, "(c.owner_id = :owner_id OR EXISTS (SELECT 1 FROM policies WHERE subject = :shared_by AND :action=ANY(actions) AND object = policies.object))")
+		query = append(query, "(c.owner_id = :owner_id OR (policies.object IN (SELECT object FROM policies WHERE subject = :shared_by AND :action=ANY(actions))))")
 	}
 	// For listing clients that the specified client is shared with
 	if pm.SharedBy != "" && pm.Owner == "" {


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?
FIxes listing users that have been shared with me and that are mine i.e list users with `?visibility=all`

### Which issue(s) does this PR fix/relate to?
No issue. It is a bug fix

### List any changes that modify/break current functionality
Listing all users previously listed all users
```bash
curl "http://localhost/users?visibility=all" -H Authorization:\ Bearer\ $USER2TOKEN
{
  "limit": 10,
  "total": 2,
  "users": [
    {
      "id": "4fd33d6a-c784-44f1-97aa-9784871cd62d",
      "name": "admin",
      "credentials": { "identity": "admin@example.com", "secret": "" },
      "metadata": { "role": "admin" },
      "created_at": "2023-07-04T07:58:12.448654Z",
      "updated_at": "0001-01-01T00:00:00Z",
      "status": "enabled"
    }, 
    {
      "id": "e5e140c8-8aa0-4aea-a1c5-5c8178505eb9",
      "name": "a",
      "owner": "4fd33d6a-c784-44f1-97aa-9784871cd62d",
      "credentials": { "identity": "a@example.com", "secret": "" },
      "created_at": "2023-07-04T09:31:16.861607Z",
      "updated_at": "0001-01-01T00:00:00Z",
      "status": "enabled"
    }
  ]
}

```

instead of listing only shared users and users that are mine

```bash
curl "http://localhost/users?visibility=all" -H Authorization:\ Bearer\ $USER2TOKEN
{
  "limit": 10,
  "total": 1,
  "users": [
    {
      "id": "e5e140c8-8aa0-4aea-a1c5-5c8178505eb9",
      "name": "a",
      "owner": "4fd33d6a-c784-44f1-97aa-9784871cd62d",
      "credentials": { "identity": "a@example.com", "secret": "" },
      "created_at": "2023-07-04T09:31:16.861607Z",
      "updated_at": "0001-01-01T00:00:00Z",
      "status": "enabled"
    }
  ]
}
```
### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes

Steps to reproduce it are:
1. Create 2 users
2. Create 1 group
3. Add the 2 users to the group with `c_list` properties
4. Try listing users when you are user 2 or user 1

To be merged after https://github.com/mainflux/mainflux/pull/1843