### PR TITLE
MF - 1869 - Fix List Group Members Not To Include Owned Things

### DIFF
--- a/things/clients/postgres/clients.go
+++ b/things/clients/postgres/clients.go
@@ -167,7 +167,8 @@ func (repo clientRepo) Members(ctx context.Context, groupID string, pm mfclients
 	aq := ""
 	// If not admin, the client needs to have a g_list action on the group or they are the owner.
 	if pm.Subject != "" {
-		aq = `AND EXISTS (SELECT 1 FROM policies WHERE policies.subject = :subject AND policies.object = :group_id AND :action=ANY(actions)) OR c.owner_id = :subject`
+		aq = `AND (EXISTS (SELECT 1 FROM policies p WHERE p.subject = :subject AND :action=ANY(actions)) 
+				OR EXISTS (SELECT 1 FROM groups g WHERE g.owner_id = :subject AND g.id = :group_id))`
 	}
 
 	q := fmt.Sprintf(`SELECT c.id, c.name, c.tags, c.metadata, c.identity, c.secret, c.status, c.created_at FROM clients c

--- a/users/clients/postgres/clients_test.go
+++ b/users/clients/postgres/clients_test.go
@@ -586,7 +586,7 @@ func TestGroupsMembers(t *testing.T) {
 		mp, err := crepo.Members(context.Background(), tc.ID, mfclients.Page{Total: 10, Offset: 0, Limit: 10, Status: mfclients.AllStatus, Subject: clientB.ID, Action: "g_list"})
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 		if tc.ID == group.ID {
-			assert.ElementsMatch(t, mp.Members, []mfclients.Client{clientA, clientB}, fmt.Sprintf("%s: expected %v got %v\n", desc, []mfclients.Client{clientA, clientB}, mp.Members))
+			assert.ElementsMatch(t, mp.Members, []mfclients.Client{clientA}, fmt.Sprintf("%s: expected %v got %v\n", desc, []mfclients.Client{clientA, clientB}, mp.Members))
 		}
 	}
 }

--- a/users/clients/service.go
+++ b/users/clients/service.go
@@ -199,14 +199,6 @@ func (svc service) ListClients(ctx context.Context, token string, pm mfclients.P
 	if err != nil {
 		return mfclients.ClientsPage{}, err
 	}
-	for i, client := range clients.Clients {
-		if client.ID == id {
-			clients.Clients = append(clients.Clients[:i], clients.Clients[i+1:]...)
-			if clients.Total != 0 {
-				clients.Total--
-			}
-		}
-	}
 
 	return clients, nil
 }


### PR DESCRIPTION
### What does this do?
When doing a list of group members, we initially included the owner subquery that inherently lists clients you are shared with and also clients that you own, rather than listing clients that are shared with you or listing clients of that group if you own that group. Hence you can list members of a group which you own but you haven't assigned yourself or the admin hasn't assigned you a list action on that group.

### Which issue(s) does this PR fix/relate to?
Resolves #1869  

### List any changes that modify/break current functionality
- when listing members of a group not to include members you own but rather members that are in that group
- move the check of not listing yourself to the repository as it interferes with offset and limit parameters when you are included in the range.

### Have you included tests for your changes?
I have modified existing tests

### Did you document any new/modified functionality?
No

### Notes
The code to check this can be found here https://gist.github.com/rodneyosodo/ab16db8a7dd175c82024ad5760b89cac
