### PR TITLE
MF - 1875 - Fix Listing Clients With Visibility

### DIFF
--- a/things/clients/service.go
+++ b/things/clients/service.go
@@ -103,13 +103,18 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 	// If the user is admin, fetch all things from database.
 	case nil:
 		switch {
+		// visibility = all
 		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = ""
 			pm.Owner = ""
+		// visibility = shared
 		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = userID
+			pm.Owner = ""
+		// visibility = mine
 		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = userID
+			pm.SharedBy = ""
 		}
 
 	default:
@@ -117,13 +122,18 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 		// If user provides 'sharedby' key, fetch things from policies. Otherwise,
 		// fetch things from the database based on thing's 'owner' field.
 		switch {
+		// visibility = all
 		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = userID
+			pm.Owner = userID
+		// visibility = shared
 		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = userID
 			pm.Owner = ""
+		// visibility = mine
 		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = userID
+			pm.SharedBy = ""
 		default:
 			pm.Owner = userID
 		}

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -170,25 +170,35 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 	// If the user is admin, fetch all users from database.
 	case nil:
 		switch {
+		// visibility = all
 		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = ""
 			pm.Owner = ""
+		// visibility = shared
 		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = id
+			pm.Owner = ""
+		// visibility = mine
 		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = id
+			pm.SharedBy = ""
 		}
 
 	// If the user is not admin, fetch users that they own or are shared with them.
 	default:
 		switch {
+		// visibility = all
 		case pm.SharedBy == myKey && pm.Owner == myKey:
 			pm.SharedBy = id
+			pm.Owner = id
+		// visibility = shared
 		case pm.SharedBy == myKey && pm.Owner != myKey:
 			pm.SharedBy = id
 			pm.Owner = ""
+		// visibility = mine
 		case pm.Owner == myKey && pm.SharedBy != myKey:
 			pm.Owner = id
+			pm.SharedBy = ""
 		default:
 			pm.Owner = id
 		}


### PR DESCRIPTION
### What does this do?
When listing clients with visibility set to all, include ownerID as the repository layer does an OR operation rather than an AND operation as compared to other joins

### Which issue(s) does this PR fix/relate to?
Resolves #1875 

### List any changes that modify/break current functionality
Fixes a bug when you list clients with visibility query parameter set to all include both clients you own and clients that are shared with you

### Have you included tests for your changes?
Manually test by [![asciicast](https://asciinema.org/a/zQ4BhZLJK0qDStkpbDqlHujKp.svg)](https://asciinema.org/a/zQ4BhZLJK0qDStkpbDqlHujKp)

### Did you document any new/modified functionality?
No

### Notes
N/A