### PR TITLE
NOISSUE - Add List Actions

### DIFF
--- a/users/policies/policies.go
+++ b/users/policies/policies.go
@@ -5,6 +5,7 @@ package policies
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/mainflux/mainflux/internal/apiutil"
@@ -159,4 +160,51 @@ func ValidateAction(act string) bool {
 	}
 	return false
 
+}
+
+// addListAction adds list actions to the actions slice if c_ or g_ actions are present.
+//
+// 1. If c_<anything> actions are present, add c_list and g_list actions to the actions slice.
+//
+// 2. If g_<anything> actions are present, add g_list action to the actions slice.
+func addListAction(actions []string) []string {
+	hasCAction := false
+	hasGAction := false
+
+	for _, action := range actions {
+		if strings.HasPrefix(action, "c_") {
+			hasCAction = true
+		}
+		if strings.HasPrefix(action, "g_") {
+			hasGAction = true
+		}
+	}
+
+	updatedActions := make([]string, 0)
+
+	updatedActions = append(updatedActions, actions...)
+
+	if hasCAction {
+		updatedActions = append(updatedActions, "c_list", "g_list")
+	}
+
+	if hasGAction {
+		updatedActions = append(updatedActions, "g_list")
+	}
+
+	return removeDuplicates(updatedActions)
+}
+
+func removeDuplicates(slice []string) []string {
+	unique := make(map[string]bool)
+	result := make([]string, 0, len(slice))
+
+	for _, item := range slice {
+		if !unique[item] {
+			unique[item] = true
+			result = append(result, item)
+		}
+	}
+
+	return result
 }

--- a/users/policies/service.go
+++ b/users/policies/service.go
@@ -64,6 +64,7 @@ func (svc service) AddPolicy(ctx context.Context, token string, p Policy) error 
 	if err := p.Validate(); err != nil {
 		return err
 	}
+	p.Actions = addListAction(p.Actions)
 
 	p.OwnerID = id
 	p.CreatedAt = time.Now()

--- a/users/policies/service_test.go
+++ b/users/policies/service_test.go
@@ -85,6 +85,50 @@ func TestAddPolicy(t *testing.T) {
 			token: testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), csvc, cRepo, phasher),
 		},
 		{
+			desc: "add a new policy with c_update action",
+			page: policies.PolicyPage{},
+			policy: policies.Policy{
+				Subject: testsutil.GenerateUUID(t, idProvider),
+				Object:  testsutil.GenerateUUID(t, idProvider),
+				Actions: []string{"c_update"},
+			},
+			err:   nil,
+			token: testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), csvc, cRepo, phasher),
+		},
+		{
+			desc: "add a new policy with c_update and c_list action",
+			page: policies.PolicyPage{},
+			policy: policies.Policy{
+				Subject: testsutil.GenerateUUID(t, idProvider),
+				Object:  testsutil.GenerateUUID(t, idProvider),
+				Actions: []string{"c_update", "c_list"},
+			},
+			err:   nil,
+			token: testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), csvc, cRepo, phasher),
+		},
+		{
+			desc: "add a new policy with g_update action",
+			page: policies.PolicyPage{},
+			policy: policies.Policy{
+				Subject: testsutil.GenerateUUID(t, idProvider),
+				Object:  testsutil.GenerateUUID(t, idProvider),
+				Actions: []string{"g_update"},
+			},
+			err:   nil,
+			token: testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), csvc, cRepo, phasher),
+		},
+		{
+			desc: "add a new policy with g_update and g_list action",
+			page: policies.PolicyPage{},
+			policy: policies.Policy{
+				Subject: testsutil.GenerateUUID(t, idProvider),
+				Object:  testsutil.GenerateUUID(t, idProvider),
+				Actions: []string{"g_update", "g_list"},
+			},
+			err:   nil,
+			token: testsutil.GenerateValidToken(t, testsutil.GenerateUUID(t, idProvider), csvc, cRepo, phasher),
+		},
+		{
 			desc: "add a new policy with more actions",
 			page: policies.PolicyPage{},
 			policy: policies.Policy{


### PR DESCRIPTION
### What does this do?
When adding actions additionally add listing action
c_<anything> includes c_list and g_list
g_<anything> includes g_list

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Add list actions together with other actions if not provided

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
Steps to reproduce this 
1. Create 2 users `a` and `b` and group `a`
2. Add users `a` and `b` to that group with the `c_update` action
3. List users with user `a` token with visibility option set as shared.