### PR TITLE
NOISSUE- update health method in SDK

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,7 @@ make cli
 
 ### Service
 
-#### Get Mainflux services Health Check
+#### Get Mainflux Services Health Check
 
 ```bash
 mainflux-cli health <service>

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,10 +12,10 @@ make cli
 
 ### Service
 
-#### Get Mainflux Things services Health Check
+#### Get Mainflux services Health Check
 
 ```bash
-mainflux-cli health
+mainflux-cli health <service>
 ```
 
 ### Users management
@@ -90,8 +90,8 @@ mainflux-cli things create '{"name":"myThing", "metadata": {"key1":"value1"}}' <
 mainflux-cli provision things <file> <user_token>
 ```
 
-* `file` - A CSV or JSON file containing thing names (must have extension `.csv` or `.json`)
-* `user_token` - A valid user auth token for the current system
+- `file` - A CSV or JSON file containing thing names (must have extension `.csv` or `.json`)
+- `user_token` - A valid user auth token for the current system
 
 An example CSV file might be:
 
@@ -106,22 +106,23 @@ in which the first column is the thing's name.
 A comparable JSON file would be
 
 ```json
-[{
-        "name": "<thing1_name>",
-        "status": "enabled"
-    },
-    {
-        "name": "<thing2_name>",
-        "status": "disabled"
-    }, {
-
-        "name": "<thing3_name>",
-        "status": "enabled",
-        "credentials": {
-            "identity": "<thing3_identity>",
-            "secret": "<thing3_secret>"
-        }
+[
+  {
+    "name": "<thing1_name>",
+    "status": "enabled"
+  },
+  {
+    "name": "<thing2_name>",
+    "status": "disabled"
+  },
+  {
+    "name": "<thing3_name>",
+    "status": "enabled",
+    "credentials": {
+      "identity": "<thing3_identity>",
+      "secret": "<thing3_secret>"
     }
+  }
 ]
 ```
 
@@ -181,8 +182,8 @@ mainflux-cli channels create '{"name":"myChannel"}' <user_token>
 mainflux-cli provision channels <file> <user_token>
 ```
 
-* `file` - A CSV or JSON file containing channel names (must have extension `.csv` or `.json`)
-* `user_token` - A valid user auth token for the current system
+- `file` - A CSV or JSON file containing channel names (must have extension `.csv` or `.json`)
+- `user_token` - A valid user auth token for the current system
 
 An example CSV file might be:
 
@@ -197,21 +198,22 @@ in which the first column is channel names.
 A comparable JSON file would be
 
 ```json
-[{
-        "name": "<channel1_name>",
-        "description": "<channel1_description>",
-        "status": "enabled"
-    },
-    {
-        "name": "<channel2_name>",
-        "description": "<channel2_description>",
-        "status": "disabled"
-    }, {
-
-        "name": "<channel3_name>",
-        "description": "<channel3_description>",
-        "status": "enabled"
-    }
+[
+  {
+    "name": "<channel1_name>",
+    "description": "<channel1_description>",
+    "status": "enabled"
+  },
+  {
+    "name": "<channel2_name>",
+    "description": "<channel2_description>",
+    "status": "disabled"
+  },
+  {
+    "name": "<channel3_name>",
+    "description": "<channel3_description>",
+    "status": "enabled"
+  }
 ]
 ```
 
@@ -267,8 +269,8 @@ mainflux-cli things connect <thing_id> <channel_id> <user_token>
 mainflux-cli provision connect <file> <user_token>
 ```
 
-* `file` - A CSV or JSON file containing thing and channel ids (must have extension `.csv` or `.json`)
-* `user_token` - A valid user auth token for the current system
+- `file` - A CSV or JSON file containing thing and channel ids (must have extension `.csv` or `.json`)
+- `user_token` - A valid user auth token for the current system
 
 An example CSV file might be
 
@@ -277,20 +279,14 @@ An example CSV file might be
 <thing_id2>,<channel_id2>
 ```
 
-in which the first column is thing IDs and the second column is channel IDs.  A connection will be created for each thing to each channel.  This example would result in 4 connections being created.
+in which the first column is thing IDs and the second column is channel IDs. A connection will be created for each thing to each channel. This example would result in 4 connections being created.
 
 A comparable JSON file would be
 
 ```json
 {
-    "client_ids": [
-        "<thing_id1>",
-        "<thing_id2>"
-    ],
-    "group_ids": [
-        "<channel_id1>",
-        "<channel_id2>"
-    ]
+  "client_ids": ["<thing_id1>", "<thing_id2>"],
+  "group_ids": ["<channel_id1>", "<channel_id2>"]
 }
 ```
 

--- a/cli/health.go
+++ b/cli/health.go
@@ -8,11 +8,17 @@ import "github.com/spf13/cobra"
 // NewHealthCmd returns health check command.
 func NewHealthCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "health",
+		Use:   "health <service>",
 		Short: "Health Check",
-		Long:  `Mainflux Things service Health Check`,
-		Run: func(_ *cobra.Command, _ []string) {
-			v, err := sdk.Health()
+		Long: "Mainflux service Health Check\n" +
+			"usage:\n" +
+			"\tmainflux-cli health <service>",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				logUsage(cmd.Use)
+				return
+			}
+			v, err := sdk.Health(args[0])
 			if err != nil {
 				logError(err)
 				return

--- a/pkg/sdk/go/health.go
+++ b/pkg/sdk/go/health.go
@@ -36,7 +36,7 @@ func (sdk mfSDK) Health(service string) (HealthInfo, errors.SDKError) {
 		url = fmt.Sprintf("%s/health", sdk.thingsURL)
 	case "users":
 		url = fmt.Sprintf("%s/health", sdk.usersURL)
-	case "boostrap":
+	case "bootstrap":
 		url = fmt.Sprintf("%s/health", sdk.bootstrapURL)
 	}
 

--- a/pkg/sdk/go/health.go
+++ b/pkg/sdk/go/health.go
@@ -29,8 +29,16 @@ type HealthInfo struct {
 	BuildTime string `json:"build_time"`
 }
 
-func (sdk mfSDK) Health() (HealthInfo, errors.SDKError) {
-	url := fmt.Sprintf("%s/health", sdk.thingsURL)
+func (sdk mfSDK) Health(service string) (HealthInfo, errors.SDKError) {
+	var url string
+	switch service {
+	case "things":
+		url = fmt.Sprintf("%s/health", sdk.thingsURL)
+	case "users":
+		url = fmt.Sprintf("%s/health", sdk.usersURL)
+	case "boostrap":
+		url = fmt.Sprintf("%s/health", sdk.bootstrapURL)
+	}
 
 	resp, err := sdk.client.Get(url)
 	if err != nil {

--- a/pkg/sdk/go/health.go
+++ b/pkg/sdk/go/health.go
@@ -38,6 +38,12 @@ func (sdk mfSDK) Health(service string) (HealthInfo, errors.SDKError) {
 		url = fmt.Sprintf("%s/health", sdk.usersURL)
 	case "bootstrap":
 		url = fmt.Sprintf("%s/health", sdk.bootstrapURL)
+	case "certs":
+		url = fmt.Sprintf("%s/health", sdk.certsURL)
+	case "reader":
+		url = fmt.Sprintf("%s/health", sdk.readerURL)
+	case "http-adapter":
+		url = fmt.Sprintf("%s/health", sdk.httpAdapterURL)
 	}
 
 	resp, err := sdk.client.Get(url)

--- a/pkg/sdk/go/health_test.go
+++ b/pkg/sdk/go/health_test.go
@@ -10,18 +10,16 @@ import (
 	"github.com/mainflux/mainflux"
 	"github.com/mainflux/mainflux/pkg/errors"
 	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
-	"github.com/mainflux/mainflux/things/clients"
+	thingsclients "github.com/mainflux/mainflux/things/clients"
 	"github.com/mainflux/mainflux/things/clients/mocks"
 	gmocks "github.com/mainflux/mainflux/things/groups/mocks"
 	"github.com/mainflux/mainflux/things/policies"
-	pmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	thingspmocks "github.com/mainflux/mainflux/things/policies/mocks"
+	usersclients "github.com/mainflux/mainflux/users/clients"
 	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
+	"github.com/mainflux/mainflux/users/jwt"
+	userspmocks "github.com/mainflux/mainflux/users/policies/mocks"
 	"github.com/stretchr/testify/assert"
-)
-
-const (
-	thingsDescription = "things service"
-	thingsStatus      = "pass"
 )
 
 func TestHealth(t *testing.T) {
@@ -29,38 +27,58 @@ func TestHealth(t *testing.T) {
 	gRepo := new(gmocks.Repository)
 	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
 	thingCache := mocks.NewCache()
-	policiesCache := pmocks.NewCache()
+	policiesCache := thingspmocks.NewCache()
+	tokenizer := jwt.NewRepository([]byte(secret), accessDuration, refreshDuration)
 
-	pRepo := new(pmocks.Repository)
-	psvc := policies.NewService(uauth, pRepo, policiesCache, idProvider)
+	thingsPRepo := new(thingspmocks.Repository)
+	psvc := policies.NewService(uauth, thingsPRepo, policiesCache, idProvider)
 
-	svc := clients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
-	ts := newThingsServer(svc, psvc)
-	defer ts.Close()
+	thSvc := thingsclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	ths := newThingsServer(thSvc, psvc)
+	defer ths.Close()
+
+	usersPRepo := new(userspmocks.Repository)
+	usSvc := usersclients.NewService(cRepo, usersPRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	usClSv := newClientServer(usSvc)
+	defer usClSv.Close()
 
 	sdkConf := sdk.Config{
-		ThingsURL:       ts.URL,
+		ThingsURL:       ths.URL,
+		UsersURL:        usClSv.URL,
 		MsgContentType:  contentType,
 		TLSVerification: false,
 	}
 
 	mfsdk := sdk.NewSDK(sdkConf)
 	cases := map[string]struct {
-		empty bool
-		err   errors.SDKError
+		service     string
+		empty       bool
+		description string
+		status      string
+		err         errors.SDKError
 	}{
 		"get things service health check": {
-			empty: false,
-			err:   nil,
+			service:     "things",
+			empty:       false,
+			err:         nil,
+			description: "things service",
+			status:      "pass",
+		},
+		"get users service health check": {
+			service:     "users",
+			empty:       false,
+			err:         nil,
+			description: "users service",
+			status:      "pass",
 		},
 	}
 	for desc, tc := range cases {
-		h, err := mfsdk.Health()
+		h, err := mfsdk.Health(tc.service)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", desc, tc.err, err))
-		assert.Equal(t, thingsStatus, h.Status, fmt.Sprintf("%s: expected %s status, got %s", desc, thingsStatus, h.Status))
+		assert.Equal(t, tc.status, h.Status, fmt.Sprintf("%s: expected %s status, got %s", desc, tc.status, h.Status))
 		assert.Equal(t, tc.empty, h.Version == "", fmt.Sprintf("%s: expected non-empty version", desc))
 		assert.Equal(t, mainflux.Commit, h.Commit, fmt.Sprintf("%s: expected non-empty commit", desc))
-		assert.Equal(t, thingsDescription, h.Description, fmt.Sprintf("%s: expected proper description, got %s", desc, h.Description))
+		assert.Equal(t, tc.description, h.Description, fmt.Sprintf("%s: expected proper description, got %s", desc, h.Description))
 		assert.Equal(t, mainflux.BuildTime, h.BuildTime, fmt.Sprintf("%s: expected default epoch date, got %s", desc, h.BuildTime))
 	}
 }

--- a/pkg/sdk/go/health_test.go
+++ b/pkg/sdk/go/health_test.go
@@ -17,7 +17,6 @@ import (
 	thingspmocks "github.com/mainflux/mainflux/things/policies/mocks"
 	usersclients "github.com/mainflux/mainflux/users/clients"
 	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
-	usersclientmock "github.com/mainflux/mainflux/users/clients/mocks"
 	"github.com/mainflux/mainflux/users/jwt"
 	userspmocks "github.com/mainflux/mainflux/users/policies/mocks"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +25,7 @@ import (
 
 func TestHealth(t *testing.T) {
 	thingcRepo := new(thingsclientsmock.Repository)
-	usercRepo := new(usersclientmock.Repository)
+	usercRepo := new(cmocks.Repository)
 	gRepo := new(gmocks.Repository)
 	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
 	thingCache := thingsclientsmock.NewCache()

--- a/pkg/sdk/go/health_test.go
+++ b/pkg/sdk/go/health_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 	sdk "github.com/mainflux/mainflux/pkg/sdk/go"
 	thingsclients "github.com/mainflux/mainflux/things/clients"
-	"github.com/mainflux/mainflux/things/clients/mocks"
+	thingsclientsmock "github.com/mainflux/mainflux/things/clients/mocks"
 	gmocks "github.com/mainflux/mainflux/things/groups/mocks"
 	"github.com/mainflux/mainflux/things/policies"
 	thingspmocks "github.com/mainflux/mainflux/things/policies/mocks"
 	usersclients "github.com/mainflux/mainflux/users/clients"
 	cmocks "github.com/mainflux/mainflux/users/clients/mocks"
+	usersclientmock "github.com/mainflux/mainflux/users/clients/mocks"
 	"github.com/mainflux/mainflux/users/jwt"
 	userspmocks "github.com/mainflux/mainflux/users/policies/mocks"
 	"github.com/stretchr/testify/assert"
@@ -24,22 +25,23 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	cRepo := new(mocks.Repository)
+	thingcRepo := new(thingsclientsmock.Repository)
+	usercRepo := new(usersclientmock.Repository)
 	gRepo := new(gmocks.Repository)
 	uauth := cmocks.NewAuthService(users, map[string][]cmocks.SubjectSet{adminID: {uadminPolicy}})
-	thingCache := mocks.NewCache()
+	thingCache := thingsclientsmock.NewCache()
 	policiesCache := thingspmocks.NewCache()
 	tokenizer := jwt.NewRepository([]byte(secret), accessDuration, refreshDuration)
 
 	thingspRepo := new(thingspmocks.Repository)
 	psvc := policies.NewService(uauth, thingspRepo, policiesCache, idProvider)
 
-	thsvc := thingsclients.NewService(uauth, psvc, cRepo, gRepo, thingCache, idProvider)
+	thsvc := thingsclients.NewService(uauth, psvc, thingcRepo, gRepo, thingCache, idProvider)
 	ths := newThingsServer(thsvc, psvc)
 	defer ths.Close()
 
 	userspRepo := new(userspmocks.Repository)
-	usSvc := usersclients.NewService(cRepo, userspRepo, tokenizer, emailer, phasher, idProvider, passRegex)
+	usSvc := usersclients.NewService(usercRepo, userspRepo, tokenizer, emailer, phasher, idProvider, passRegex)
 	usclsv := newClientServer(usSvc)
 	defer usclsv.Close()
 

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -804,7 +804,7 @@ type SDK interface {
 	//  fmt.Println(err)
 	SetContentType(ct ContentType) errors.SDKError
 
-	// Health returns things service health check.
+	// Health returns service health check.
 	//
 	// example:
 	//  health, _ := sdk.Health("service")

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -807,9 +807,9 @@ type SDK interface {
 	// Health returns things service health check.
 	//
 	// example:
-	//  health, _ := sdk.Health()
+	//  health, _ := sdk.Health("service")
 	//  fmt.Println(health)
-	Health() (HealthInfo, errors.SDKError)
+	Health(service string) (HealthInfo, errors.SDKError)
 
 	// AddBootstrap add bootstrap configuration
 	//


### PR DESCRIPTION

### What does this do?
Updates the health method in the SDK to facilitate retrieving the health of other services
### Which issue(s) does this PR fix/relate to?
None
### List any changes that modify/break current functionality
Instead of getting only the health of things service, we can be able to get the health of users, things, bootstrap, certs,reader, and HTTP-adapter services
### Have you included tests for your changes?
yes
### Did you document any new/modified functionality?
No
### Notes
![image](https://github.com/mainflux/mainflux/assets/100555904/df1e1e2d-cc20-4ce8-b721-36045c9f73a8)
![image](https://github.com/mainflux/mainflux/assets/100555904/6d810891-f17d-4a0e-a236-ea89b2c29c70)
