### PR TITLE
NOISSUE - Return Authentication Error on Identify

### DIFF
--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -590,7 +590,7 @@ func TestListThingsByChannel(t *testing.T) {
 			channelID: testsutil.GenerateUUID(t, idProvider),
 			page:      sdk.PageMetadata{},
 			response:  []sdk.Thing(nil),
-			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:      "list things with an invalid id",
@@ -660,7 +660,7 @@ func TestThing(t *testing.T) {
 			response: sdk.Thing{},
 			token:    invalidToken,
 			thingID:  generateUUID(t),
-			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "view thing with valid token and invalid thing id",
@@ -674,7 +674,7 @@ func TestThing(t *testing.T) {
 			response: sdk.Thing{},
 			token:    invalidToken,
 			thingID:  mocks.WrongID,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 	}
 
@@ -746,7 +746,7 @@ func TestUpdateThing(t *testing.T) {
 			thing:    thing1,
 			response: sdk.Thing{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update thing name with invalid id",
@@ -838,7 +838,7 @@ func TestUpdateThingTags(t *testing.T) {
 			thing:    thing1,
 			response: sdk.Thing{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update thing name with invalid id",
@@ -923,7 +923,7 @@ func TestUpdateThingSecret(t *testing.T) {
 			newSecret: "newPassword",
 			token:     "non-existent",
 			response:  sdk.Thing{},
-			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:       errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:      "update thing secret with wrong old secret",
@@ -1001,7 +1001,7 @@ func TestUpdateThingOwner(t *testing.T) {
 			thing:    thing2,
 			response: sdk.Thing{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthorization, http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(errors.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update thing name with invalid id",

--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -294,7 +294,7 @@ func (svc service) identify(ctx context.Context, token string) (string, error) {
 	req := &upolicies.IdentifyReq{Token: token}
 	res, err := svc.uauth.Identify(ctx, req)
 	if err != nil {
-		return "", errors.Wrap(errors.ErrAuthorization, err)
+		return "", errors.Wrap(errors.ErrAuthentication, err)
 	}
 	return res.GetId(), nil
 }

--- a/things/clients/service_test.go
+++ b/things/clients/service_test.go
@@ -284,7 +284,7 @@ func TestViewClient(t *testing.T) {
 			response: mfclients.Client{},
 			token:    inValidToken,
 			clientID: "",
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 		{
 			desc:     "view client with valid token and invalid client id",
@@ -298,7 +298,7 @@ func TestViewClient(t *testing.T) {
 			response: mfclients.Client{},
 			token:    inValidToken,
 			clientID: mocks.WrongID,
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 	}
 
@@ -616,7 +616,7 @@ func TestUpdateClient(t *testing.T) {
 			client:   client1,
 			response: mfclients.Client{},
 			token:    "non-existent",
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 		{
 			desc: "update client name with invalid ID",
@@ -625,8 +625,8 @@ func TestUpdateClient(t *testing.T) {
 				Name: "Updated Client",
 			},
 			response: mfclients.Client{},
-			token:    "non-existent",
-			err:      errors.ErrAuthorization,
+			token:    token,
+			err:      errors.ErrNotFound,
 		},
 		{
 			desc:     "update client metadata with valid token",
@@ -640,7 +640,7 @@ func TestUpdateClient(t *testing.T) {
 			client:   client2,
 			response: mfclients.Client{},
 			token:    "non-existent",
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 	}
 
@@ -681,7 +681,7 @@ func TestUpdateClientTags(t *testing.T) {
 			client:   client,
 			token:    "non-existent",
 			response: mfclients.Client{},
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 		{
 			desc: "update client name with invalid ID",
@@ -690,8 +690,8 @@ func TestUpdateClientTags(t *testing.T) {
 				Name: "Updated name",
 			},
 			response: mfclients.Client{},
-			token:    "non-existent",
-			err:      errors.ErrAuthorization,
+			token:    token,
+			err:      errors.ErrNotFound,
 		},
 	}
 
@@ -732,7 +732,7 @@ func TestUpdateClientOwner(t *testing.T) {
 			client:   client,
 			token:    "non-existent",
 			response: mfclients.Client{},
-			err:      errors.ErrAuthorization,
+			err:      errors.ErrAuthentication,
 		},
 		{
 			desc: "update client owner with invalid ID",
@@ -741,8 +741,8 @@ func TestUpdateClientOwner(t *testing.T) {
 				Owner: "updatedowner@mail.com",
 			},
 			response: mfclients.Client{},
-			token:    "non-existent",
-			err:      errors.ErrAuthorization,
+			token:    token,
+			err:      errors.ErrNotFound,
 		},
 	}
 
@@ -784,7 +784,7 @@ func TestUpdateClientSecret(t *testing.T) {
 			newSecret: "newPassword",
 			token:     "non-existent",
 			response:  mfclients.Client{},
-			err:       errors.ErrAuthorization,
+			err:       errors.ErrAuthentication,
 		},
 	}
 


### PR DESCRIPTION
### What does this do?
Wraps authentication error rather than authorization error on users identify grpc call

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Returns authentication error rather than authorization error on Identify method

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A