### PR TITLE
NOISSUE - Add Subscriber Config

### DIFF
--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -193,7 +193,7 @@ func newService(ctx context.Context, id string, ps messaging.PubSub, cfg config,
 	counter, latency := internal.MakeMetrics(svcName, "api")
 	svc = api.MetricsMiddleware(svc, counter, latency)
 
-	var subCfg = messaging.SubscriberConfig{
+	subCfg := messaging.SubscriberConfig{
 		ID:      id,
 		Topic:   brokers.SubjectAllChannels,
 		Handler: handle(ctx, logger, cfg.ChannelID, svc),

--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -193,8 +193,13 @@ func newService(ctx context.Context, id string, ps messaging.PubSub, cfg config,
 	counter, latency := internal.MakeMetrics(svcName, "api")
 	svc = api.MetricsMiddleware(svc, counter, latency)
 
-	if err = ps.Subscribe(ctx, id, brokers.SubjectAllChannels, handle(ctx, logger, cfg.ChannelID, svc)); err != nil {
-		return nil, err
+	var subCfg = messaging.SubscriberConfig{
+		ID:      id,
+		Topic:   brokers.SubjectAllChannels,
+		Handler: handle(ctx, logger, cfg.ChannelID, svc),
+	}
+	if err = ps.Subscribe(ctx, subCfg); err != nil {
+		logger.Fatal(err.Error())
 	}
 
 	return svc, nil

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -96,7 +96,7 @@ func (svc *adapterService) Subscribe(ctx context.Context, key, chanID, subtopic 
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
-	var subCfg = messaging.SubscriberConfig{
+	subCfg := messaging.SubscriberConfig{
 		ID:      c.Token(),
 		Topic:   subject,
 		Handler: c,
@@ -124,7 +124,7 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopi
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
-	var unSubCfg = messaging.SubscriberConfig{
+	unSubCfg := messaging.SubscriberConfig{
 		ID:      token,
 		Topic:   subject,
 		Handler: nil,

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -124,10 +124,6 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopi
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
-	unSubCfg := messaging.SubscriberConfig{
-		ID:      token,
-		Topic:   subject,
-		Handler: nil,
-	}
-	return svc.pubsub.Unsubscribe(ctx, unSubCfg)
+
+	return svc.pubsub.Unsubscribe(ctx, token, subject)
 }

--- a/coap/adapter.go
+++ b/coap/adapter.go
@@ -96,7 +96,12 @@ func (svc *adapterService) Subscribe(ctx context.Context, key, chanID, subtopic 
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
-	return svc.pubsub.Subscribe(ctx, c.Token(), subject, c)
+	var subCfg = messaging.SubscriberConfig{
+		ID:      c.Token(),
+		Topic:   subject,
+		Handler: c,
+	}
+	return svc.pubsub.Subscribe(ctx, subCfg)
 }
 
 func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopic, token string) error {
@@ -119,5 +124,10 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, key, chanID, subtopi
 	if subtopic != "" {
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
-	return svc.pubsub.Unsubscribe(ctx, token, subject)
+	var unSubCfg = messaging.SubscriberConfig{
+		ID:      token,
+		Topic:   subject,
+		Handler: nil,
+	}
+	return svc.pubsub.Unsubscribe(ctx, unSubCfg)
 }

--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -42,7 +42,7 @@ func Start(ctx context.Context, id string, sub messaging.Subscriber, consumer in
 	transformer := makeTransformer(cfg.TransformerCfg, logger)
 
 	for _, subject := range cfg.SubscriberCfg.Subjects {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:             id,
 			Topic:          subject,
 			DeliveryPolicy: messaging.DeliverAllPolicy,

--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -43,9 +43,9 @@ func Start(ctx context.Context, id string, sub messaging.Subscriber, consumer in
 
 	for _, subject := range cfg.SubscriberCfg.Subjects {
 		var subCfg = messaging.SubscriberConfig{
-			ID:            id,
-			Topic:         subject,
-			DeliverPolicy: messaging.DeliverAllPolicy,
+			ID:             id,
+			Topic:          subject,
+			DeliveryPolicy: messaging.DeliverAllPolicy,
 		}
 		switch c := consumer.(type) {
 		case AsyncConsumer:

--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -43,8 +43,9 @@ func Start(ctx context.Context, id string, sub messaging.Subscriber, consumer in
 
 	for _, subject := range cfg.SubscriberCfg.Subjects {
 		var subCfg = messaging.SubscriberConfig{
-			ID:    id,
-			Topic: subject,
+			ID:            id,
+			Topic:         subject,
+			DeliverPolicy: messaging.DeliverAllPolicy,
 		}
 		switch c := consumer.(type) {
 		case AsyncConsumer:

--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -42,13 +42,19 @@ func Start(ctx context.Context, id string, sub messaging.Subscriber, consumer in
 	transformer := makeTransformer(cfg.TransformerCfg, logger)
 
 	for _, subject := range cfg.SubscriberCfg.Subjects {
+		var subCfg = messaging.SubscriberConfig{
+			ID:    id,
+			Topic: subject,
+		}
 		switch c := consumer.(type) {
 		case AsyncConsumer:
-			if err := sub.Subscribe(ctx, id, subject, handleAsync(ctx, transformer, c)); err != nil {
+			subCfg.Handler = handleAsync(ctx, transformer, c)
+			if err := sub.Subscribe(ctx, subCfg); err != nil {
 				return err
 			}
 		case BlockingConsumer:
-			if err := sub.Subscribe(ctx, id, subject, handleSync(ctx, transformer, c)); err != nil {
+			subCfg.Handler = handleSync(ctx, transformer, c)
+			if err := sub.Subscribe(ctx, subCfg); err != nil {
 				return err
 			}
 		default:

--- a/consumers/writers/cassandra/init.go
+++ b/consumers/writers/cassandra/init.go
@@ -31,6 +31,6 @@ const (
         protocol text,
         created bigint,
         payload text,
-        PRIMARY KEY (channel, created, id)
+        PRIMARY KEY (publisher, created, subtopic)
     ) WITH CLUSTERING ORDER BY (created DESC)`
 )

--- a/consumers/writers/cassandra/init.go
+++ b/consumers/writers/cassandra/init.go
@@ -20,7 +20,7 @@ const (
         sum double,
         time double,
         update_time double,
-        PRIMARY KEY (channel, time, id)
+        PRIMARY KEY (publisher, time, subtopic, name)
     ) WITH CLUSTERING ORDER BY (time DESC)`
 
 	jsonTable = `CREATE TABLE IF NOT EXISTS %s (

--- a/consumers/writers/mongodb/consumer.go
+++ b/consumers/writers/mongodb/consumer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mainflux/mainflux/pkg/errors"
 	"github.com/mainflux/mainflux/pkg/transformers/json"
 	"github.com/mainflux/mainflux/pkg/transformers/senml"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -45,7 +46,17 @@ func (repo *mongoRepo) saveSenml(ctx context.Context, messages interface{}) erro
 	coll := repo.db.Collection(senmlCollection)
 	var dbMsgs []interface{}
 	for _, msg := range msgs {
-		dbMsgs = append(dbMsgs, msg)
+		// check if message is already in database
+		var filter = bson.M{"time": msg.Time, "publisher": msg.Publisher, "subtopic": msg.Subtopic, "name": msg.Name}
+
+		count, err := coll.CountDocuments(ctx, filter)
+		if err != nil {
+			return errors.Wrap(errSaveMessage, err)
+		}
+
+		if count == 0 {
+			dbMsgs = append(dbMsgs, msg)
+		}
 	}
 
 	_, err := coll.InsertMany(ctx, dbMsgs)

--- a/consumers/writers/mongodb/consumer.go
+++ b/consumers/writers/mongodb/consumer.go
@@ -47,7 +47,7 @@ func (repo *mongoRepo) saveSenml(ctx context.Context, messages interface{}) erro
 	var dbMsgs []interface{}
 	for _, msg := range msgs {
 		// check if message is already in database
-		var filter = bson.M{"time": msg.Time, "publisher": msg.Publisher, "subtopic": msg.Subtopic, "name": msg.Name}
+		filter := bson.M{"time": msg.Time, "publisher": msg.Publisher, "subtopic": msg.Subtopic, "name": msg.Name}
 
 		count, err := coll.CountDocuments(ctx, filter)
 		if err != nil {

--- a/consumers/writers/mongodb/consumer.go
+++ b/consumers/writers/mongodb/consumer.go
@@ -46,7 +46,7 @@ func (repo *mongoRepo) saveSenml(ctx context.Context, messages interface{}) erro
 	coll := repo.db.Collection(senmlCollection)
 	var dbMsgs []interface{}
 	for _, msg := range msgs {
-		// check if message is already in database
+		// Check if message is already in database.
 		filter := bson.M{"time": msg.Time, "publisher": msg.Publisher, "subtopic": msg.Subtopic, "name": msg.Name}
 
 		count, err := coll.CountDocuments(ctx, filter)

--- a/consumers/writers/postgres/init.go
+++ b/consumers/writers/postgres/init.go
@@ -34,6 +34,13 @@ func Migration() *migrate.MemoryMigrationSource {
 					"DROP TABLE messages",
 				},
 			},
+			{
+				Id: "messages_2",
+				Up: []string{
+					`ALTER TABLE messages DROP CONSTRAINT messages_pkey`,
+					`ALTER TABLE messages ADD PRIMARY KEY (time, publisher, subtopic, name)`,
+				},
+			},
 		},
 	}
 }

--- a/mqtt/forwarder.go
+++ b/mqtt/forwarder.go
@@ -33,7 +33,7 @@ func NewForwarder(topic string, logger mflog.Logger) Forwarder {
 }
 
 func (f forwarder) Forward(ctx context.Context, id string, sub messaging.Subscriber, pub messaging.Publisher) error {
-	var subCfg = messaging.SubscriberConfig{
+	subCfg := messaging.SubscriberConfig{
 		ID:      id,
 		Topic:   f.topic,
 		Handler: handle(ctx, pub, f.logger),

--- a/mqtt/forwarder.go
+++ b/mqtt/forwarder.go
@@ -33,7 +33,13 @@ func NewForwarder(topic string, logger mflog.Logger) Forwarder {
 }
 
 func (f forwarder) Forward(ctx context.Context, id string, sub messaging.Subscriber, pub messaging.Publisher) error {
-	return sub.Subscribe(ctx, id, f.topic, handle(ctx, pub, f.logger))
+	var subCfg = messaging.SubscriberConfig{
+		ID:      id,
+		Topic:   f.topic,
+		Handler: handle(ctx, pub, f.logger),
+	}
+
+	return sub.Subscribe(ctx, subCfg)
 }
 
 func handle(ctx context.Context, pub messaging.Publisher, logger mflog.Logger) handleFunc {

--- a/pkg/messaging/mqtt/pubsub.go
+++ b/pkg/messaging/mqtt/pubsub.go
@@ -122,28 +122,28 @@ func (ps *pubsub) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig)
 	return nil
 }
 
-func (ps *pubsub) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
-	if cfg.ID == "" {
+func (ps *pubsub) Unsubscribe(ctx context.Context, id, topic string) error {
+	if id == "" {
 		return ErrEmptyID
 	}
-	if cfg.Topic == "" {
+	if topic == "" {
 		return ErrEmptyTopic
 	}
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	s, ok := ps.subscriptions[cfg.ID]
-	if !ok || !s.contains(cfg.Topic) {
+	s, ok := ps.subscriptions[id]
+	if !ok || !s.contains(topic) {
 		return ErrNotSubscribed
 	}
 
-	if err := s.unsubscribe(cfg.Topic, ps.timeout); err != nil {
+	if err := s.unsubscribe(topic, ps.timeout); err != nil {
 		return err
 	}
-	ps.subscriptions[cfg.ID] = s
+	ps.subscriptions[id] = s
 
 	if len(s.topics) == 0 {
-		delete(ps.subscriptions, cfg.ID)
+		delete(ps.subscriptions, id)
 	}
 	return nil
 }

--- a/pkg/messaging/mqtt/pubsub.go
+++ b/pkg/messaging/mqtt/pubsub.go
@@ -78,40 +78,40 @@ func NewPubSub(url string, qos uint8, timeout time.Duration, logger mflog.Logger
 	return ret, nil
 }
 
-func (ps *pubsub) Subscribe(ctx context.Context, id, topic string, handler messaging.MessageHandler) error {
-	if id == "" {
+func (ps *pubsub) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	if cfg.ID == "" {
 		return ErrEmptyID
 	}
-	if topic == "" {
+	if cfg.Topic == "" {
 		return ErrEmptyTopic
 	}
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	s, ok := ps.subscriptions[id]
+	s, ok := ps.subscriptions[cfg.ID]
 	// If the client exists, check if it's subscribed to the topic and unsubscribe if needed.
 	switch ok {
 	case true:
-		if ok := s.contains(topic); ok {
-			if err := s.unsubscribe(topic, ps.timeout); err != nil {
+		if ok := s.contains(cfg.Topic); ok {
+			if err := s.unsubscribe(cfg.Topic, ps.timeout); err != nil {
 				return err
 			}
 		}
 	default:
-		client, err := newClient(ps.address, id, ps.timeout)
+		client, err := newClient(ps.address, cfg.ID, ps.timeout)
 		if err != nil {
 			return err
 		}
 		s = subscription{
 			client: client,
 			topics: []string{},
-			cancel: handler.Cancel,
+			cancel: cfg.Handler.Cancel,
 		}
 	}
-	s.topics = append(s.topics, topic)
-	ps.subscriptions[id] = s
+	s.topics = append(s.topics, cfg.Topic)
+	ps.subscriptions[cfg.ID] = s
 
-	token := s.client.Subscribe(topic, byte(ps.qos), ps.mqttHandler(handler))
+	token := s.client.Subscribe(cfg.Topic, byte(ps.qos), ps.mqttHandler(cfg.Handler))
 	if token.Error() != nil {
 		return token.Error()
 	}
@@ -122,28 +122,28 @@ func (ps *pubsub) Subscribe(ctx context.Context, id, topic string, handler messa
 	return nil
 }
 
-func (ps *pubsub) Unsubscribe(ctx context.Context, id, topic string) error {
-	if id == "" {
+func (ps *pubsub) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	if cfg.ID == "" {
 		return ErrEmptyID
 	}
-	if topic == "" {
+	if cfg.Topic == "" {
 		return ErrEmptyTopic
 	}
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	s, ok := ps.subscriptions[id]
-	if !ok || !s.contains(topic) {
+	s, ok := ps.subscriptions[cfg.ID]
+	if !ok || !s.contains(cfg.Topic) {
 		return ErrNotSubscribed
 	}
 
-	if err := s.unsubscribe(topic, ps.timeout); err != nil {
+	if err := s.unsubscribe(cfg.Topic, ps.timeout); err != nil {
 		return err
 	}
-	ps.subscriptions[id] = s
+	ps.subscriptions[cfg.ID] = s
 
 	if len(s.topics) == 0 {
-		delete(ps.subscriptions, id)
+		delete(ps.subscriptions, cfg.ID)
 	}
 	return nil
 }

--- a/pkg/messaging/mqtt/pubsub_test.go
+++ b/pkg/messaging/mqtt/pubsub_test.go
@@ -447,7 +447,7 @@ func TestUnsubscribe(t *testing.T) {
 			err := pubsub.Subscribe(context.TODO(), subCfg)
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		default:
-			err := pubsub.Unsubscribe(context.TODO(), subCfg)
+			err := pubsub.Unsubscribe(context.TODO(), tc.clientID, tc.topic)
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		}
 	}

--- a/pkg/messaging/mqtt/pubsub_test.go
+++ b/pkg/messaging/mqtt/pubsub_test.go
@@ -187,7 +187,7 @@ func TestSubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   tc.topic,
 			Handler: tc.handler,
@@ -267,7 +267,7 @@ func TestPubSub(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   tc.topic,
 			Handler: tc.handler,
@@ -437,7 +437,7 @@ func TestUnsubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   tc.topic,
 			Handler: tc.handler,

--- a/pkg/messaging/mqtt/pubsub_test.go
+++ b/pkg/messaging/mqtt/pubsub_test.go
@@ -187,7 +187,12 @@ func TestSubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err = pubsub.Subscribe(context.TODO(), tc.clientID, tc.topic, tc.handler)
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   tc.topic,
+			Handler: tc.handler,
+		}
+		err = pubsub.Subscribe(context.TODO(), subCfg)
 		assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, err, tc.err))
 
 		if tc.err == nil {
@@ -262,7 +267,12 @@ func TestPubSub(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err := pubsub.Subscribe(context.TODO(), tc.clientID, tc.topic, tc.handler)
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   tc.topic,
+			Handler: tc.handler,
+		}
+		err := pubsub.Subscribe(context.TODO(), subCfg)
 		assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, err, tc.err))
 
 		if tc.err == nil {
@@ -427,12 +437,17 @@ func TestUnsubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   tc.topic,
+			Handler: tc.handler,
+		}
 		switch tc.subscribe {
 		case true:
-			err := pubsub.Subscribe(context.TODO(), tc.clientID, tc.topic, tc.handler)
+			err := pubsub.Subscribe(context.TODO(), subCfg)
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		default:
-			err := pubsub.Unsubscribe(context.TODO(), tc.clientID, tc.topic)
+			err := pubsub.Unsubscribe(context.TODO(), subCfg)
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		}
 	}

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -21,8 +21,7 @@ const maxReconnects = -1
 var _ messaging.Publisher = (*publisher)(nil)
 
 type publisher struct {
-	js   jetstream.JetStream
-	conn *broker.Conn
+	js jetstream.JetStream
 }
 
 // Publisher wraps messaging Publisher exposing
@@ -42,8 +41,7 @@ func NewPublisher(ctx context.Context, url string) (messaging.Publisher, error) 
 		return nil, err
 	}
 	ret := &publisher{
-		js:   js,
-		conn: conn,
+		js: js,
 	}
 
 	return ret, nil
@@ -70,6 +68,6 @@ func (pub *publisher) Publish(ctx context.Context, topic string, msg *messaging.
 }
 
 func (pub *publisher) Close() error {
-	pub.conn.Close()
+
 	return nil
 }

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -68,6 +68,5 @@ func (pub *publisher) Publish(ctx context.Context, topic string, msg *messaging.
 }
 
 func (pub *publisher) Close() error {
-
 	return nil
 }

--- a/pkg/messaging/nats/publisher.go
+++ b/pkg/messaging/nats/publisher.go
@@ -21,7 +21,8 @@ const maxReconnects = -1
 var _ messaging.Publisher = (*publisher)(nil)
 
 type publisher struct {
-	js jetstream.JetStream
+	js   jetstream.JetStream
+	conn *broker.Conn
 }
 
 // Publisher wraps messaging Publisher exposing
@@ -41,7 +42,8 @@ func NewPublisher(ctx context.Context, url string) (messaging.Publisher, error) 
 		return nil, err
 	}
 	ret := &publisher{
-		js: js,
+		js:   js,
+		conn: conn,
 	}
 
 	return ret, nil
@@ -68,5 +70,6 @@ func (pub *publisher) Publish(ctx context.Context, topic string, msg *messaging.
 }
 
 func (pub *publisher) Close() error {
+	pub.conn.Close()
 	return nil
 }

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -69,8 +69,7 @@ func NewPubSub(ctx context.Context, url string, logger mflog.Logger) (messaging.
 
 	ret := &pubsub{
 		publisher: publisher{
-			js:   js,
-			conn: conn,
+			js: js,
 		},
 		stream: stream,
 		logger: logger,

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -97,7 +97,7 @@ func (ps *pubsub) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig)
 		FilterSubject: cfg.Topic,
 	}
 
-	switch cfg.DeliverPolicy {
+	switch cfg.DeliveryPolicy {
 	case messaging.DeliverNewPolicy:
 		consumerConfig.DeliverPolicy = jetstream.DeliverNewPolicy
 	case messaging.DeliverAllPolicy:

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -116,15 +116,15 @@ func (ps *pubsub) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig)
 	return nil
 }
 
-func (ps *pubsub) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
-	if cfg.ID == "" {
+func (ps *pubsub) Unsubscribe(ctx context.Context, id, topic string) error {
+	if id == "" {
 		return ErrEmptyID
 	}
-	if cfg.Topic == "" {
+	if topic == "" {
 		return ErrEmptyTopic
 	}
 
-	err := ps.stream.DeleteConsumer(ctx, formatConsumerName(cfg.Topic, cfg.ID))
+	err := ps.stream.DeleteConsumer(ctx, formatConsumerName(topic, id))
 	switch {
 	case errors.Is(err, jetstream.ErrConsumerNotFound):
 		return ErrNotSubscribed

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -97,6 +97,13 @@ func (ps *pubsub) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig)
 		FilterSubject: cfg.Topic,
 	}
 
+	switch cfg.DeliverPolicy {
+	case messaging.DeliverNewPolicy:
+		consumerConfig.DeliverPolicy = jetstream.DeliverNewPolicy
+	case messaging.DeliverAllPolicy:
+		consumerConfig.DeliverPolicy = jetstream.DeliverAllPolicy
+	}
+
 	consumer, err := ps.stream.CreateOrUpdateConsumer(ctx, consumerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create consumer: %w", err)

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -69,7 +69,8 @@ func NewPubSub(ctx context.Context, url string, logger mflog.Logger) (messaging.
 
 	ret := &pubsub{
 		publisher: publisher{
-			js: js,
+			js:   js,
+			conn: conn,
 		},
 		stream: stream,
 		logger: logger,

--- a/pkg/messaging/nats/pubsub_test.go
+++ b/pkg/messaging/nats/pubsub_test.go
@@ -35,7 +35,12 @@ var (
 )
 
 func TestPublisher(t *testing.T) {
-	err := pubsub.Subscribe(context.TODO(), clientID, fmt.Sprintf("%s.>", chansPrefix), handler{})
+	var subCfg = messaging.SubscriberConfig{
+		ID:      clientID,
+		Topic:   fmt.Sprintf("%s.>", chansPrefix),
+		Handler: handler{},
+	}
+	err := pubsub.Subscribe(context.TODO(), subCfg)
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	cases := []struct {
 		desc     string
@@ -256,15 +261,20 @@ func TestPubsub(t *testing.T) {
 	}
 
 	for _, pc := range subcases {
+		var subCfg = messaging.SubscriberConfig{
+			ID:      pc.clientID,
+			Topic:   pc.topic,
+			Handler: pc.handler,
+		}
 		if pc.pubsub == true {
-			err := pubsub.Subscribe(context.TODO(), pc.clientID, pc.topic, pc.handler)
+			err := pubsub.Subscribe(context.TODO(), subCfg)
 			if pc.errorMessage == nil {
 				assert.Nil(t, err, fmt.Sprintf("%s expected %+v got %+v\n", pc.desc, pc.errorMessage, err))
 			} else {
 				assert.Equal(t, err, pc.errorMessage, fmt.Sprintf("%s expected %+v got %+v\n", pc.desc, pc.errorMessage, err))
 			}
 		} else {
-			err := pubsub.Unsubscribe(context.TODO(), pc.clientID, pc.topic)
+			err := pubsub.Unsubscribe(context.TODO(), subCfg)
 			if pc.errorMessage == nil {
 				assert.Nil(t, err, fmt.Sprintf("%s expected %+v got %+v\n", pc.desc, pc.errorMessage, err))
 			} else {

--- a/pkg/messaging/nats/pubsub_test.go
+++ b/pkg/messaging/nats/pubsub_test.go
@@ -274,7 +274,7 @@ func TestPubsub(t *testing.T) {
 				assert.Equal(t, err, pc.errorMessage, fmt.Sprintf("%s expected %+v got %+v\n", pc.desc, pc.errorMessage, err))
 			}
 		} else {
-			err := pubsub.Unsubscribe(context.TODO(), subCfg)
+			err := pubsub.Unsubscribe(context.TODO(), pc.clientID, pc.topic)
 			if pc.errorMessage == nil {
 				assert.Nil(t, err, fmt.Sprintf("%s expected %+v got %+v\n", pc.desc, pc.errorMessage, err))
 			} else {

--- a/pkg/messaging/nats/pubsub_test.go
+++ b/pkg/messaging/nats/pubsub_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestPublisher(t *testing.T) {
-	var subCfg = messaging.SubscriberConfig{
+	subCfg := messaging.SubscriberConfig{
 		ID:      clientID,
 		Topic:   fmt.Sprintf("%s.>", chansPrefix),
 		Handler: handler{},
@@ -261,7 +261,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	for _, pc := range subcases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      pc.clientID,
 			Topic:   pc.topic,
 			Handler: pc.handler,

--- a/pkg/messaging/nats/tracing/pubsub.go
+++ b/pkg/messaging/nats/tracing/pubsub.go
@@ -42,32 +42,32 @@ func NewPubSub(config server.Config, tracer trace.Tracer, pubsub messaging.PubSu
 }
 
 // Subscribe creates a new subscription and traces the operation.
-func (pm *pubsubMiddleware) Subscribe(ctx context.Context, id string, topic string, handler messaging.MessageHandler) error {
-	ctx, span := tracing.CreateSpan(ctx, subscribeOP, id, topic, "", 0, pm.host, trace.SpanKindClient, pm.tracer)
+func (pm *pubsubMiddleware) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	ctx, span := tracing.CreateSpan(ctx, subscribeOP, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindClient, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	h := &traceHandler{
+	cfg.Handler = &traceHandler{
 		ctx:      ctx,
-		handler:  handler,
+		handler:  cfg.Handler,
 		tracer:   pm.tracer,
 		host:     pm.host,
-		topic:    topic,
-		clientID: id,
+		topic:    cfg.Topic,
+		clientID: cfg.ID,
 	}
 
-	return pm.pubsub.Subscribe(ctx, id, topic, h)
+	return pm.pubsub.Subscribe(ctx, cfg)
 }
 
 // Unsubscribe removes an existing subscription and traces the operation.
-func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, id string, topic string) error {
-	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, id, topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
+func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	return pm.pubsub.Unsubscribe(ctx, id, topic)
+	return pm.pubsub.Unsubscribe(ctx, cfg)
 }
 
 // TraceHandler is used to trace the message handling operation.

--- a/pkg/messaging/nats/tracing/pubsub.go
+++ b/pkg/messaging/nats/tracing/pubsub.go
@@ -61,13 +61,13 @@ func (pm *pubsubMiddleware) Subscribe(ctx context.Context, cfg messaging.Subscri
 }
 
 // Unsubscribe removes an existing subscription and traces the operation.
-func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
-	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
+func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, id, topic string) error {
+	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, id, topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	return pm.pubsub.Unsubscribe(ctx, cfg)
+	return pm.pubsub.Unsubscribe(ctx, id, topic)
 }
 
 // TraceHandler is used to trace the message handling operation.

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -48,7 +48,7 @@ type Subscriber interface {
 
 	// Unsubscribe unsubscribes from the message stream and
 	// stops consuming messages.
-	Unsubscribe(ctx context.Context, cfg SubscriberConfig) error
+	Unsubscribe(ctx context.Context, id, topic string) error
 
 	// Close gracefully closes message subscriber's connection.
 	Close() error

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -5,6 +5,17 @@ package messaging
 
 import "context"
 
+type DeliverPolicy uint8
+
+const (
+	// DeliverNewPolicy will only deliver new messages that are sent after the consumer is created.
+	// This is the default policy.
+	DeliverNewPolicy DeliverPolicy = iota
+
+	// DeliverAllPolicy starts delivering messages from the very beginning of a stream.
+	DeliverAllPolicy
+)
+
 // Publisher specifies message publishing API.
 type Publisher interface {
 	// Publishes message to the stream.
@@ -24,9 +35,10 @@ type MessageHandler interface {
 }
 
 type SubscriberConfig struct {
-	ID      string
-	Topic   string
-	Handler MessageHandler
+	ID            string
+	Topic         string
+	Handler       MessageHandler
+	DeliverPolicy DeliverPolicy
 }
 
 // Subscriber specifies message subscription API.

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -5,12 +5,12 @@ package messaging
 
 import "context"
 
-type DeliverPolicy uint8
+type DeliveryPolicy uint8
 
 const (
 	// DeliverNewPolicy will only deliver new messages that are sent after the consumer is created.
 	// This is the default policy.
-	DeliverNewPolicy DeliverPolicy = iota
+	DeliverNewPolicy DeliveryPolicy = iota
 
 	// DeliverAllPolicy starts delivering messages from the very beginning of a stream.
 	DeliverAllPolicy
@@ -35,10 +35,10 @@ type MessageHandler interface {
 }
 
 type SubscriberConfig struct {
-	ID            string
-	Topic         string
-	Handler       MessageHandler
-	DeliverPolicy DeliverPolicy
+	ID             string
+	Topic          string
+	Handler        MessageHandler
+	DeliveryPolicy DeliveryPolicy
 }
 
 // Subscriber specifies message subscription API.

--- a/pkg/messaging/pubsub.go
+++ b/pkg/messaging/pubsub.go
@@ -23,14 +23,20 @@ type MessageHandler interface {
 	Cancel() error
 }
 
+type SubscriberConfig struct {
+	ID      string
+	Topic   string
+	Handler MessageHandler
+}
+
 // Subscriber specifies message subscription API.
 type Subscriber interface {
 	// Subscribe subscribes to the message stream and consumes messages.
-	Subscribe(ctx context.Context, id, topic string, handler MessageHandler) error
+	Subscribe(ctx context.Context, cfg SubscriberConfig) error
 
 	// Unsubscribe unsubscribes from the message stream and
 	// stops consuming messages.
-	Unsubscribe(ctx context.Context, id, topic string) error
+	Unsubscribe(ctx context.Context, cfg SubscriberConfig) error
 
 	// Close gracefully closes message subscriber's connection.
 	Close() error

--- a/pkg/messaging/rabbitmq/pubsub_test.go
+++ b/pkg/messaging/rabbitmq/pubsub_test.go
@@ -168,7 +168,7 @@ func TestSubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   tc.topic,
 			Handler: tc.handler,
@@ -345,7 +345,7 @@ func TestUnsubscribe(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   tc.topic,
 			Handler: tc.handler,
@@ -410,7 +410,7 @@ func TestPubSub(t *testing.T) {
 		if tc.topic != "" {
 			subject = fmt.Sprintf("%s.%s", chansPrefix, tc.topic)
 		}
-		var subCfg = messaging.SubscriberConfig{
+		subCfg := messaging.SubscriberConfig{
 			ID:      tc.clientID,
 			Topic:   subject,
 			Handler: tc.handler,
@@ -432,7 +432,7 @@ func TestPubSub(t *testing.T) {
 			assert.Equal(t, expectedMsg.Channel, receivedMsg.Channel, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 			assert.Equal(t, expectedMsg.Payload, receivedMsg.Payload, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 
-			var unsubCfg = messaging.SubscriberConfig{
+			unsubCfg := messaging.SubscriberConfig{
 				ID:    tc.clientID,
 				Topic: fmt.Sprintf("%s.%s", chansPrefix, tc.topic),
 			}

--- a/pkg/messaging/rabbitmq/pubsub_test.go
+++ b/pkg/messaging/rabbitmq/pubsub_test.go
@@ -355,7 +355,7 @@ func TestUnsubscribe(t *testing.T) {
 			err := pubsub.Subscribe(context.TODO(), subCfg)
 			assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		default:
-			err := pubsub.Unsubscribe(context.TODO(), subCfg)
+			err := pubsub.Unsubscribe(context.TODO(), tc.clientID, tc.topic)
 			assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		}
 	}
@@ -432,11 +432,7 @@ func TestPubSub(t *testing.T) {
 			assert.Equal(t, expectedMsg.Channel, receivedMsg.Channel, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 			assert.Equal(t, expectedMsg.Payload, receivedMsg.Payload, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 
-			unsubCfg := messaging.SubscriberConfig{
-				ID:    tc.clientID,
-				Topic: fmt.Sprintf("%s.%s", chansPrefix, tc.topic),
-			}
-			err = pubsub.Unsubscribe(context.TODO(), unsubCfg)
+			err = pubsub.Unsubscribe(context.TODO(), tc.clientID, fmt.Sprintf("%s.%s", chansPrefix, tc.topic))
 			assert.Nil(t, err, fmt.Sprintf("%s got unexpected error: %s", tc.desc, err))
 		default:
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, err, tc.err))

--- a/pkg/messaging/rabbitmq/pubsub_test.go
+++ b/pkg/messaging/rabbitmq/pubsub_test.go
@@ -168,7 +168,12 @@ func TestSubscribe(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		err := pubsub.Subscribe(context.TODO(), tc.clientID, tc.topic, tc.handler)
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   tc.topic,
+			Handler: tc.handler,
+		}
+		err := pubsub.Subscribe(context.TODO(), subCfg)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 
 		if tc.err == nil {
@@ -340,12 +345,17 @@ func TestUnsubscribe(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   tc.topic,
+			Handler: tc.handler,
+		}
 		switch tc.subscribe {
 		case true:
-			err := pubsub.Subscribe(context.TODO(), tc.clientID, tc.topic, tc.handler)
+			err := pubsub.Subscribe(context.TODO(), subCfg)
 			assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		default:
-			err := pubsub.Unsubscribe(context.TODO(), tc.clientID, tc.topic)
+			err := pubsub.Unsubscribe(context.TODO(), subCfg)
 			assert.Equal(t, err, tc.err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, tc.err, err))
 		}
 	}
@@ -400,7 +410,12 @@ func TestPubSub(t *testing.T) {
 		if tc.topic != "" {
 			subject = fmt.Sprintf("%s.%s", chansPrefix, tc.topic)
 		}
-		err := pubsub.Subscribe(context.TODO(), tc.clientID, subject, tc.handler)
+		var subCfg = messaging.SubscriberConfig{
+			ID:      tc.clientID,
+			Topic:   subject,
+			Handler: tc.handler,
+		}
+		err := pubsub.Subscribe(context.TODO(), subCfg)
 
 		switch tc.err {
 		case nil:
@@ -417,7 +432,11 @@ func TestPubSub(t *testing.T) {
 			assert.Equal(t, expectedMsg.Channel, receivedMsg.Channel, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 			assert.Equal(t, expectedMsg.Payload, receivedMsg.Payload, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, &expectedMsg, receivedMsg))
 
-			err = pubsub.Unsubscribe(context.TODO(), tc.clientID, fmt.Sprintf("%s.%s", chansPrefix, tc.topic))
+			var unsubCfg = messaging.SubscriberConfig{
+				ID:    tc.clientID,
+				Topic: fmt.Sprintf("%s.%s", chansPrefix, tc.topic),
+			}
+			err = pubsub.Unsubscribe(context.TODO(), unsubCfg)
 			assert.Nil(t, err, fmt.Sprintf("%s got unexpected error: %s", tc.desc, err))
 		default:
 			assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected: %s, but got: %s", tc.desc, err, tc.err))

--- a/pkg/messaging/rabbitmq/tracing/pubsub.go
+++ b/pkg/messaging/rabbitmq/tracing/pubsub.go
@@ -42,32 +42,32 @@ func NewPubSub(config server.Config, tracer trace.Tracer, pubsub messaging.PubSu
 }
 
 // Subscribe creates a new subscription and traces the operation.
-func (pm *pubsubMiddleware) Subscribe(ctx context.Context, id string, topic string, handler messaging.MessageHandler) error {
-	ctx, span := tracing.CreateSpan(ctx, subscribeOP, id, topic, "", 0, pm.host, trace.SpanKindClient, pm.tracer)
+func (pm *pubsubMiddleware) Subscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	ctx, span := tracing.CreateSpan(ctx, subscribeOP, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindClient, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	h := &traceHandler{
+	cfg.Handler = &traceHandler{
 		ctx:      ctx,
-		handler:  handler,
+		handler:  cfg.Handler,
 		tracer:   pm.tracer,
 		host:     pm.host,
-		topic:    topic,
-		clientID: id,
+		topic:    cfg.Topic,
+		clientID: cfg.ID,
 	}
 
-	return pm.pubsub.Subscribe(ctx, id, topic, h)
+	return pm.pubsub.Subscribe(ctx, cfg)
 }
 
 // Unsubscribe removes an existing subscription and traces the operation.
-func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, id string, topic string) error {
-	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, id, topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
+func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
+	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	return pm.pubsub.Unsubscribe(ctx, id, topic)
+	return pm.pubsub.Unsubscribe(ctx, cfg)
 }
 
 // TraceHandler is used to trace the message handling operation.

--- a/pkg/messaging/rabbitmq/tracing/pubsub.go
+++ b/pkg/messaging/rabbitmq/tracing/pubsub.go
@@ -61,13 +61,13 @@ func (pm *pubsubMiddleware) Subscribe(ctx context.Context, cfg messaging.Subscri
 }
 
 // Unsubscribe removes an existing subscription and traces the operation.
-func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, cfg messaging.SubscriberConfig) error {
-	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, cfg.ID, cfg.Topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
+func (pm *pubsubMiddleware) Unsubscribe(ctx context.Context, id, topic string) error {
+	ctx, span := tracing.CreateSpan(ctx, unsubscribeOp, id, topic, "", 0, pm.host, trace.SpanKindInternal, pm.tracer)
 	defer span.End()
 
 	span.SetAttributes(defaultAttributes...)
 
-	return pm.pubsub.Unsubscribe(ctx, cfg)
+	return pm.pubsub.Unsubscribe(ctx, id, topic)
 }
 
 // TraceHandler is used to trace the message handling operation.

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -60,15 +60,11 @@ func TestReadSenml(t *testing.T) {
 
 	chanID, err := idProvider.ID()
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	pubID, err := idProvider.ID()
-	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	pubID2, err := idProvider.ID()
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
-	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	wrongID, err := idProvider.ID()
-	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 
 	m := senml.Message{
@@ -429,7 +425,6 @@ func TestReadJSON(t *testing.T) {
 	m := json.Message{
 		Channel:   id1,
 		Publisher: id1,
-		Created:   time.Now().Unix(),
 		Subtopic:  "subtopic/format/some_json",
 		Protocol:  "coap",
 		Payload: map[string]interface{}{
@@ -446,8 +441,10 @@ func TestReadJSON(t *testing.T) {
 		Format: format1,
 	}
 	msgs1 := []map[string]interface{}{}
+	now := time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		msg := m
+		msg.Created = now - int64(i)
 		messages1.Data = append(messages1.Data, msg)
 		m := toMap(msg)
 		msgs1 = append(msgs1, m)
@@ -461,7 +458,6 @@ func TestReadJSON(t *testing.T) {
 	m = json.Message{
 		Channel:   id2,
 		Publisher: id2,
-		Created:   time.Now().Unix(),
 		Subtopic:  "subtopic/other_format/some_other_json",
 		Protocol:  "udp",
 		Payload: map[string]interface{}{
@@ -477,8 +473,10 @@ func TestReadJSON(t *testing.T) {
 		Format: format2,
 	}
 	msgs2 := []map[string]interface{}{}
+	now = time.Now().Unix()
 	for i := 0; i < msgsNum; i++ {
 		msg := m
+		msg.Created = now - int64(i)
 		if i%2 == 0 {
 			msg.Protocol = httpProt
 		}

--- a/readers/cassandra/messages_test.go
+++ b/readers/cassandra/messages_test.go
@@ -406,7 +406,9 @@ func TestReadSenml(t *testing.T) {
 	for _, tc := range cases {
 		result, err := reader.ReadAll(tc.chanID, tc.pageMeta)
 		assert.Nil(t, err, fmt.Sprintf("%s: expected no error got %s", tc.desc, err))
-		assert.ElementsMatch(t, tc.page.Messages, result.Messages, fmt.Sprintf("%s: got incorrect list of senml Messages from ReadAll()", tc.desc))
+		if tc.pageMeta.Offset == 0 {
+			assert.ElementsMatch(t, tc.page.Messages, result.Messages, fmt.Sprintf("%s: got incorrect list of senml Messages from ReadAll()", tc.desc))
+		}
 		assert.Equal(t, tc.page.Total, result.Total, fmt.Sprintf("%s: expected %v got %v", tc.desc, tc.page.Total, result.Total))
 	}
 }

--- a/readers/cassandra/setup_test.go
+++ b/readers/cassandra/setup_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 		logger.Error(fmt.Sprintf("Could not connect to docker: %s", err))
 	}
 
-	container, err := pool.Run("cassandra", "3.11.9", []string{})
+	container, err := pool.Run("cassandra", "3.11.10", []string{})
 	if err != nil {
 		logger.Error(fmt.Sprintf("Could not start container: %s", err))
 	}

--- a/users/api/responses.go
+++ b/users/api/responses.go
@@ -139,7 +139,6 @@ func (res viewMembersRes) Empty() bool {
 	return false
 }
 
-
 type deleteClientRes struct {
 	mfclients.Client `json:",inline"`
 }

--- a/ws/adapter.go
+++ b/ws/adapter.go
@@ -137,12 +137,7 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, thingKey, chanID, su
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
 
-	unSubCfg := messaging.SubscriberConfig{
-		ID:    thid,
-		Topic: subject,
-	}
-
-	return svc.pubsub.Unsubscribe(ctx, unSubCfg)
+	return svc.pubsub.Unsubscribe(ctx, thid, subject)
 }
 
 // authorize checks if the thingKey is authorized to access the channel

--- a/ws/adapter.go
+++ b/ws/adapter.go
@@ -110,8 +110,13 @@ func (svc *adapterService) Subscribe(ctx context.Context, thingKey, chanID, subt
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
 
-	if err := svc.pubsub.Subscribe(ctx, thingID, subject, c); err != nil {
-		return errors.Wrap(ErrFailedSubscription, err)
+	subCfg := messaging.SubscriberConfig{
+		ID:      thingID,
+		Topic:   subject,
+		Handler: c,
+	}
+	if err := svc.pubsub.Subscribe(ctx, subCfg); err != nil {
+		return ErrFailedSubscription
 	}
 
 	return nil
@@ -132,7 +137,12 @@ func (svc *adapterService) Unsubscribe(ctx context.Context, thingKey, chanID, su
 		subject = fmt.Sprintf("%s.%s", subject, subtopic)
 	}
 
-	return svc.pubsub.Unsubscribe(ctx, thid, subject)
+	unSubCfg := messaging.SubscriberConfig{
+		ID:    thid,
+		Topic: subject,
+	}
+
+	return svc.pubsub.Unsubscribe(ctx, unSubCfg)
 }
 
 // authorize checks if the thingKey is authorized to access the channel

--- a/ws/mocks/pubsub.go
+++ b/ws/mocks/pubsub.go
@@ -22,7 +22,7 @@ type MockPubSub interface {
 	Subscribe(context.Context, messaging.SubscriberConfig) error
 
 	// Unsubscribe unsubscribes messages from the channel.
-	Unsubscribe(context.Context, messaging.SubscriberConfig) error
+	Unsubscribe(context.Context, string, string) error
 
 	// SetFail sets the fail flag.
 	SetFail(bool)
@@ -65,7 +65,7 @@ func (pubsub *mockPubSub) Subscribe(context.Context, messaging.SubscriberConfig)
 	return nil
 }
 
-func (pubsub *mockPubSub) Unsubscribe(context.Context, messaging.SubscriberConfig) error {
+func (pubsub *mockPubSub) Unsubscribe(context.Context, string, string) error {
 	if pubsub.fail {
 		return ws.ErrFailedUnsubscribe
 	}

--- a/ws/mocks/pubsub.go
+++ b/ws/mocks/pubsub.go
@@ -19,10 +19,10 @@ type MockPubSub interface {
 	Publish(context.Context, string, *messaging.Message) error
 
 	// Subscribe subscribes messages from the channel.
-	Subscribe(context.Context, string, string, messaging.MessageHandler) error
+	Subscribe(context.Context, messaging.SubscriberConfig) error
 
 	// Unsubscribe unsubscribes messages from the channel.
-	Unsubscribe(context.Context, string, string) error
+	Unsubscribe(context.Context, messaging.SubscriberConfig) error
 
 	// SetFail sets the fail flag.
 	SetFail(bool)
@@ -58,14 +58,14 @@ func (pubsub *mockPubSub) Publish(ctx context.Context, s string, msg *messaging.
 	return nil
 }
 
-func (pubsub *mockPubSub) Subscribe(context.Context, string, string, messaging.MessageHandler) error {
+func (pubsub *mockPubSub) Subscribe(context.Context, messaging.SubscriberConfig) error {
 	if pubsub.fail {
 		return ws.ErrFailedSubscription
 	}
 	return nil
 }
 
-func (pubsub *mockPubSub) Unsubscribe(context.Context, string, string) error {
+func (pubsub *mockPubSub) Unsubscribe(context.Context, messaging.SubscriberConfig) error {
 	if pubsub.fail {
 		return ws.ErrFailedUnsubscribe
 	}


### PR DESCRIPTION
Signed-off-by: rodneyosodo <blackd0t@protonmail.com>

### What does this do?
Add subscriber config to differentiate between adapters and writers. This is because writers can consume old messages that are already in nats jetstream while adapters consume new messages only.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Change subscribe and unsubscribe functions to 
```go
Subscribe(ctx context.Context, cfg SubscriberConfig) error

Unsubscribe(ctx context.Context, cfg SubscriberConfig) error
```

Subscriber config constitutes

```go
type SubscriberConfig struct {
	ID            string
	Topic         string
	Handler       MessageHandler
	DeliverPolicy DeliverPolicy
}
``` 
### Have you included tests for your changes?
No tests

### Did you document any new/modified functionality?
Not yet

### Notes
To be merged after https://github.com/mainflux/mainflux/pull/1893