### PR TITLE
MG-2072 - Allow use of optional handler on logger

### DIFF
--- a/bootstrap/postgres/setup_test.go
+++ b/bootstrap/postgres/setup_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	testLog, _ = mglog.New(os.Stdout, "info")
+	testLog, _ = mglog.New(os.Stdout, "info", nil)
 	db         *sqlx.DB
 )
 

--- a/certs/postgres/setup_test.go
+++ b/certs/postgres/setup_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	testLog, _ = mglog.New(os.Stdout, "info")
+	testLog, _ = mglog.New(os.Stdout, "info", nil)
 	db         *sqlx.DB
 )
 

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -78,7 +78,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err.Error())
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -70,7 +70,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/cassandra-reader/main.go
+++ b/cmd/cassandra-reader/main.go
@@ -53,7 +53,7 @@ func main() {
 		log.Fatalf("failed to load %s service configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/cassandra-writer/main.go
+++ b/cmd/cassandra-writer/main.go
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/certs/main.go
+++ b/cmd/certs/main.go
@@ -72,7 +72,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/influxdb-reader/main.go
+++ b/cmd/influxdb-reader/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/influxdb-writer/main.go
+++ b/cmd/influxdb-writer/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/invitations/main.go
+++ b/cmd/invitations/main.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/lora/main.go
+++ b/cmd/lora/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/mongodb-reader/main.go
+++ b/cmd/mongodb-reader/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/mongodb-writer/main.go
+++ b/cmd/mongodb-writer/main.go
@@ -58,7 +58,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/mqtt/main.go
+++ b/cmd/mqtt/main.go
@@ -75,7 +75,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/opcua/main.go
+++ b/cmd/opcua/main.go
@@ -72,7 +72,7 @@ func main() {
 		log.Fatalf("failed to load %s opcua client configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/postgres-reader/main.go
+++ b/cmd/postgres-reader/main.go
@@ -53,7 +53,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/postgres-writer/main.go
+++ b/cmd/postgres-writer/main.go
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -48,7 +48,7 @@ func main() {
 		log.Fatalf(fmt.Sprintf("failed to load %s configuration : %s", svcName, err))
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.Server.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.Server.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/smpp-notifier/main.go
+++ b/cmd/smpp-notifier/main.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/smtp-notifier/main.go
+++ b/cmd/smtp-notifier/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 
 	var logger *slog.Logger
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/timescale-reader/main.go
+++ b/cmd/timescale-reader/main.go
@@ -53,7 +53,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/timescale-writer/main.go
+++ b/cmd/timescale-writer/main.go
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalf("failed to load %s service configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -71,7 +71,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	cfg.PassRegex = passRegex
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -61,7 +61,7 @@ func main() {
 		log.Fatalf("failed to load %s configuration : %s", svcName, err)
 	}
 
-	logger, err := mglog.New(os.Stdout, cfg.LogLevel)
+	logger, err := mglog.New(os.Stdout, cfg.LogLevel, nil)
 	if err != nil {
 		log.Fatalf("failed to init logger: %s", err.Error())
 	}

--- a/consumers/writers/cassandra/setup_test.go
+++ b/consumers/writers/cassandra/setup_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 )
 
-var logger, _ = mglog.New(os.Stdout, "info")
+var logger, _ = mglog.New(os.Stdout, "info", nil)
 
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")

--- a/consumers/writers/influxdb/consumer_test.go
+++ b/consumers/writers/influxdb/consumer_test.go
@@ -23,7 +23,7 @@ import (
 const valueFields = 5
 
 var (
-	testLog, _    = mglog.New(os.Stdout, "info")
+	testLog, _    = mglog.New(os.Stdout, "info", nil)
 	streamsSize   = 250
 	rowCountSenml = fmt.Sprintf(`from(bucket: "%s") 
 	|> range(start: -1h, stop: 1h) 

--- a/consumers/writers/mongodb/consumer_test.go
+++ b/consumers/writers/mongodb/consumer_test.go
@@ -25,7 +25,7 @@ import (
 var (
 	port        string
 	addr        string
-	testLog, _  = mglog.New(os.Stdout, "info")
+	testLog, _  = mglog.New(os.Stdout, "info", nil)
 	testDB      = "test"
 	collection  = "messages"
 	msgsNum     = 100

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -10,16 +10,19 @@ import (
 	"time"
 )
 
-// New returns wrapped slog logger.
-func New(w io.Writer, levelText string) (*slog.Logger, error) {
+// New returns wrapped slog logger
+// if handler is not set slog.JsonHandler is used.
+func New(w io.Writer, levelText string, handler slog.Handler) (*slog.Logger, error) {
 	var level slog.Level
 	if err := level.UnmarshalText([]byte(levelText)); err != nil {
 		return &slog.Logger{}, fmt.Errorf(`{"level":"error","message":"%s: %s","ts":"%s"}`, err, levelText, time.RFC3339Nano)
 	}
 
-	logHandler := slog.NewJSONHandler(w, &slog.HandlerOptions{
-		Level: level,
-	})
+	if handler == nil {
+		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level: level,
+		})
+	}
 
-	return slog.New(logHandler), nil
+	return slog.New(handler), nil
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -50,7 +50,7 @@ func TestLoggerInitialization(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			writer := &mockWriter{}
-			logger, err := mglog.New(writer, tc.level)
+			logger, err := mglog.New(writer, tc.level, nil)
 			if tc.level == "invalid" {
 				assert.NotNil(t, err, "expected error during logger initialization")
 				assert.NotNil(t, logger, "logger should not be nil when an error occurs")

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -442,7 +442,7 @@ func TestDisconnect(t *testing.T) {
 }
 
 func newHandler() (session.Handler, *authmocks.AuthClient) {
-	logger, err := mglog.New(&logBuffer, "debug")
+	logger, err := mglog.New(&logBuffer, "debug", nil)
 	if err != nil {
 		log.Fatalf("failed to create logger: %s", err)
 	}

--- a/pkg/messaging/mqtt/setup_test.go
+++ b/pkg/messaging/mqtt/setup_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	address = fmt.Sprintf("%s:%s", "localhost", container.GetPort(port))
 	pool.MaxWait = poolMaxWait
 
-	logger, err = mglog.New(os.Stdout, "debug")
+	logger, err = mglog.New(os.Stdout, "debug", nil)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/pkg/messaging/nats/setup_test.go
+++ b/pkg/messaging/nats/setup_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	logger, err := mglog.New(os.Stdout, "error")
+	logger, err := mglog.New(os.Stdout, "error", nil)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/pkg/messaging/rabbitmq/setup_test.go
+++ b/pkg/messaging/rabbitmq/setup_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	logger, err = mglog.New(os.Stdout, "debug")
+	logger, err = mglog.New(os.Stdout, "debug", nil)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/readers/cassandra/setup_test.go
+++ b/readers/cassandra/setup_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 )
 
-var logger, _ = mglog.New(os.Stdout, "info")
+var logger, _ = mglog.New(os.Stdout, "info", nil)
 
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")

--- a/readers/influxdb/setup_test.go
+++ b/readers/influxdb/setup_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	testLog, _ = mglog.New(os.Stdout, "info")
+	testLog, _ = mglog.New(os.Stdout, "info", nil)
 	address    string
 )
 

--- a/readers/mongodb/setup_test.go
+++ b/readers/mongodb/setup_test.go
@@ -17,7 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-var testLog, _ = mglog.New(os.Stdout, "info")
+var testLog, _ = mglog.New(os.Stdout, "info", nil)
 
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")

--- a/tools/mqtt-bench/bench.go
+++ b/tools/mqtt-bench/bench.go
@@ -22,7 +22,7 @@ func Benchmark(cfg Config) error {
 	if err := checkConnection(cfg.MQTT.Broker.URL, 1); err != nil {
 		return err
 	}
-	logger, err := mglog.New(os.Stdout, "debug")
+	logger, err := mglog.New(os.Stdout, "debug", nil)
 	if err != nil {
 		return err
 	}

--- a/twins/mongodb/twins_test.go
+++ b/twins/mongodb/twins_test.go
@@ -36,7 +36,7 @@ const (
 var (
 	port        string
 	addr        string
-	testLog, _  = mglog.New(os.Stdout, "info")
+	testLog, _  = mglog.New(os.Stdout, "info", nil)
 	idProvider  = uuid.New()
 	invalidName = strings.Repeat("m", maxNameSize+1)
 )


### PR DESCRIPTION
# What type of PR is this?
This is a feature which allows setting og the logger handler

## What does this do?
Allows setting of logger handler, if not set json handler is used.

## Which issue(s) does this PR fix/relate to?
- Resolves #2072 

## Have you included tests for your changes?
No I have not added tests as this does not alter current core functionality

## Did you document any new/modified feature?

Yes I have added inline comments

### Notes

<!--Please provide any additional information you feel is important.-->
