### PR TITLE
NOISSUE - Add JSON Tags to `connectChannelThingRequest` struct

### DIFF
--- a/things/api/http/requests.go
+++ b/things/api/http/requests.go
@@ -366,8 +366,8 @@ func (req unassignUserGroupsRequest) validate() error {
 
 type connectChannelThingRequest struct {
 	token     string
-	ThingID   string
-	ChannelID string
+	ThingID   string `json:"thing_id,omitempty"`
+	ChannelID string `json:"channel_id,omitempty"`
 }
 
 func (req *connectChannelThingRequest) validate() error {


### PR DESCRIPTION
### What does this do?
The `connectChannelThingRequest` struct in the `things/api/http/requests.go` file has been updated to include JSON tags for the ThingID and ChannelID fields. This change allows for proper serialization and deserialization of the struct when working with JSON data.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Manually tested

### Did you document any new/modified functionality?
No

### Notes
N/A