### PR TITLE
NOISSUE - Use Magistrala `errors.Wrap` for HandleError

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -4,8 +4,7 @@
 package postgres
 
 import (
-	"errors"
-
+	"github.com/absmach/magistrala/pkg/errors"
 	repoerror "github.com/absmach/magistrala/pkg/errors/repository"
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -24,13 +23,13 @@ func HandleError(wrapper, err error) error {
 	if ok {
 		switch pqErr.Code {
 		case errDuplicate:
-			return errors.Join(repoerror.ErrConflict, err)
+			return errors.Wrap(repoerror.ErrConflict, err)
 		case errInvalid, errTruncation:
-			return errors.Join(repoerror.ErrMalformedEntity, err)
+			return errors.Wrap(repoerror.ErrMalformedEntity, err)
 		case errFK:
-			return errors.Join(repoerror.ErrCreateEntity, err)
+			return errors.Wrap(repoerror.ErrCreateEntity, err)
 		}
 	}
 
-	return errors.Join(wrapper, err)
+	return errors.Wrap(wrapper, err)
 }

--- a/invitations/postgres/invitations_test.go
+++ b/invitations/postgres/invitations_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/absmach/magistrala/internal/testsutil"
 	"github.com/absmach/magistrala/invitations"
 	"github.com/absmach/magistrala/invitations/postgres"
+	"github.com/absmach/magistrala/pkg/errors"
 	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,7 +175,7 @@ func TestInvitationCreate(t *testing.T) {
 		case err == nil:
 			assert.Nil(t, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		default:
-			assert.ErrorIs(t, err, tc.err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		}
 	}
 }


### PR DESCRIPTION

<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `MG-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/magistrala/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?

This is a bug fix in `postgres.HandleError` to use magistrala errors.Wrap rather than std lib
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

- Updated the error assertion in the invitations_test.go file.
- Replaced the assert.ErrorIs() function with assert.True() and errors.Contains() to check if the expected error is contained in the actual error.

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #137 
- Resolves #

## Have you included tests for your changes?

Yes

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?

No

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
