### PR TITLE
NOISSUE - Align WS Documentation

### DIFF
--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -83,11 +83,6 @@ func main() {
 		return
 	}
 
-	targetServerConf := server.Config{
-		Port: targetWSPort,
-		Host: targetWSHost,
-	}
-
 	authConfig := auth.Config{}
 	if err := env.ParseWithOptions(&authConfig, env.Options{Prefix: envPrefixAuthz}); err != nil {
 		logger.Error(fmt.Sprintf("failed to load %s auth configuration : %s", svcName, err))
@@ -125,11 +120,11 @@ func main() {
 		return
 	}
 	defer nps.Close()
-	nps = brokerstracing.NewPubSub(targetServerConf, tracer, nps)
+	nps = brokerstracing.NewPubSub(httpServerConfig, tracer, nps)
 
 	svc := newService(authClient, nps, logger, tracer)
 
-	hs := httpserver.New(ctx, cancel, svcName, targetServerConf, api.MakeHandler(ctx, svc, logger, cfg.InstanceID), logger)
+	hs := httpserver.New(ctx, cancel, svcName, httpServerConfig, api.MakeHandler(ctx, svc, logger, cfg.InstanceID), logger)
 
 	if cfg.SendTelemetry {
 		chc := chclient.New(svcName, magistrala.Version, logger, cancel)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,7 +18,7 @@ type Server interface {
 }
 
 type Config struct {
-	Host         string `env:"HOST"            envDefault:""`
+	Host         string `env:"HOST"            envDefault:"localhost"`
 	Port         string `env:"PORT"            envDefault:""`
 	CertFile     string `env:"SERVER_CERT"     envDefault:""`
 	KeyFile      string `env:"SERVER_KEY"      envDefault:""`

--- a/pkg/auth/connect.go
+++ b/pkg/auth/connect.go
@@ -32,11 +32,11 @@ var (
 )
 
 type Config struct {
+	URL          string        `env:"URL"              envDefault:""`
+	Timeout      time.Duration `env:"TIMEOUT"          envDefault:"1s"`
 	ClientCert   string        `env:"CLIENT_CERT"      envDefault:""`
 	ClientKey    string        `env:"CLIENT_KEY"       envDefault:""`
 	ServerCAFile string        `env:"SERVER_CA_CERTS"  envDefault:""`
-	URL          string        `env:"URL"              envDefault:""`
-	Timeout      time.Duration `env:"TIMEOUT"          envDefault:"1s"`
 }
 
 // Handler is used to handle gRPC connection.

--- a/ws/README.md
+++ b/ws/README.md
@@ -1,34 +1,36 @@
 # WebSocket adapter
 
-WebSocket adapter provides an [WebSocket](https://en.wikipedia.org/wiki/WebSocket#:~:text=WebSocket%20is%20a%20computer%20communications,protocol%20is%20known%20as%20WebSockets.) API for sending and receiving messages through the platform.
+WebSocket adapter provides a [WebSocket](https://en.wikipedia.org/wiki/WebSocket#:~:text=WebSocket%20is%20a%20computer%20communications,protocol%20is%20known%20as%20WebSockets.) API for sending and receiving messages through the platform.
 
 ## Configuration
 
-The service is configured using the environment variables presented in the
-following table. Note that any unset variables will be replaced with their
-default values.
+The service is configured using the environment variables presented in the following table. Note that any unset variables will be replaced with their default values.
 
-| Variable                       | Description                                         | Default                          |
-| ------------------------------ | --------------------------------------------------- | -------------------------------- |
-| MG_WS_ADAPTER_LOG_LEVEL        | Log level for the WS Adapter                        | info                             |
-| MG_WS_ADAPTER_HTTP_HOST        | Service WS host                                     |                                  |
-| MG_WS_ADAPTER_HTTP_PORT        | Service WS port                                     | 8190                             |
-| MG_WS_ADAPTER_HTTP_SERVER_CERT | Service WS server certificate                       |                                  |
-| MG_WS_ADAPTER_HTTP_SERVER_KEY  | Service WS server key                               |                                  |
-| MG_THINGS_AUTH_GRPC_URL        | Things service Auth gRPC URL                        | <localhost:7000>                 |
-| MG_THINGS_AUTH_GRPC_TIMEOUT    | Things service Auth gRPC request timeout in seconds | 1s                               |
-| MG_THINGS_AUTH_GRPC_CLIENT_TLS | Flag that indicates if TLS should be turned on      | false                            |
-| MG_THINGS_AUTH_GRPC_CA_CERTS   | Path to trusted CAs in PEM format                   |                                  |
-| MG_MESSAGE_BROKER_URL          | Message broker instance URL                         | <nats://localhost:4222>          |
-| MG_JAEGER_URL                  | Jaeger server URL                                   | <http://jaeger:14268/api/traces> |
-| MG_SEND_TELEMETRY              | Send telemetry to magistrala call home server       | true                             |
-| MG_WS_ADAPTER_INSTANCE_ID      | Service instance ID                                 | ""                               |
+| Variable                           | Description                                                                        | Default                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------- |
+| MG_WS_ADAPTER_LOG_LEVEL            | Log level for the WS Adapter (debug, info, warn, error)                            | info                             |
+| MG_WS_ADAPTER_HTTP_HOST            | Service WS host                                                                    | ""                               |
+| MG_WS_ADAPTER_HTTP_PORT            | Service WS port                                                                    | 8190                             |
+| MG_WS_ADAPTER_HTTP_SERVER_CERT     | Path to the PEM encoded server certificate file                                    | ""                               |
+| MG_WS_ADAPTER_HTTP_SERVER_KEY      | Path to the PEM encoded server key file                                            | ""                               |
+| MG_WS_ADAPTER_HTTP_SERVER_CA_CERTS | Path to the PEM encoded server CA certificate file                                 | ""                               |
+| MG_WS_ADAPTER_HTTP_CLIENT_CA_CERTS | Path to the PEM encoded client CA certificate file                                 | ""                               |
+| MG_THINGS_AUTH_GRPC_URL            | Things service Auth gRPC URL                                                       | <things:7000>                    |
+| MG_THINGS_AUTH_GRPC_TIMEOUT        | Things service Auth gRPC request timeout in seconds                                | 1s                               |
+| MG_THINGS_AUTH_GRPC_CLIENT_CERT    | Path to the PEM encoded things service Auth gRPC client certificate file           | ""                               |
+| MG_THINGS_AUTH_GRPC_CLIENT_KEY     | Path to the PEM encoded things service Auth gRPC client key file                   | ""                               |
+| MG_THINGS_AUTH_GRPC_SERVER_CERTS   | Path to the PEM encoded things server Auth gRPC server trusted CA certificate file | ""                               |
+| MG_MESSAGE_BROKER_URL              | Message broker instance URL                                                        | <nats://broker:4222>             |
+| MG_JAEGER_URL                      | Jaeger server URL                                                                  | <http://jaeger:14268/api/traces> |
+| MG_JAEGER_TRACE_RATIO              | Jaeger sampling ratio                                                              | 1.0                              |
+| MG_SEND_TELEMETRY                  | Send telemetry to magistrala call home server                                      | true                             |
+| MG_WS_ADAPTER_INSTANCE_ID          | Service instance ID                                                                | ""                               |
 
 ## Deployment
 
-The service is distributed as Docker container. Check the [`ws-adapter`](https://github.com/absmach/magistrala/blob/master/docker/docker-compose.yml#L350-L368) service section in docker-compose to see how the service is deployed.
+The service is distributed as Docker container. Check the [`ws-adapter`](https://github.com/absmach/magistrala/blob/master/docker/docker-compose.yml) service section in docker-compose to see how the service is deployed.
 
-Running this service outside of container requires working instance of the message broker service.
+Running this service outside of container requires working instance of the message broker service, things service and Jaeger server.
 To start the service outside of the container, execute the following shell script:
 
 ```bash
@@ -44,23 +46,30 @@ make ws
 make install
 
 # set the environment variables and run the service
-MG_WS_ADAPTER_LOG_LEVEL=[WS adapter log level] \
-MG_WS_ADAPTER_HTTP_HOST=[Service WS host] \
-MG_WS_ADAPTER_HTTP_PORT=[Service WS port] \
-MG_WS_ADAPTER_HTTP_SERVER_CERT=[Service WS server certificate] \
-MG_WS_ADAPTER_HTTP_SERVER_KEY=[Service WS server key] \
-MG_THINGS_AUTH_GRPC_URL=[Things service Auth gRPC URL] \
-MG_THINGS_AUTH_GRPC_TIMEOUT=[Things service Auth gRPC request timeout in seconds] \
-MG_THINGS_AUTH_GRPC_CLIENT_TLS=[Flag that indicates if TLS should be turned on] \
-MG_THINGS_AUTH_GRPC_CA_CERTS=[Path to trusted CAs in PEM format] \
-MG_MESSAGE_BROKER_URL=[Message broker instance URL] \
-MG_JAEGER_URL=[Jaeger server URL] \
-MG_SEND_TELEMETRY=[Send telemetry to magistrala call home server] \
-MG_WS_ADAPTER_INSTANCE_ID=[Service instance ID] \
+MG_WS_ADAPTER_LOG_LEVEL=info \
+MG_WS_ADAPTER_HTTP_HOST=localhost \
+MG_WS_ADAPTER_HTTP_PORT=8190 \
+MG_WS_ADAPTER_HTTP_SERVER_CERT="" \
+MG_WS_ADAPTER_HTTP_SERVER_KEY="" \
+MG_WS_ADAPTER_HTTP_SERVER_CA_CERTS="" \
+MG_WS_ADAPTER_HTTP_CLIENT_CA_CERTS="" \
+MG_THINGS_AUTH_GRPC_URL=localhost:7000 \
+MG_THINGS_AUTH_GRPC_TIMEOUT=1s \
+MG_THINGS_AUTH_GRPC_CLIENT_CERT="" \
+MG_THINGS_AUTH_GRPC_CLIENT_KEY="" \
+MG_THINGS_AUTH_GRPC_SERVER_CERTS="" \
+MG_MESSAGE_BROKER_URL=nats://localhost:4222 \
+MG_JAEGER_URL=http://localhost:14268/api/traces \
+MG_JAEGER_TRACE_RATIO=1.0 \
+MG_SEND_TELEMETRY=true \
+MG_WS_ADAPTER_INSTANCE_ID="" \
 $GOBIN/magistrala-ws
 ```
 
+Setting `MG_WS_ADAPTER_HTTP_SERVER_CERT` and `MG_WS_ADAPTER_HTTP_SERVER_KEY` will enable TLS against the service. The service expects a file in PEM format for both the certificate and the key. Setting `MG_WS_ADAPTER_HTTP_SERVER_CA_CERTS` will enable TLS against the service trusting only those CAs that are provided. The service expects a file in PEM format of trusted CAs. Setting `MG_WS_ADAPTER_HTTP_CLIENT_CA_CERTS` will enable TLS against the service trusting only those CAs that are provided. The service expects a file in PEM format of trusted CAs.
+
+Setting `MG_THINGS_AUTH_GRPC_CLIENT_CERT` and `MG_THINGS_AUTH_GRPC_CLIENT_KEY` will enable TLS against the things service. The service expects a file in PEM format for both the certificate and the key. Setting `MG_THINGS_AUTH_GRPC_SERVER_CERTS` will enable TLS against the things service trusting only those CAs that are provided. The service expects a file in PEM format of trusted CAs.
+
 ## Usage
 
-For more information about service capabilities and its usage, please check out
-the [WebSocket paragraph](https://mainflux.readthedocs.io/en/latest/messaging/#websocket) in the Getting Started guide.
+For more information about service capabilities and its usage, please check out the [WebSocket section](https://docs.mainflux.io/messaging/#websocket).

--- a/ws/api/transport.go
+++ b/ws/api/transport.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	protocol            = "ws"
+	service             = "ws"
 	readwriteBufferSize = 1024
 )
 
@@ -42,7 +42,8 @@ func MakeHandler(ctx context.Context, svc ws.Service, l mglog.Logger, instanceID
 	mux := bone.New()
 	mux.GetFunc("/channels/:chanID/messages", handshake(ctx, svc))
 	mux.GetFunc("/channels/:chanID/messages/*", handshake(ctx, svc))
-	mux.GetFunc("/version", magistrala.Health(protocol, instanceID))
+
+	mux.GetFunc("/health", magistrala.Health(service, instanceID))
 	mux.Handle("/metrics", promhttp.Handler())
 
 	return mux

--- a/ws/handler.go
+++ b/ws/handler.go
@@ -135,13 +135,13 @@ func (h *handler) Publish(ctx context.Context, topic *string, payload *[]byte) e
 		return errors.Wrap(ErrFailedPublish, ErrClientNotInitialized)
 	}
 	h.logger.Info(fmt.Sprintf(LogInfoPublished, s.ID, *topic))
-	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
 
 	if len(*payload) == 0 {
 		return ErrFailedMessagePublish
 	}
 
+	// Topics are in the format:
+	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
 	channelParts := channelRegExp.FindStringSubmatch(*topic)
 	if len(channelParts) < 2 {
 		return errors.Wrap(ErrFailedPublish, ErrMalformedTopic)


### PR DESCRIPTION
### What does this do?
Align documentation so the WS service can run outside the container with the necessary dependencies. 
Refactor server configuration i.e removing tagretServerConf as it is used internally to proxy WS connection hence not configurable and update README.md
Add default env variable for host to be localhost

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Manually tested

### Did you document any new/modified functionality?
Yes

### Notes
N/A