### PR TITLE
NOISSUE - Convert Docker Project Name to Lowercase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ USER_REPO ?= $(shell git remote get-url origin | sed -e 's/.*\/\([^/]*\)\/\([^/]
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD  2>/dev/null || git describe --tags --abbrev=0  2>/dev/null )
 empty:=
 space:= $(empty) $(empty)
-DOCKER_PROJECT ?= $(shell echo $(subst $(space),,$(USER_REPO)_$(BRANCH)) | tr -c -s '[:alnum:][=-=]' '_')
+DOCKER_PROJECT ?= $(shell echo $(subst $(space),,$(USER_REPO)_$(BRANCH)) | tr -c -s '[:alnum:][=-=]' '_' | tr '[:upper:]' '[:lower:]')
 DOCKER_COMPOSE_COMMANDS_SUPPORTED := up down config
 DEFAULT_DOCKER_COMPOSE_COMMAND  := up
 GRPC_MTLS_CERT_FILES_EXISTS = 0


### PR DESCRIPTION
### What does this do?
Converts docker project name to lowercase in case the branch is in uppercase since most of our branches are `MF-` which is uppercase

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Yes
![image](https://github.com/mainflux/mainflux/assets/28790446/90cace58-6e35-4ee7-87f1-ea3e660b6d96)

### Did you document any new/modified functionality?
No

### Notes
- Naming convention of mainflux branches https://github.com/mainflux/mainflux/blob/master/CONTRIBUTING.md
- Project name specifications https://docs.docker.com/compose/reference/#use--p-to-specify-a-project-name