### PR TITLE
NOISSUE - Remove Development Mode on Certs Creation

### DIFF
--- a/certs/README.md
+++ b/certs/README.md
@@ -20,8 +20,7 @@ MF_CERTS_VAULT_TOKEN=<vault_acces_token>
 
 For lab purposes you can use docker-compose and script for setting up PKI in [https://github.com/mteodor/vault](https://github.com/mteodor/vault)
 
-Issuing certificate is same as in **Development** mode.
-In this mode certificates can also be revoked:
+The certificates can also be revoked using `certs` service. To revoke a certificate you need to provide `thing_id` of the thing for which the certificate was issued.
 
 ```bash
 curl -s -S -X DELETE http://localhost:9019/certs/revoke -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json'   -d '{"thing_id":"c30b8842-507c-4bcd-973c-74008cef3be5"}'

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,36 +1,7 @@
 # Certs Service
 
 Issues certificates for things. `Certs` service can create certificates to be used when `Mainflux` is deployed to support mTLS.
-Certificate service can create certificates in two modes:
-
-1. Development mode - to be used when no PKI is deployed, this works similar to the [make thing_cert](../docker/ssl/Makefile)
-2. PKI mode - certificates issued by PKI, when you deploy `Vault` as PKI certificate management `cert` service will proxy requests to `Vault` previously checking access rights and saving info on successfully created certificate.
-
-## Development mode
-
-If `MF_CERTS_VAULT_HOST` is empty than Development mode is on.
-
-To issue a certificate:
-
-```bash
-
-TOK=`curl  -s --insecure -S -X POST http://localhost/tokens -H 'Content-Type: application/json' -d '{"email":"edge@email.com","password":"12345678"}' | jq -r '.token'`
-
-curl -s -S  -X POST  http://localhost:9019/certs -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json'   -d '{"thing_id":<thing_id>}'
-```
-
-```json
-{
-  "ThingID": "",
-  "ClientCert": "-----BEGIN CERTIFICATE-----\nMIIDmTCCAoGgAwIBAgIRANmkAPbTR1UYeYO0Id/4+8gwDQYJKoZIhvcNAQELBQAw\nVzESMBAGA1UEAwwJbG9jYWxob3N0MREwDwYDVQQKDAhNYWluZmx1eDEMMAoGA1UE\nCwwDSW9UMSAwHgYJKoZIhvcNAQkBFhFpbmZvQG1haW5mbHV4LmNvbTAeFw0yMDA2\nMzAxNDIxMDlaFw0yMDA5MjMyMjIxMDlaMFUxETAPBgNVBAoTCE1haW5mbHV4MREw\nDwYDVQQLEwhtYWluZmx1eDEtMCsGA1UEAxMkYjAwZDBhNzktYjQ2YS00NTk3LTli\nNGYtMjhkZGJhNTBjYTYyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\ntgS2fLUWG3CCQz/l6VRQRJfRvWmdxK0mW6zIXGeeOILYZeaLiuiUnohwMJ4RiMqT\nuJbInAIuO/Tt5osfrCFFzPEOLYJ5nZBBaJfTIAxqf84Ou1oeMRll4wpzgeKx0rJO\nXMAARwn1bT9n3uky5QQGSLy4PyyILzSXH/1yCQQctdQB/Ar/UI1TaYoYlGzh7dHT\nWpcxq1HYgCyAtcrQrGD0rEwUn82UBCrnya+bygNqu0oDzIFQwa1G8jxSgXk0mFS1\nWrk7rBipsvp8HQhdnvbEVz4k4AAKcQxesH4DkRx/EXmU2UvN3XysvcJ2bL+UzMNI\njNhAe0pgPbB82F6zkYZ/XQIDAQABo2IwYDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0l\nBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMA4GA1UdDgQHBAUBAgMEBjAfBgNVHSME\nGDAWgBRs4xR91qEjNRGmw391xS7x6Tc+8jANBgkqhkiG9w0BAQsFAAOCAQEAW/dS\nV4vNLTZwBnPVHUX35pRFxPKvscY+vnnpgyDtITgZHYe0KL+Bs3IHuywtqaezU5x1\nkZo+frE1OcpRvp7HJtDiT06yz+18qOYZMappCWCeAFWtZkMhlvnm3TqTkgui6Xgl\nGj5xnPb15AOlsDE2dkv5S6kEwJGHdVX6AOWfB4ubUq5S9e4ABYzXGUty6Hw/ZUmJ\nhCTRVJ7cQJVTJsl1o7CYT8JBvUUG75LirtoFE4M4JwsfsKZXzrQffTf1ynqI3dN/\nHWySEbvTSWcRcA3MSmOTxGt5/zwCglHDlWPKMrXtjTW7NPuGL5/P9HSB9HGVVeET\nDUMdvYwgj0cUCEu3LA==\n-----END CERTIFICATE-----\n",
-  "IssuingCA": "",
-  "CAChain": null,
-  "ClientKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAtgS2fLUWG3CCQz/l6VRQRJfRvWmdxK0mW6zIXGeeOILYZeaL\niuiUnohwMJ4RiMqTuJbInAIuO/Tt5osfrCFFzPEOLYJ5nZBBaJfTIAxqf84Ou1oe\nMRll4wpzgeKx0rJOXMAARwn1bT9n3uky5QQGSLy4PyyILzSXH/1yCQQctdQB/Ar/\nUI1TaYoYlGzh7dHTWpcxq1HYgCyAtcrQrGD0rEwUn82UBCrnya+bygNqu0oDzIFQ\nwa1G8jxSgXk0mFS1Wrk7rBipsvp8HQhdnvbEVz4k4AAKcQxesH4DkRx/EXmU2UvN\n3XysvcJ2bL+UzMNIjNhAe0pgPbB82F6zkYZ/XQIDAQABAoIBAALoal3tqq+/iWU3\npR2oKiweXMxw3oNg3McEKKNJSH7QoFJob3xFoPIzbc9pBxCvY9LEHepYIpL0o8RW\nHqhqU6olg7t4ZSb+Qf1Ax6+wYxctnJCjrO3N4RHSfevqSjr6fEQBEUARSal4JNmr\n0hNUkCEjWrIvrPFMHsn1C5hXR3okJQpGsad4oCGZDp2eZ/NDyvmLBLci9/5CJdRv\n6roOF5ShWweKcz1+pfy666Q8RiUI7H1zXjPaL4yqkv8eg/WPOO0dYF2Ri2Grk9OY\n1qTM0W1vi9zfncinZ0DpgtwMTFQezGwhUyJHSYHmjVBA4AaYIyOQAI/2dl5fXM+O\n9JfXpOUCgYEA10xAtMc/8KOLbHCprpc4pbtOqfchq/M04qPKxQNAjqvLodrWZZgF\nexa+B3eWWn5MxmQMx18AjBCPwbNDK8Rkd9VqzdWempaSblgZ7y1a0rRNTXzN5DFP\noiuRQV4wszCuj5XSdPn+lxApaI/4+TQ0oweIZCpGW39XKePPoB5WZiMCgYEA2G3W\niJncRpmxWwrRPi1W26E9tWOT5s9wYgXWMc+PAVUd/qdDRuMBHpu861Qoghp/MJog\nBYqt2rQqU0OxvIXlXPrXPHXrCLOFwybRCBVREZrg4BZNnjyDTLOu9C+0M3J9ImCh\n3vniYqb7S0gRmoDM0R3Zu4+ajfP2QOGLXw1qHH8CgYEAl0EQ7HBW8V5UYzi7XNcM\nixKOb0YZt83DR74+hC6GujTjeLBfkzw8DX+qvWA8lxLIKVC80YxivAQemryv4h21\nX6Llx/nd1UkXUsI+ZhP9DK5y6I9XroseIRZuk/fyStFWsbVWB6xiOgq2rKkJBzqw\nCCEQpx40E6/gsqNDiIAHvvUCgYBkkjXc6FJ55DWMLuyozfzMtpKsVYeG++InSrsM\nDn1PizQS/7q9mAMPLCOP312rh5CPDy/OI3FCbfI1GwHerwG0QUP/bnQ3aOTBmKoN\n7YnsemIA/5w16bzBycWE5x3/wjXv4aOWr9vJJ/siMm0rtKp4ijyBcevKBxHpeGWB\nWAR1FQKBgGIqAxGnBpip9E24gH894BaGHHMpQCwAxARev6sHKUy27eFUd6ipoTva\n4Wv36iz3gxU4R5B0gyfnxBNiUab/z90cb5+6+FYO13kqjxRRZWffohk5nHlmFN9K\nea7KQHTfTdRhOLUzW2yVqLi9pzfTfA6Yqf3U1YD3bgnWrp1VQnjo\n-----END RSA PRIVATE KEY-----\n",
-  "PrivateKeyType": "",
-  "Serial": "",
-  "Expire": "0001-01-01T00:00:00Z"
-}
-```
+Certificate service can create certificates using PKI mode - where certificates issued by PKI, when you deploy `Vault` as PKI certificate management `cert` service will proxy requests to `Vault` previously checking access rights and saving info on successfully created certificate.
 
 ## PKI mode
 
@@ -40,7 +11,7 @@ To setup `Vault` follow steps in [Build Your Own Certificate Authority (CA)](htt
 
 To setup certs service with `Vault` following environment variables must be set:
 
-```
+```bash
 MF_CERTS_VAULT_HOST=vault-domain.com
 MF_CERTS_VAULT_PKI_PATH=<vault_pki_path>
 MF_CERTS_VAULT_ROLE=<vault_role>

--- a/docker/addons/vault/README.md
+++ b/docker/addons/vault/README.md
@@ -1,27 +1,28 @@
+# Vault
+
 This is Vault service deployment to be used with Mainflux.
 
 When the Vault service is started, some initialization steps need to be done to set things up.
 
 ## Configuration
 
-| Variable                  | Description                                                             | Default        |
-| ------------------------- | ----------------------------------------------------------------------- | -------------- |
-| MF_VAULT_HOST             | Vault service address                                                   | vault          |
-| MF_VAULT_PORT             | Vault service port                                                      | 8200           |
-| MF_VAULT_UNSEAL_KEY_1     | Vault unseal key                                                        | ""             |
-| MF_VAULT_UNSEAL_KEY_2     | Vault unseal key                                                        | ""             |
-| MF_VAULT_UNSEAL_KEY_3     | Vault unseal key                                                        | ""             |
-| MF_VAULT_TOKEN            | Vault cli access token                                                  | ""             |
-| MF_VAULT_PKI_PATH         | Vault secrets engine path for CA                                        | pki            |
-| MF_VAULT_PKI_INT_PATH     | Vault secrets engine path for intermediate CA                           | pki_int        |
-| MF_VAULT_CA_ROLE_NAME     | Vault secrets engine role                                               | mainflux       |
-| MF_VAULT_CA_NAME          | Certificates name used by `vault-set-pki.sh`                            | mainflux       |
-| MF_VAULT_CA_CN            | Common name used for CA creation by `vault-set-pki.sh`                  | mainflux.com   |
-| MF_VAULT_CA_OU            | Org unit used for CA creation by `vault-set-pki.sh`                     | Mainflux Cloud |
-| MF_VAULT_CA_O             | Organization used for CA creation by `vault-set-pki.sh`                 | Mainflux Labs  |
-| MF_VAULT_CA_C             | Country used for CA creation by `vault-set-pki.sh`                      | Serbia         |
-| MF_VAULT_CA_L             | Location used for CA creation by `vault-set-pki.sh`                     | Belgrade       |
-
+| Variable              | Description                                             | Default        |
+| --------------------- | ------------------------------------------------------- | -------------- |
+| MF_VAULT_HOST         | Vault service address                                   | vault          |
+| MF_VAULT_PORT         | Vault service port                                      | 8200           |
+| MF_VAULT_UNSEAL_KEY_1 | Vault unseal key                                        | ""             |
+| MF_VAULT_UNSEAL_KEY_2 | Vault unseal key                                        | ""             |
+| MF_VAULT_UNSEAL_KEY_3 | Vault unseal key                                        | ""             |
+| MF_VAULT_TOKEN        | Vault cli access token                                  | ""             |
+| MF_VAULT_PKI_PATH     | Vault secrets engine path for CA                        | pki            |
+| MF_VAULT_PKI_INT_PATH | Vault secrets engine path for intermediate CA           | pki_int        |
+| MF_VAULT_CA_ROLE_NAME | Vault secrets engine role                               | mainflux       |
+| MF_VAULT_CA_NAME      | Certificates name used by `vault-set-pki.sh`            | mainflux       |
+| MF_VAULT_CA_CN        | Common name used for CA creation by `vault-set-pki.sh`  | mainflux.com   |
+| MF_VAULT_CA_OU        | Org unit used for CA creation by `vault-set-pki.sh`     | Mainflux Cloud |
+| MF_VAULT_CA_O         | Organization used for CA creation by `vault-set-pki.sh` | Mainflux Labs  |
+| MF_VAULT_CA_C         | Country used for CA creation by `vault-set-pki.sh`      | Serbia         |
+| MF_VAULT_CA_L         | Location used for CA creation by `vault-set-pki.sh`     | Belgrade       |
 
 ## Setup
 
@@ -37,7 +38,7 @@ After this step, the corresponding Vault environment variables (`MF_VAULT_TOKEN`
 
 Example contents for `data/secrets`:
 
-```
+```bash
 Unseal Key 1: Ay0YZecYJ2HVtNtXfPootXK5LtF+JZoDmBb7IbbYdLBI
 Unseal Key 2: P6hb7x2cglv0p61jdLyNE3+d44cJUOFaDt9jHFDfr8Df
 Unseal Key 3: zSBfDHzUiWoOzXKY1pnnBqKO8UD2MDLuy8DNTxNtEBFy
@@ -79,13 +80,13 @@ After it runs, it copies the necessary certificates and keys to the `docker/ssl/
 
 The CA parameters are obtained from the environment variables starting with `MF_VAULT_CA` in `.env` file.
 
-## Vault CLI 
+## Vault CLI
 
 It can also be useful to run the Vault CLI for inspection and administration work.
 
 This can be done directly using the Vault image in Docker: `docker run -it mainflux/vault:latest vault`
 
-```
+```bash
 Usage: vault <command> [args]
 
 Common commands:

--- a/pkg/sdk/go/responses.go
+++ b/pkg/sdk/go/responses.go
@@ -74,7 +74,7 @@ type BootstrapPage struct {
 }
 
 type CertSerials struct {
-	Serials []string `json:"serials"`
+	Certs []Cert `json:"certs"`
 	pageRes
 }
 


### PR DESCRIPTION
 This commit ensures that the correct mode is set based on the value of `MF_CERTS_VAULT_HOST`.

### What does this do?
Remove documentation for development mode. Since we only support PKI mode. I have created an issue to work on development mode.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Previously, the `MF_CERTS_VAULT_HOST` environment variable was being checked, resulting in incorrect behaviour when issuing certificates in development mode as we need a valid host.https://github.com/mainflux/mainflux/blob/65b63742354b9ad91f5ab6ac6bb74b6481311db8/cmd/certs/main.go#L89C1-L93C3

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
Yes

### Notes
Linked to https://github.com/ultravioletrs/issues/issues/314 https://github.com/mainflux/docs/pull/161