### PR TITLE
NOISSUE - SDK : Handling non JSON error messages from service 

### DIFF
--- a/pkg/sdk/go/message_test.go
+++ b/pkg/sdk/go/message_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const eof = "EOF"
-
 func newMessageService(cc policies.AuthServiceClient) adapter.Service {
 	pub := mocks.NewPublisher()
 
@@ -72,7 +70,7 @@ func TestSendMessage(t *testing.T) {
 			chanID: chanID,
 			msg:    msg,
 			auth:   invalidToken,
-			err:    errors.NewSDKErrorWithStatus(errors.New(eof), http.StatusUnauthorized),
+			err:    errors.NewSDKErrorWithStatus(errors.New(""), http.StatusUnauthorized),
 		},
 		"publish message with wrong content type": {
 			chanID: chanID,
@@ -90,7 +88,7 @@ func TestSendMessage(t *testing.T) {
 			chanID: chanID,
 			msg:    msg,
 			auth:   "invalid-token",
-			err:    errors.NewSDKErrorWithStatus(errors.New(eof), http.StatusUnauthorized),
+			err:    errors.NewSDKErrorWithStatus(errors.New(""), http.StatusUnauthorized),
 		},
 	}
 	for desc, tc := range cases {


### PR DESCRIPTION
Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?
 - SDK handles non JSON error messages from service
 Details : Services will respond non JSON messages , For Example, when we try to access the endpoint like http://localhost/things/not/found/endpoint, we will get response 404 Not Found 
 Like this kind of URL used then SDK can't able handle and returns JSON unmarshal error
 
 #### Example :
 In CLI we use to get these kind of error
 ```bash
$ mainflux-cli users token $username $password -u http://localhost/users 
error: Status: Not Found: json: cannot unmarshal number into Go value of type map[string]interface {}
```
#### Actual response of invalid URL is 
![image](https://github.com/mainflux/mainflux/assets/30824765/a4f88184-855f-4024-af93-1052b4f1fc81)


**This PR handle these kind of non JSON error message from service, 
It will provide information for  non JSON error message**
```bash
$ mainflux-cli users token $username $password -u http://localhost/users 
error: Status: Not Found: 404 page not found
```


### Which issue(s) does this PR fix/relate to?
Put here `Resolves #XXX` to auto-close the issue that your PR fixes (if such)

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
