### PR TITLE
NOISSUE - Update Go Version on Docker and CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version go 1.20
+      - sem-version go 1.21
 blocks:
   - name: Setup
     dependencies: []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.21-alpine AS builder
 ARG SVC
 ARG GOARCH
 ARG GOARM

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,6 @@
 # This script contains commands to be executed by the CI tool.
 NPROC=$(nproc)
-GO_VERSION=1.19.4
+GO_VERSION=1.21.3
 PROTOC_VERSION=23.3
 PROTOC_GEN_VERSION=v1.31.0
 PROTOC_GRPC_VERSION=v1.3.0


### PR DESCRIPTION
Signed-off-by: Rodney Osodo <28790446+rodneyosodo@users.noreply.github.com>

### What does this do?
Updates `go` version on semaphore CI and docker images

### Which issue(s) does this PR fix/relate to?
No issue. There was a breaking change when you tried to build images using docker with `make dockers` command. This fixes it.

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Tested docker build manually

### Did you document any new/modified functionality?
No

### Notes
N/A