### PR TITLE
NOISSUE - CLI: Errors to StdErr and others to StdOut

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -51,38 +52,38 @@ func logJSON(iList ...interface{}) {
 			return
 		}
 
-		fmt.Printf("\n%s\n\n", string(pj))
+		fmt.Fprintf(os.Stdout, "\n%s\n\n", string(pj))
 	}
 }
 
 func logUsage(u string) {
-	fmt.Printf(color.YellowString("\nusage: %s\n\n"), u)
+	fmt.Fprintf(os.Stdout, color.YellowString("\nusage: %s\n\n"), u)
 }
 
 func logError(err error) {
 	boldRed := color.New(color.FgRed, color.Bold)
-	boldRed.Print("\nerror: ")
+	boldRed.Fprintf(os.Stderr, "\nerror: ")
 
-	fmt.Printf("%s\n\n", color.RedString(err.Error()))
+	fmt.Fprintf(os.Stderr, "%s\n\n", color.RedString(err.Error()))
 }
 
 func logOK() {
-	fmt.Printf("\n%s\n\n", color.BlueString("ok"))
+	fmt.Fprintf(os.Stdout, "\n%s\n\n", color.BlueString("ok"))
 }
 
 func logCreated(e string) {
 	if RawOutput {
-		fmt.Println(e)
+		fmt.Fprintln(os.Stdout, e)
 	} else {
-		fmt.Printf(color.BlueString("\ncreated: %s\n\n"), e)
+		fmt.Fprintf(os.Stdout, color.BlueString("\ncreated: %s\n\n"), e)
 	}
 }
 
 func logRevokedTime(t time.Time) {
 	if RawOutput {
-		fmt.Println(t)
+		fmt.Fprintln(os.Stdout, t)
 	} else {
-		fmt.Printf(color.BlueString("\nrevoked: %v\n\n"), t)
+		fmt.Fprintf(os.Stdout, color.BlueString("\nrevoked: %v\n\n"), t)
 	}
 }
 


### PR DESCRIPTION
Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?
 - send cli errors to stderr
 
 #### Details : 
 

 In CLI errors are not coming through stderr , instead it comes in stdout 
To Duplicate the issue
```bash 
$ ./build/mainflux-cli users get all invalid_token 2>  error_file
error: Status: Unauthorized: failed to perform authentication over the entity
```
In the above command you will find empty file with name `error_file`

But if you try the below command 
```bash
$ ./build/mainflux-cli users get all invalid_token 1> error_file
```
You will see the output in `error_file`

Ideally all the errors should sends to `stderr`

This shows error are throwing stdout   

### Which issue(s) does this PR fix/relate to?
Put here `Resolves #XXX` to auto-close the issue that your PR fixes (if such)

### List any changes that modify/break current functionality


### Have you included tests for your changes?

### Did you document any new/modified functionality?


### Notes
