### PR TITLE
MF-1901 - Return `ThingID` on Authorize

### DIFF
--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -497,10 +497,6 @@ func TestListMembers(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		fmt.Println()
-		fmt.Println(tc.desc)
-		fmt.Println()
-
 		repoCall := pRepo.On("CheckAdmin", mock.Anything, mock.Anything).Return(nil)
 		repoCall1 := cRepo.On("Members", mock.Anything, tc.groupID, mock.Anything).Return(mfclients.MembersPage{Members: convertClients(tc.response)}, tc.err)
 		membersPage, err := mfsdk.Members(tc.groupID, tc.page, tc.token)

--- a/things/policies/mocks/channels.go
+++ b/things/policies/mocks/channels.go
@@ -5,8 +5,6 @@ package mocks
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/mainflux/mainflux/pkg/errors"
@@ -25,34 +23,30 @@ func NewCache() policies.Cache {
 	}
 }
 
-func (ccm *cacheMock) Put(_ context.Context, policy policies.Policy) error {
+func (ccm *cacheMock) Put(_ context.Context, key, value string) error {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
 
-	ccm.policies[fmt.Sprintf("%s:%s", policy.Subject, policy.Object)] = strings.Join(policy.Actions, ":")
+	ccm.policies[key] = value
 	return nil
 }
 
-func (ccm *cacheMock) Get(_ context.Context, policy policies.Policy) (policies.Policy, error) {
+func (ccm *cacheMock) Get(_ context.Context, key string) (string, error) {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
-	actions := ccm.policies[fmt.Sprintf("%s:%s", policy.Subject, policy.Object)]
+	actions := ccm.policies[key]
 
 	if actions != "" {
-		return policies.Policy{
-			Subject: policy.Subject,
-			Object:  policy.Object,
-			Actions: strings.Split(actions, ":"),
-		}, nil
+		return actions, nil
 	}
 
-	return policies.Policy{}, errors.ErrNotFound
+	return "", errors.ErrNotFound
 }
 
-func (ccm *cacheMock) Remove(_ context.Context, policy policies.Policy) error {
+func (ccm *cacheMock) Remove(_ context.Context, key string) error {
 	ccm.mu.Lock()
 	defer ccm.mu.Unlock()
 
-	delete(ccm.policies, fmt.Sprintf("%s:%s", policy.Subject, policy.Object))
+	delete(ccm.policies, key)
 	return nil
 }

--- a/things/policies/mocks/channels.go
+++ b/things/policies/mocks/channels.go
@@ -44,7 +44,7 @@ func (ccm *cacheMock) Get(_ context.Context, policy policies.Policy) (policies.P
 
 	val := ccm.policies[key]
 	if val == "" {
-		return policies.Policy{}, "", nil
+		return policies.Policy{}, "", errors.ErrNotFound
 	}
 
 	thingID := extractThingID(val)
@@ -54,7 +54,7 @@ func (ccm *cacheMock) Get(_ context.Context, policy policies.Policy) (policies.P
 
 	policy.Actions = separateActions(val)
 
-	return policy, thingID, errors.ErrNotFound
+	return policy, thingID, nil
 }
 
 func (ccm *cacheMock) Remove(_ context.Context, policy policies.Policy) error {

--- a/things/policies/mocks/channels.go
+++ b/things/policies/mocks/channels.go
@@ -52,7 +52,7 @@ func (ccm *cacheMock) Get(_ context.Context, policy policies.CachedPolicy) (poli
 		return policies.CachedPolicy{}, errors.ErrNotFound
 	}
 
-	policy.Policy.Actions = separateActions(val)
+	policy.Actions = separateActions(val)
 	policy.ThingID = thingID
 
 	return policy, nil
@@ -70,13 +70,15 @@ func (ccm *cacheMock) Remove(_ context.Context, policy policies.CachedPolicy) er
 }
 
 // kv is used to create a key-value pair for caching.
-// If thingID is not empty, it will be appended to the value.
 func kv(p policies.CachedPolicy) (string, string) {
+	key := p.ThingKey + separator + p.ChannelID
+	val := strings.Join(p.Actions, separator)
+
 	if p.ThingID != "" {
-		return p.Policy.Subject + separator + p.Policy.Object, strings.Join(p.Policy.Actions, separator) + separator + p.ThingID
+		val += separator + p.ThingID
 	}
 
-	return p.Policy.Subject + separator + p.Policy.Object, strings.Join(p.Policy.Actions, separator)
+	return key, val
 }
 
 // separateActions is used to separate the actions from the cache values.

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -96,8 +96,10 @@ type Service interface {
 }
 
 type CachedPolicy struct {
-	Policy  Policy
-	ThingID string
+	ThingID   string
+	ThingKey  string
+	ChannelID string
+	Actions   []string
 }
 
 // Cache contains channel-thing connection caching interface.

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -98,13 +98,13 @@ type Service interface {
 // Cache contains channel-thing connection caching interface.
 type Cache interface {
 	// Put adds policy to cahce.
-	Put(ctx context.Context, policy Policy) error
+	Put(ctx context.Context, key, value string) error
 
 	// Get retrieves policy from cache.
-	Get(ctx context.Context, policy Policy) (Policy, error)
+	Get(ctx context.Context, key string) (string, error)
 
 	// Remove deletes a policy from cache.
-	Remove(ctx context.Context, policy Policy) error
+	Remove(ctx context.Context, key string) error
 }
 
 // validate returns an error if policy representation is invalid.

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -98,13 +98,13 @@ type Service interface {
 // Cache contains channel-thing connection caching interface.
 type Cache interface {
 	// Put adds policy to cahce.
-	Put(ctx context.Context, key, value string) error
+	Put(ctx context.Context, policy Policy, thingID string) error
 
 	// Get retrieves policy from cache.
-	Get(ctx context.Context, key string) (string, error)
+	Get(ctx context.Context, policy Policy) (Policy, string, error)
 
 	// Remove deletes a policy from cache.
-	Remove(ctx context.Context, key string) error
+	Remove(ctx context.Context, policy Policy) error
 }
 
 // validate returns an error if policy representation is invalid.

--- a/things/policies/policies.go
+++ b/things/policies/policies.go
@@ -95,16 +95,21 @@ type Service interface {
 	ListPolicies(ctx context.Context, token string, p Page) (PolicyPage, error)
 }
 
+type CachedPolicy struct {
+	Policy  Policy
+	ThingID string
+}
+
 // Cache contains channel-thing connection caching interface.
 type Cache interface {
 	// Put adds policy to cahce.
-	Put(ctx context.Context, policy Policy, thingID string) error
+	Put(ctx context.Context, policy CachedPolicy) error
 
 	// Get retrieves policy from cache.
-	Get(ctx context.Context, policy Policy) (Policy, string, error)
+	Get(ctx context.Context, policy CachedPolicy) (CachedPolicy, error)
 
 	// Remove deletes a policy from cache.
-	Remove(ctx context.Context, policy Policy) error
+	Remove(ctx context.Context, policy CachedPolicy) error
 }
 
 // validate returns an error if policy representation is invalid.

--- a/things/policies/redis/policies.go
+++ b/things/policies/redis/policies.go
@@ -24,13 +24,13 @@ type pcache struct {
 
 // NewCache returns redis policy cache implementation.
 func NewCache(client *redis.Client, duration time.Duration) policies.Cache {
-	return pcache{
+	return &pcache{
 		client:      client,
 		keyDuration: duration,
 	}
 }
 
-func (pc pcache) Put(ctx context.Context, policy policies.CachedPolicy) error {
+func (pc *pcache) Put(ctx context.Context, policy policies.CachedPolicy) error {
 	key, value := kv(policy)
 
 	if err := pc.client.Set(ctx, key, value, pc.keyDuration).Err(); err != nil {
@@ -40,7 +40,7 @@ func (pc pcache) Put(ctx context.Context, policy policies.CachedPolicy) error {
 	return nil
 }
 
-func (pc pcache) Get(ctx context.Context, policy policies.CachedPolicy) (policies.CachedPolicy, error) {
+func (pc *pcache) Get(ctx context.Context, policy policies.CachedPolicy) (policies.CachedPolicy, error) {
 	key, _ := kv(policy)
 	res := pc.client.Get(ctx, key)
 	// Nil response indicates non-existent key in Redis client.
@@ -68,7 +68,7 @@ func (pc pcache) Get(ctx context.Context, policy policies.CachedPolicy) (policie
 	return policy, nil
 }
 
-func (pc pcache) Remove(ctx context.Context, policy policies.CachedPolicy) error {
+func (pc *pcache) Remove(ctx context.Context, policy policies.CachedPolicy) error {
 	key, _ := kv(policy)
 	if err := pc.client.Del(ctx, key).Err(); err != nil {
 		return errors.Wrap(errors.ErrRemoveEntity, err)

--- a/things/policies/redis/policies.go
+++ b/things/policies/redis/policies.go
@@ -63,7 +63,7 @@ func (pc pcache) Get(ctx context.Context, policy policies.CachedPolicy) (policie
 	}
 
 	policy.ThingID = thingID
-	policy.Policy.Actions = separateActions(val)
+	policy.Actions = separateActions(val)
 
 	return policy, nil
 }
@@ -78,13 +78,15 @@ func (pc pcache) Remove(ctx context.Context, policy policies.CachedPolicy) error
 }
 
 // kv is used to create a key-value pair for caching.
-// If thingID is not empty, it will be appended to the value.
 func kv(p policies.CachedPolicy) (string, string) {
+	key := p.ThingKey + separator + p.ChannelID
+	val := strings.Join(p.Actions, separator)
+
 	if p.ThingID != "" {
-		return p.Policy.Subject + separator + p.Policy.Object, strings.Join(p.Policy.Actions, separator) + separator + p.ThingID
+		val += separator + p.ThingID
 	}
 
-	return p.Policy.Subject + separator + p.Policy.Object, strings.Join(p.Policy.Actions, separator)
+	return key, val
 }
 
 // separateActions is used to separate the actions from the cache values.

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -53,19 +53,19 @@ func NewService(auth upolicies.AuthServiceClient, p Repository, ccache Cache, id
 func (svc service) Authorize(ctx context.Context, ar AccessRequest) (Policy, error) {
 	// Fetch from cache first.
 	cpolicy := CachedPolicy{
-		Policy: Policy{
-			Subject: ar.Subject,
-			Object:  ar.Object,
-		},
+		ThingKey:  ar.Subject,
+		ChannelID: ar.Object,
 	}
 
 	cpolicy, err := svc.policyCache.Get(ctx, cpolicy)
 	if err == nil {
-		for _, action := range cpolicy.Policy.Actions {
+		for _, action := range cpolicy.Actions {
 			if action == ar.Action {
-				cpolicy.Policy.Subject = cpolicy.ThingID
+				var policy = Policy{
+					Subject: cpolicy.ThingID,
+				}
 
-				return cpolicy.Policy, nil
+				return policy, nil
 			}
 		}
 
@@ -134,7 +134,8 @@ func (svc service) AddPolicy(ctx context.Context, token string, external bool, p
 	p.UpdatedBy = userID
 
 	var cpolicy = CachedPolicy{
-		Policy: p,
+		ThingKey:  p.Subject,
+		ChannelID: p.Object,
 	}
 	if err := svc.policyCache.Remove(ctx, cpolicy); err != nil {
 		return Policy{}, err
@@ -204,7 +205,8 @@ func (svc service) UpdatePolicy(ctx context.Context, token string, p Policy) (Po
 	p.UpdatedBy = userID
 
 	var cpolicy = CachedPolicy{
-		Policy: p,
+		ThingKey:  p.Subject,
+		ChannelID: p.Object,
 	}
 	if err := svc.policyCache.Remove(ctx, cpolicy); err != nil {
 		return Policy{}, err
@@ -242,7 +244,8 @@ func (svc service) DeletePolicy(ctx context.Context, token string, p Policy) err
 	}
 
 	var cpolicy = CachedPolicy{
-		Policy: p,
+		ThingKey:  p.Subject,
+		ChannelID: p.Object,
 	}
 	if err := svc.policyCache.Remove(ctx, cpolicy); err != nil {
 		return err

--- a/things/policies/service.go
+++ b/things/policies/service.go
@@ -97,7 +97,12 @@ func (svc service) Authorize(ctx context.Context, ar AccessRequest) (Policy, err
 			return Policy{}, err
 		}
 
-		cpolicy.ThingID = ar.Subject
+		cpolicy = CachedPolicy{
+			ThingID:   policy.Subject,
+			ThingKey:  ar.Subject,
+			ChannelID: ar.Object,
+			Actions:   policy.Actions,
+		}
 		if err := svc.policyCache.Put(ctx, cpolicy); err != nil {
 			return policy, err
 		}


### PR DESCRIPTION
### What does this do?
Change the policies cache signature to accept both policies action and `thingID`. `ThingID` is appended to actions

### Which issue(s) does this PR fix/relate to?
Resolves #1901 

### List any changes that modify/break current functionality
Listed above on what the PR does.

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
On code

### Notes
To be merged after https://github.com/mainflux/mainflux/pull/1899