### PR TITLE
NOISSUE - MQTT To Publish Payload Only

### DIFF
--- a/mqtt/forwarder.go
+++ b/mqtt/forwarder.go
@@ -43,15 +43,17 @@ func handle(ctx context.Context, pub messaging.Publisher, logger mflog.Logger) h
 		}
 		// Use concatenation instead of fmt.Sprintf for the
 		// sake of simplicity and performance.
-		topic := fmt.Sprintf("channels/%s/messages", msg.Channel)
+		topic := "channels/" + msg.Channel + "/messages"
 		if msg.Subtopic != "" {
-			topic = fmt.Sprintf("%s/%s", topic, strings.ReplaceAll(msg.Subtopic, ".", "/"))
+			topic = topic + "/" + strings.ReplaceAll(msg.Subtopic, ".", "/")
 		}
+
 		go func() {
 			if err := pub.Publish(ctx, topic, msg); err != nil {
 				logger.Warn(fmt.Sprintf("Failed to forward message: %s", err))
 			}
 		}()
+
 		return nil
 	}
 }

--- a/pkg/messaging/mqtt/pubsub.go
+++ b/pkg/messaging/mqtt/pubsub.go
@@ -62,7 +62,7 @@ type pubsub struct {
 }
 
 // NewPubSub returns MQTT message publisher/subscriber.
-func NewPubSub(url, queue string, timeout time.Duration, logger mflog.Logger) (messaging.PubSub, error) {
+func NewPubSub(url, _ string, timeout time.Duration, logger mflog.Logger) (messaging.PubSub, error) {
 	client, err := newClient(url, "mqtt-publisher", timeout)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func newClient(address, id string, timeout time.Duration) (mqtt.Client, error) {
 }
 
 func (ps *pubsub) mqttHandler(h messaging.MessageHandler) mqtt.MessageHandler {
-	return func(c mqtt.Client, m mqtt.Message) {
+	return func(_ mqtt.Client, m mqtt.Message) {
 		var msg messaging.Message
 		if err := proto.Unmarshal(m.Payload(), &msg); err != nil {
 			ps.logger.Warn(fmt.Sprintf("Failed to unmarshal received message: %s", err))

--- a/pkg/messaging/mqtt/pubsub_test.go
+++ b/pkg/messaging/mqtt/pubsub_test.go
@@ -111,7 +111,9 @@ func TestPublisher(t *testing.T) {
 		assert.Nil(t, err, fmt.Sprintf("%s: failed to serialize protobuf error: %s\n", tc.desc, err))
 
 		receivedMsg := <-msgChan
-		assert.Equal(t, data, receivedMsg, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, data, receivedMsg))
+		if tc.payload != nil {
+			assert.Equal(t, expectedMsg.GetPayload(), receivedMsg, fmt.Sprintf("%s: expected %+v got %+v\n", tc.desc, data, receivedMsg))
+		}
 	}
 }
 
@@ -271,9 +273,14 @@ func TestPubSub(t *testing.T) {
 				Subtopic:  subtopic,
 				Payload:   data,
 			}
+			data, err := proto.Marshal(&expectedMsg)
+			assert.Nil(t, err, fmt.Sprintf("%s: failed to serialize protobuf error: %s\n", tc.desc, err))
 
+			msg := messaging.Message{
+				Payload: data,
+			}
 			// Publish message, and then receive it on message channel.
-			err := pubsub.Publish(context.TODO(), topic, &expectedMsg)
+			err = pubsub.Publish(context.TODO(), topic, &msg)
 			assert.Nil(t, err, fmt.Sprintf("%s: got unexpected error: %s\n", tc.desc, err))
 
 			receivedMsg := <-msgChan

--- a/pkg/messaging/nats/pubsub.go
+++ b/pkg/messaging/nats/pubsub.go
@@ -161,6 +161,7 @@ func (ps *pubsub) natsHandler(h messaging.MessageHandler) broker.MsgHandler {
 			ps.logger.Warn(fmt.Sprintf("Failed to unmarshal received message: %s", err))
 			return
 		}
+
 		if err := h.Handle(&msg); err != nil {
 			ps.logger.Warn(fmt.Sprintf("Failed to handle Mainflux message: %s", err))
 		}


### PR DESCRIPTION
### What does this do?
Since other protocol adapters i.e extract payload only and leave other fields of the message, it would be prudent that also mqtt forward to only forward payload rather than entire message

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Publish payload only rather than entire marshlled message message

#### Output of message from `mosquitto_sub` from 3 protocol adapters i.e `coap`, `mqtt` and `http`

Before
```bash
$6049195d-1b3f-4f32-897a-c1ded8dd9d66$61bc32ad-1439-471a-8e51-1d0f43e4bf35"http*c[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]0����؂��

$6049195d-1b3f-4f32-897a-c1ded8dd9d66$61bc32ad-1439-471a-8e51-1d0f43e4bf35"coap*c[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]0���؂��
[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]
```

After 
```bash
[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]
[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]
[{"bn":"demo", "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}]
```
### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
N/A