### PR TITLE
NOISSUE - Make Username Unique

### DIFF
--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -40,10 +40,12 @@ func Migration() *migrate.MemoryMigrationSource {
 			{
 				Id: "clients_02",
 				Up: []string{
-					`ALTER TABLE clients ADD CONSTRAINT clients_name_key UNIQUE (name)`,
+					`ALTER TABLE clients ALTER COLUMN name SET NOT NULL`,
+					`ALTER TABLE clients ADD CONSTRAINT clients_name_unique UNIQUE (name)`,
 				},
 				Down: []string{
-					`ALTER TABLE clients DROP CONSTRAINT clients_name_key`,
+					`ALTER TABLE clients ALTER COLUMN name DROP NOT NULL`,
+					`ALTER TABLE clients DROP CONSTRAINT clients_name_unique`,
 				},
 			},
 		},

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -20,7 +20,7 @@ func Migration() *migrate.MemoryMigrationSource {
 				Up: []string{
 					`CREATE TABLE IF NOT EXISTS clients (
 						id          VARCHAR(36) PRIMARY KEY,
-						name        VARCHAR(254),
+						name        VARCHAR(254) NOT NULL UNIQUE,
 						owner_id    VARCHAR(36),
 						identity    VARCHAR(254) NOT NULL UNIQUE,
 						secret      TEXT NOT NULL,
@@ -35,17 +35,6 @@ func Migration() *migrate.MemoryMigrationSource {
 				},
 				Down: []string{
 					`DROP TABLE IF EXISTS clients`,
-				},
-			},
-			{
-				Id: "clients_02",
-				Up: []string{
-					`ALTER TABLE clients ALTER COLUMN name SET NOT NULL`,
-					`ALTER TABLE clients ADD CONSTRAINT clients_name_unique UNIQUE (name)`,
-				},
-				Down: []string{
-					`ALTER TABLE clients ALTER COLUMN name DROP NOT NULL`,
-					`ALTER TABLE clients DROP CONSTRAINT clients_name_unique`,
 				},
 			},
 		},

--- a/users/postgres/init.go
+++ b/users/postgres/init.go
@@ -37,6 +37,15 @@ func Migration() *migrate.MemoryMigrationSource {
 					`DROP TABLE IF EXISTS clients`,
 				},
 			},
+			{
+				Id: "clients_02",
+				Up: []string{
+					`ALTER TABLE clients ADD CONSTRAINT clients_name_key UNIQUE (name)`,
+				},
+				Down: []string{
+					`ALTER TABLE clients DROP CONSTRAINT clients_name_key`,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
### What does this do?
This commit adds a new migration to the users. The migration adds a unique constraint to the "clients" table in the database. This constraint ensures that the "name" column of the "clients" table is unique.

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
Make username unique

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

### Notes
N/A