### PR TITLE
MG-2117 - Remove repository errors from API layer

### DIFF
--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -152,6 +152,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/DomainPermissionRes"
+        "400":
+          description: Malformed entity specification.
         "401":
           description: Missing or invalid access token provided.
         "404":

--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -156,6 +156,8 @@ paths:
           description: Malformed entity specification.
         "401":
           description: Missing or invalid access token provided.
+        "403":
+          description: Failed authorization over the domain.
         "404":
           description: A non-existent entity request.
         "422":

--- a/api/openapi/bootstrap.yml
+++ b/api/openapi/bootstrap.yml
@@ -96,6 +96,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/ConfigRes"
+        "400":
+          description: Missing or invalid config.
         "401":
           description: Missing or invalid access token provided.
         "404":

--- a/api/openapi/users.yml
+++ b/api/openapi/users.yml
@@ -519,6 +519,8 @@ paths:
           $ref: "#/components/responses/TokenRes"
         "400":
           description: Failed due to malformed JSON.
+        "401":
+          description: Missing or invalid access token provided.
         "404":
           description: A non-existent entity request.
         "415":

--- a/api/openapi/users.yml
+++ b/api/openapi/users.yml
@@ -419,6 +419,8 @@ paths:
           description: Failed due to malformed JSON.
         "401":
           description: Missing or invalid access token provided.
+        "404":
+          description: Entity not found.
         "415":
           description: Missing or invalid content type.
         "422":

--- a/auth/api/http/domains/endpoint_test.go
+++ b/auth/api/http/domains/endpoint_test.go
@@ -307,21 +307,21 @@ func TestListDomains(t *testing.T) {
 			err:    nil,
 		},
 		{
-			desc:   "list domains  with empty name",
+			desc:   "list domains with empty name",
 			token:  validToken,
 			query:  "name= ",
 			status: http.StatusBadRequest,
 			err:    apiutil.ErrValidation,
 		},
 		{
-			desc:   "list domains  with duplicate name",
+			desc:   "list domains with duplicate name",
 			token:  validToken,
 			query:  "name=1&name=2",
 			status: http.StatusBadRequest,
 			err:    apiutil.ErrInvalidQueryParams,
 		},
 		{
-			desc:  "list domains  with status",
+			desc:  "list domains with status",
 			token: validToken,
 			listDomainsRequest: auth.DomainsPage{
 				Total:   1,
@@ -332,7 +332,7 @@ func TestListDomains(t *testing.T) {
 			err:    nil,
 		},
 		{
-			desc:   "list domains  with invalid status",
+			desc:   "list domains with invalid status",
 			token:  validToken,
 			query:  "status=invalid",
 			status: http.StatusBadRequest,
@@ -1047,7 +1047,7 @@ func TestAssignDomainUsers(t *testing.T) {
 			contentType: contentType,
 			token:       validToken,
 			status:      http.StatusBadRequest,
-			err:         apiutil.ErrValidation,
+			err:         apiutil.ErrMissingID,
 		},
 		{
 			desc:        "assign domain users with empty relation",
@@ -1056,7 +1056,7 @@ func TestAssignDomainUsers(t *testing.T) {
 			contentType: contentType,
 			token:       validToken,
 			status:      http.StatusBadRequest,
-			err:         apiutil.ErrValidation,
+			err:         apiutil.ErrMalformedPolicy,
 		},
 	}
 

--- a/auth/api/http/keys/endpoint_test.go
+++ b/auth/api/http/keys/endpoint_test.go
@@ -239,7 +239,7 @@ func TestRetrieve(t *testing.T) {
 			desc:   "retrieve a non-existing key",
 			id:     "non-existing",
 			token:  token.AccessToken,
-			status: http.StatusNotFound,
+			status: http.StatusBadRequest,
 			err:    svcerr.ErrNotFound,
 		},
 		{

--- a/auth/service.go
+++ b/auth/service.go
@@ -186,7 +186,14 @@ func (svc service) Authorize(ctx context.Context, pr PolicyReq) error {
 func (svc service) checkPolicy(ctx context.Context, pr PolicyReq) error {
 	// Domain status is required for if user sent authorization request on things, channels, groups and domains
 	if pr.SubjectType == UserType && (pr.ObjectType == GroupType || pr.ObjectType == ThingType || pr.ObjectType == DomainType) {
-		if err := svc.checkDomain(ctx, pr.SubjectType, pr.Subject, pr.Domain); err != nil {
+		domainID := pr.Domain
+		if domainID == "" {
+			if pr.ObjectType != DomainType {
+				return svcerr.ErrDomainAuthorization
+			}
+			domainID = pr.Object
+		}
+		if err := svc.checkDomain(ctx, pr.SubjectType, pr.Subject, domainID); err != nil {
 			return err
 		}
 	}

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -215,6 +215,7 @@ func TestIssue(t *testing.T) {
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
+				Object:      groupName,
 			},
 			checkPolicyErr:       repoerr.ErrNotFound,
 			retrieveByIDResponse: auth.Domain{},
@@ -253,6 +254,7 @@ func TestIssue(t *testing.T) {
 				Permission:  auth.MembershipPermission,
 			},
 			checkPolicyErr:       svcerr.ErrAuthorization,
+			checkPolicyErr1:      svcerr.ErrAuthorization,
 			retrieveByIDResponse: auth.Domain{Status: auth.EnabledStatus},
 			err:                  svcerr.ErrAuthorization,
 		},
@@ -288,7 +290,7 @@ func TestIssue(t *testing.T) {
 				Permission:  auth.MembershipPermission,
 			},
 			checkPolicyErr:       svcerr.ErrAuthorization,
-			checkPolicyErr1:      nil,
+			checkPolicyErr1:      svcerr.ErrAuthorization,
 			retrieveByIDResponse: auth.Domain{Status: auth.EnabledStatus},
 			err:                  svcerr.ErrAuthorization,
 		},
@@ -443,6 +445,7 @@ func TestIssue(t *testing.T) {
 				Subject:     "mgx_test@example.com",
 				SubjectType: auth.UserType,
 				SubjectKind: "",
+				Object:      groupName,
 				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -522,6 +525,7 @@ func TestIssue(t *testing.T) {
 			},
 			checkPolicyRequest1: auth.PolicyReq{
 				SubjectType: auth.UserType,
+				Object:      groupName,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -876,8 +880,9 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
-				Permission:  auth.AdminPermission,
+				Permission:  auth.MembershipPermission,
 			},
 			checkPolicyReq1: auth.PolicyReq{
 				Subject:     id,
@@ -890,8 +895,9 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
-				Permission:  auth.MembershipPermission,
+				Permission:  auth.AdminPermission,
 			},
 
 			retrieveDomainRes: auth.Domain{
@@ -928,6 +934,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -968,6 +975,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1007,6 +1015,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1047,6 +1056,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1080,6 +1090,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1104,6 +1115,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1128,6 +1140,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1153,6 +1166,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1177,6 +1191,7 @@ func TestAuthorize(t *testing.T) {
 			checkPolicyReq2: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
+				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -1184,6 +1199,7 @@ func TestAuthorize(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
+		fmt.Println(tc.desc)
 		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq).Return(tc.checkPolicyErr)
 		repoCall1 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(tc.retrieveDomainRes, nil)
 		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq1).Return(tc.checkPolicyErr1)
@@ -1197,7 +1213,7 @@ func TestAuthorize(t *testing.T) {
 		repoCall3.Unset()
 		repoCall4.Unset()
 	}
-
+	fmt.Println("Cases 1 end")
 	cases2 := []struct {
 		desc      string
 		policyReq auth.PolicyReq

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -133,19 +133,19 @@ func TestIssue(t *testing.T) {
 	}
 
 	cases2 := []struct {
-		desc                 string
-		key                  auth.Key
-		saveResponse         auth.Key
-		retrieveByIDResponse auth.Domain
-		token                string
-		saveErr              error
-		checkPolicyRequest   auth.PolicyReq
-		checkPolicyRequest1  auth.PolicyReq
-		checkPolicyRequest2  auth.PolicyReq
-		checkPolicyErr       error
-		checkPolicyErr1      error
-		retreiveByIDErr      error
-		err                  error
+		desc                   string
+		key                    auth.Key
+		saveResponse           auth.Key
+		retrieveByIDResponse   auth.Domain
+		token                  string
+		saveErr                error
+		checkPolicyReq3uest     auth.PolicyReq
+		checkPlatformPolicyReq auth.PolicyReq
+		checkDomainPolicyReq   auth.PolicyReq
+		checkPolicyErr         error
+		checkPolicyErr1        error
+		retreiveByIDErr        error
+		err                    error
 	}{
 		{
 			desc: "issue login key",
@@ -153,16 +153,13 @@ func TestIssue(t *testing.T) {
 				Type:     auth.AccessKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -177,16 +174,13 @@ func TestIssue(t *testing.T) {
 				IssuedAt: time.Now(),
 				Domain:   groupName,
 			},
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -202,16 +196,13 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkPlatformPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -230,25 +221,19 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
-				Subject:     "",
+			checkPlatformPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      groupName,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyRequest2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -266,25 +251,19 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
-				Subject:     "",
+			checkPlatformPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      groupName,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyRequest2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -302,25 +281,19 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
-				Subject:     "",
+			checkPlatformPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      groupName,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyRequest2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
@@ -333,10 +306,10 @@ func TestIssue(t *testing.T) {
 	}
 	for _, tc := range cases2 {
 		repoCall := krepo.On("Save", mock.Anything, mock.Anything).Return(mock.Anything, tc.saveErr)
-		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest).Return(tc.checkPolicyErr)
-		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest1).Return(tc.checkPolicyErr1)
+		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3uest).Return(tc.checkPolicyErr)
+		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPlatformPolicyReq).Return(tc.checkPolicyErr1)
 		repoCall3 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(tc.retrieveByIDResponse, tc.retreiveByIDErr)
-		repoCall4 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest2).Return(tc.checkPolicyErr)
+		repoCall4 := prepo.On("CheckPolicy", mock.Anything, tc.checkDomainPolicyReq).Return(tc.checkPolicyErr)
 		_, err := svc.Issue(context.Background(), tc.token, tc.key)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 		repoCall.Unset()
@@ -399,14 +372,14 @@ func TestIssue(t *testing.T) {
 	}
 
 	cases4 := []struct {
-		desc                string
-		key                 auth.Key
-		token               string
-		checkPolicyRequest  auth.PolicyReq
-		checkPolicyRequest1 auth.PolicyReq
-		checkPolicyErr      error
-		retrieveByIDErr     error
-		err                 error
+		desc                 string
+		key                  auth.Key
+		token                string
+		checkPolicyReq3uest   auth.PolicyReq
+		checkDOmainPolicyReq auth.PolicyReq
+		checkPolicyErr       error
+		retrieveByIDErr      error
+		err                  error
 	}{
 		{
 			desc: "issue refresh key",
@@ -414,12 +387,10 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest: auth.PolicyReq{
+			checkPolicyReq3uest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
@@ -432,21 +403,17 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest: auth.PolicyReq{
+			checkPolicyReq3uest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDOmainPolicyReq: auth.PolicyReq{
 				Subject:     "mgx_test@example.com",
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      groupName,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -461,11 +428,9 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDOmainPolicyReq: auth.PolicyReq{
 				Subject:     "mgx_test@example.com",
 				SubjectType: auth.UserType,
-				SubjectKind: "",
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -478,11 +443,9 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDOmainPolicyReq: auth.PolicyReq{
 				Subject:     "mgx_test@example.com",
 				SubjectType: auth.UserType,
-				SubjectKind: "",
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -495,12 +458,10 @@ func TestIssue(t *testing.T) {
 				Type:     auth.InvitationKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyRequest: auth.PolicyReq{
+			checkPolicyReq3uest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
@@ -514,16 +475,13 @@ func TestIssue(t *testing.T) {
 				IssuedAt: time.Now(),
 				Domain:   groupName,
 			},
-			checkPolicyRequest: auth.PolicyReq{
-				Subject:     "",
+			checkPolicyReq3uest: auth.PolicyReq{
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyRequest1: auth.PolicyReq{
+			checkDOmainPolicyReq: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      groupName,
 				ObjectType:  auth.DomainType,
@@ -536,9 +494,9 @@ func TestIssue(t *testing.T) {
 		},
 	}
 	for _, tc := range cases4 {
-		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest).Return(tc.checkPolicyErr)
+		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3uest).Return(tc.checkPolicyErr)
 		repoCall1 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(auth.Domain{}, tc.retrieveByIDErr)
-		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest1).Return(tc.checkPolicyErr)
+		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkDOmainPolicyReq).Return(tc.checkPolicyErr)
 		_, err := svc.Issue(context.Background(), tc.token, tc.key)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
 		repoCall.Unset()
@@ -802,16 +760,16 @@ func TestAuthorize(t *testing.T) {
 	emptyDomain, _ := te.Issue(key)
 
 	cases := []struct {
-		desc              string
-		policyReq         auth.PolicyReq
-		retrieveDomainRes auth.Domain
-		checkPolicyReq    auth.PolicyReq
-		checkPolicyReq1   auth.PolicyReq
-		checkPolicyReq2   auth.PolicyReq
-		checkPolicyErr    error
-		checkPolicyErr1   error
-		checkPolicyErr2   error
-		err               error
+		desc                 string
+		policyReq            auth.PolicyReq
+		retrieveDomainRes    auth.Domain
+		checkPolicyReq3       auth.PolicyReq
+		checkAdminPolicyReq  auth.PolicyReq
+		checkDomainPolicyReq auth.PolicyReq
+		checkPolicyErr       error
+		checkPolicyErr1      error
+		checkPolicyErr2      error
+		err                  error
 	}{
 		{
 			desc: "authorize token successfully",
@@ -823,7 +781,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     id,
 				SubjectType: auth.UserType,
@@ -832,7 +790,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
@@ -850,7 +808,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.GroupType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -858,7 +816,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.GroupType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
@@ -877,14 +835,14 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -892,7 +850,7 @@ func TestAuthorize(t *testing.T) {
 				Object:      validID,
 				ObjectType:  auth.DomainType,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -917,13 +875,13 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -931,7 +889,7 @@ func TestAuthorize(t *testing.T) {
 				Object:      validID,
 				ObjectType:  auth.DomainType,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -957,7 +915,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -965,14 +923,14 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Permission:  auth.AdminPermission,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -997,7 +955,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -1005,14 +963,14 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Permission:  auth.AdminPermission,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1038,7 +996,7 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
@@ -1046,14 +1004,14 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Permission:  auth.AdminPermission,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1079,15 +1037,14 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1106,13 +1063,13 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1131,13 +1088,13 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformKind,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1149,21 +1106,20 @@ func TestAuthorize(t *testing.T) {
 		{
 			desc: "authorize a user key successfully",
 			policyReq: auth.PolicyReq{
-				Subject:     "",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.UsersKind,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				SubjectKind: auth.UsersKind,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1182,13 +1138,13 @@ func TestAuthorize(t *testing.T) {
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      validID,
@@ -1200,10 +1156,10 @@ func TestAuthorize(t *testing.T) {
 	}
 	for _, tc := range cases {
 		fmt.Println(tc.desc)
-		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq).Return(tc.checkPolicyErr)
+		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3).Return(tc.checkPolicyErr)
 		repoCall1 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(tc.retrieveDomainRes, nil)
-		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq1).Return(tc.checkPolicyErr1)
-		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq2).Return(tc.checkPolicyErr1)
+		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkAdminPolicyReq).Return(tc.checkPolicyErr1)
+		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkDomainPolicyReq).Return(tc.checkPolicyErr1)
 		repoCall4 := krepo.On("Remove", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		err := svc.Authorize(context.Background(), tc.policyReq)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s got %s\n", tc.desc, tc.err, err))
@@ -1222,7 +1178,6 @@ func TestAuthorize(t *testing.T) {
 		{
 			desc: "authorize token with invalid platform validation",
 			policyReq: auth.PolicyReq{
-				Subject:     "",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.UsersKind,
 				Object:      validID,
@@ -2207,22 +2162,22 @@ func TestAssignUsers(t *testing.T) {
 	svc, accessToken := newService()
 
 	cases := []struct {
-		desc              string
-		token             string
-		domainID          string
-		userIDs           []string
-		relation          string
-		checkPolicyReq    auth.PolicyReq
-		checkPolicyReq1   auth.PolicyReq
-		checkPolicyReq2   auth.PolicyReq
-		checkPolicyReq3   auth.PolicyReq
-		checkpolicyErr    error
-		checkPolicyErr1   error
-		checkPolicyErr2   error
-		addPoliciesErr    error
-		savePoliciesErr   error
-		deletePoliciesErr error
-		err               error
+		desc                 string
+		token                string
+		domainID             string
+		userIDs              []string
+		relation             string
+		checkPolicyReq3       auth.PolicyReq
+		checkAdminPolicyReq  auth.PolicyReq
+		checkDomainPolicyReq auth.PolicyReq
+		checkPolicyReq33      auth.PolicyReq
+		checkpolicyErr       error
+		checkPolicyErr1      error
+		checkPolicyErr2      error
+		addPoliciesErr       error
+		savePoliciesErr      error
+		deletePoliciesErr    error
+		err                  error
 	}{
 		{
 			desc:     "assign users successfully",
@@ -2230,36 +2185,32 @@ func TestAssignUsers(t *testing.T) {
 			domainID: validID,
 			userIDs:  []string{validID},
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     validID,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2275,32 +2226,28 @@ func TestAssignUsers(t *testing.T) {
 			domainID: validID,
 			userIDs:  []string{validID},
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     validID,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
@@ -2311,27 +2258,25 @@ func TestAssignUsers(t *testing.T) {
 			token:    accessToken,
 			domainID: inValid,
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      inValid,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      inValid,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2347,36 +2292,32 @@ func TestAssignUsers(t *testing.T) {
 			userIDs:  []string{inValid},
 			domainID: validID,
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     inValid,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2392,36 +2333,32 @@ func TestAssignUsers(t *testing.T) {
 			domainID: validID,
 			userIDs:  []string{validID},
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     validID,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2437,36 +2374,32 @@ func TestAssignUsers(t *testing.T) {
 			domainID: validID,
 			userIDs:  []string{validID},
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     validID,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2482,36 +2415,32 @@ func TestAssignUsers(t *testing.T) {
 			domainID: validID,
 			userIDs:  []string{validID},
 			relation: auth.ViewerRelation,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.ViewPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     validID,
 				SubjectType: auth.UserType,
-				SubjectKind: "",
 				Object:      auth.MagistralaObject,
-				ObjectKind:  "",
 				ObjectType:  auth.PlatformType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq3: auth.PolicyReq{
+			checkPolicyReq33: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2526,10 +2455,10 @@ func TestAssignUsers(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := drepo.On("RetrieveByID", mock.Anything, groupName).Return(auth.Domain{}, nil)
-		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq).Return(tc.checkpolicyErr)
-		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq1).Return(tc.checkPolicyErr1)
-		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq2).Return(tc.checkPolicyErr2)
-		repoCall4 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3).Return(tc.checkPolicyErr2)
+		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3).Return(tc.checkpolicyErr)
+		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkAdminPolicyReq).Return(tc.checkPolicyErr1)
+		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkDomainPolicyReq).Return(tc.checkPolicyErr2)
+		repoCall4 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq33).Return(tc.checkPolicyErr2)
 		repoCall5 := prepo.On("AddPolicies", mock.Anything, mock.Anything).Return(tc.addPoliciesErr)
 		repoCall6 := drepo.On("SavePolicies", mock.Anything, mock.Anything, mock.Anything).Return(tc.savePoliciesErr)
 		repoCall7 := prepo.On("DeletePolicies", mock.Anything, mock.Anything).Return(tc.deletePoliciesErr)
@@ -2550,46 +2479,44 @@ func TestUnassignUsers(t *testing.T) {
 	svc, accessToken := newService()
 
 	cases := []struct {
-		desc               string
-		token              string
-		domainID           string
-		checkPolicyReq     auth.PolicyReq
-		checkPolicyReq1    auth.PolicyReq
-		checkPolicyReq2    auth.PolicyReq
-		checkPolicyErr     error
-		checkPolicyErr1    error
-		deletePoliciesErr  error
-		deletePoliciesErr1 error
-		err                error
+		desc                 string
+		token                string
+		domainID             string
+		checkPolicyReq3       auth.PolicyReq
+		checkAdminPolicyReq  auth.PolicyReq
+		checkDomainPolicyReq auth.PolicyReq
+		checkPolicyErr       error
+		checkPolicyErr1      error
+		deletePoliciesErr    error
+		deletePoliciesErr1   error
+		err                  error
 	}{
 		{
 			desc:     "unassign users successfully",
 			token:    accessToken,
 			domainID: validID,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.MembershipPermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
@@ -2599,23 +2526,21 @@ func TestUnassignUsers(t *testing.T) {
 			desc:     "unassign users with invalid token",
 			token:    inValidToken,
 			domainID: validID,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
@@ -2625,27 +2550,25 @@ func TestUnassignUsers(t *testing.T) {
 			desc:     "unassign users with invalid domainID",
 			token:    accessToken,
 			domainID: inValid,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      inValid,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      inValid,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2659,27 +2582,25 @@ func TestUnassignUsers(t *testing.T) {
 			desc:     "unassign users with failed to delete policies from agent",
 			token:    accessToken,
 			domainID: validID,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2693,27 +2614,25 @@ func TestUnassignUsers(t *testing.T) {
 			desc:     "unassign users with failed to delete policies from domain",
 			token:    accessToken,
 			domainID: validID,
-			checkPolicyReq: auth.PolicyReq{
+			checkPolicyReq3: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.SharePermission,
 			},
-			checkPolicyReq1: auth.PolicyReq{
+			checkAdminPolicyReq: auth.PolicyReq{
 				Domain:      groupName,
 				Subject:     "testID",
 				SubjectType: auth.UserType,
 				SubjectKind: auth.TokenKind,
 				Object:      validID,
-				ObjectKind:  "",
 				ObjectType:  auth.DomainType,
 				Permission:  auth.AdminPermission,
 			},
-			checkPolicyReq2: auth.PolicyReq{
+			checkDomainPolicyReq: auth.PolicyReq{
 				Subject:     id,
 				SubjectType: auth.UserType,
 				Object:      "mgx",
@@ -2727,9 +2646,9 @@ func TestUnassignUsers(t *testing.T) {
 
 	for _, tc := range cases {
 		repoCall := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(auth.Domain{}, nil)
-		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq).Return(tc.checkPolicyErr)
-		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq1).Return(tc.checkPolicyErr1)
-		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq2).Return(tc.checkPolicyErr1)
+		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3).Return(tc.checkPolicyErr)
+		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkAdminPolicyReq).Return(tc.checkPolicyErr1)
+		repoCall3 := prepo.On("CheckPolicy", mock.Anything, tc.checkDomainPolicyReq).Return(tc.checkPolicyErr1)
 		repoCall4 := prepo.On("DeletePolicies", mock.Anything, mock.Anything, mock.Anything).Return(tc.deletePoliciesErr)
 		repoCall5 := drepo.On("DeletePolicies", mock.Anything, mock.Anything, mock.Anything).Return(tc.deletePoliciesErr1)
 		err := svc.UnassignUsers(context.Background(), tc.token, tc.domainID, []string{" ", " "}, auth.AdministratorRelation)

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -139,7 +139,7 @@ func TestIssue(t *testing.T) {
 		retrieveByIDResponse   auth.Domain
 		token                  string
 		saveErr                error
-		checkPolicyReq3uest     auth.PolicyReq
+		checkPolicyRequest     auth.PolicyReq
 		checkPlatformPolicyReq auth.PolicyReq
 		checkDomainPolicyReq   auth.PolicyReq
 		checkPolicyErr         error
@@ -153,7 +153,7 @@ func TestIssue(t *testing.T) {
 				Type:     auth.AccessKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -174,7 +174,7 @@ func TestIssue(t *testing.T) {
 				IssuedAt: time.Now(),
 				Domain:   groupName,
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -196,7 +196,7 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -221,7 +221,7 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -251,7 +251,7 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -281,7 +281,7 @@ func TestIssue(t *testing.T) {
 				Domain:   groupName,
 			},
 			token: accessToken,
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -306,7 +306,7 @@ func TestIssue(t *testing.T) {
 	}
 	for _, tc := range cases2 {
 		repoCall := krepo.On("Save", mock.Anything, mock.Anything).Return(mock.Anything, tc.saveErr)
-		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3uest).Return(tc.checkPolicyErr)
+		repoCall1 := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest).Return(tc.checkPolicyErr)
 		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkPlatformPolicyReq).Return(tc.checkPolicyErr1)
 		repoCall3 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(tc.retrieveByIDResponse, tc.retreiveByIDErr)
 		repoCall4 := prepo.On("CheckPolicy", mock.Anything, tc.checkDomainPolicyReq).Return(tc.checkPolicyErr)
@@ -375,7 +375,7 @@ func TestIssue(t *testing.T) {
 		desc                 string
 		key                  auth.Key
 		token                string
-		checkPolicyReq3uest   auth.PolicyReq
+		checkPolicyRequest   auth.PolicyReq
 		checkDOmainPolicyReq auth.PolicyReq
 		checkPolicyErr       error
 		retrieveByIDErr      error
@@ -387,7 +387,7 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
@@ -403,7 +403,7 @@ func TestIssue(t *testing.T) {
 				Type:     auth.RefreshKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
@@ -458,7 +458,7 @@ func TestIssue(t *testing.T) {
 				Type:     auth.InvitationKey,
 				IssuedAt: time.Now(),
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				Subject:     email,
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
@@ -475,7 +475,7 @@ func TestIssue(t *testing.T) {
 				IssuedAt: time.Now(),
 				Domain:   groupName,
 			},
-			checkPolicyReq3uest: auth.PolicyReq{
+			checkPolicyRequest: auth.PolicyReq{
 				SubjectType: auth.UserType,
 				Object:      auth.MagistralaObject,
 				ObjectType:  auth.PlatformType,
@@ -494,7 +494,7 @@ func TestIssue(t *testing.T) {
 		},
 	}
 	for _, tc := range cases4 {
-		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyReq3uest).Return(tc.checkPolicyErr)
+		repoCall := prepo.On("CheckPolicy", mock.Anything, tc.checkPolicyRequest).Return(tc.checkPolicyErr)
 		repoCall1 := drepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(auth.Domain{}, tc.retrieveByIDErr)
 		repoCall2 := prepo.On("CheckPolicy", mock.Anything, tc.checkDOmainPolicyReq).Return(tc.checkPolicyErr)
 		_, err := svc.Issue(context.Background(), tc.token, tc.key)
@@ -763,7 +763,7 @@ func TestAuthorize(t *testing.T) {
 		desc                 string
 		policyReq            auth.PolicyReq
 		retrieveDomainRes    auth.Domain
-		checkPolicyReq3       auth.PolicyReq
+		checkPolicyReq3      auth.PolicyReq
 		checkAdminPolicyReq  auth.PolicyReq
 		checkDomainPolicyReq auth.PolicyReq
 		checkPolicyErr       error
@@ -2167,10 +2167,10 @@ func TestAssignUsers(t *testing.T) {
 		domainID             string
 		userIDs              []string
 		relation             string
-		checkPolicyReq3       auth.PolicyReq
+		checkPolicyReq3      auth.PolicyReq
 		checkAdminPolicyReq  auth.PolicyReq
 		checkDomainPolicyReq auth.PolicyReq
-		checkPolicyReq33      auth.PolicyReq
+		checkPolicyReq33     auth.PolicyReq
 		checkpolicyErr       error
 		checkPolicyErr1      error
 		checkPolicyErr2      error
@@ -2482,7 +2482,7 @@ func TestUnassignUsers(t *testing.T) {
 		desc                 string
 		token                string
 		domainID             string
-		checkPolicyReq3       auth.PolicyReq
+		checkPolicyReq3      auth.PolicyReq
 		checkAdminPolicyReq  auth.PolicyReq
 		checkDomainPolicyReq auth.PolicyReq
 		checkPolicyErr       error

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -88,9 +88,9 @@ var (
 
 	missingIDRes  = toJSON(apiutil.ErrorRes{Err: apiutil.ErrMissingID.Error(), Msg: apiutil.ErrValidation.Error()})
 	missingKeyRes = toJSON(apiutil.ErrorRes{Err: apiutil.ErrBearerKey.Error(), Msg: apiutil.ErrValidation.Error()})
-	bsErrorRes    = toJSON(apiutil.ErrorRes{Err: svcerr.ErrNotFound.Error(), Msg: bootstrap.ErrBootstrap.Error()})
+	bsErrorRes    = toJSON(apiutil.ErrorRes{Msg: bootstrap.ErrBootstrap.Error()})
 	extKeyRes     = toJSON(apiutil.ErrorRes{Msg: bootstrap.ErrExternalKey.Error()})
-	extSecKeyRes  = toJSON(apiutil.ErrorRes{Err: "encoding/hex: invalid byte: U+002D '-'", Msg: bootstrap.ErrExternalKeySecure.Error()})
+	extSecKeyRes  = toJSON(apiutil.ErrorRes{Msg: bootstrap.ErrExternalKeySecure.Error()})
 )
 
 type testRequest struct {
@@ -1138,7 +1138,7 @@ func TestBootstrap(t *testing.T) {
 			status:      http.StatusNotFound,
 			res:         bsErrorRes,
 			secure:      false,
-			err:         errors.Wrap(bootstrap.ErrBootstrap, svcerr.ErrNotFound),
+			err:         bootstrap.ErrBootstrap,
 		},
 		{
 			desc:        "bootstrap a Thing with an empty ID",
@@ -1192,7 +1192,7 @@ func TestBootstrap(t *testing.T) {
 			status:      http.StatusForbidden,
 			res:         extSecKeyRes,
 			secure:      true,
-			err:         errors.Wrap(bootstrap.ErrExternalKeySecure, errors.New("encoding/hex: invalid byte: U+002D '-'")),
+			err:         bootstrap.ErrExternalKeySecure,
 		},
 	}
 

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -31,7 +31,9 @@ var (
 	// ErrBootstrap indicates error in getting bootstrap configuration.
 	ErrBootstrap = errors.New("failed to read bootstrap configuration")
 
-	errAddBootstrap       = errors.New("failed to add bootstrap configuration")
+	// ErrAddBootstrap indicates error in adding bootstrap configuration.
+	ErrAddBootstrap = errors.New("failed to add bootstrap configuration")
+
 	errUpdateConnections  = errors.New("failed to update connections")
 	errRemoveBootstrap    = errors.New("failed to remove bootstrap configuration")
 	errChangeState        = errors.New("failed to change state of bootstrap configuration")
@@ -164,7 +166,7 @@ func (bs bootstrapService) Add(ctx context.Context, token string, cfg Config) (C
 				err = errors.Wrap(err, errT)
 			}
 		}
-		return Config{}, errors.Wrap(errAddBootstrap, err)
+		return Config{}, errors.Wrap(ErrAddBootstrap, err)
 	}
 
 	cfg.ThingID = saved

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -400,7 +400,7 @@ func (bs bootstrapService) thing(id, token string) (mgsdk.Thing, error) {
 		}
 		thing, sdkErr := bs.sdk.CreateThing(mgsdk.Thing{ID: id, Name: "Bootstrapped Thing " + id}, token)
 		if sdkErr != nil {
-			return mgsdk.Thing{}, errors.Wrap(errCreateThing, errors.New(sdkErr.Err().Msg()))
+			return mgsdk.Thing{}, errors.Wrap(errCreateThing, sdkErr)
 		}
 		return thing, nil
 	}

--- a/certs/service.go
+++ b/certs/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/absmach/magistrala"
 	"github.com/absmach/magistrala/certs/pki"
 	"github.com/absmach/magistrala/pkg/errors"
-	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
 	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	mgsdk "github.com/absmach/magistrala/pkg/sdk/go"
 )
@@ -156,7 +155,7 @@ func (cs *certsService) ListCerts(ctx context.Context, token, thingID string, of
 
 	cp, err := cs.certsRepo.RetrieveByThing(ctx, u.GetId(), thingID, offset, limit)
 	if err != nil {
-		return Page{}, errors.Wrap(repoerr.ErrNotFound, err)
+		return Page{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}
 
 	for i, cert := range cp.Certs {
@@ -188,7 +187,7 @@ func (cs *certsService) ViewCert(ctx context.Context, token, serialID string) (C
 
 	cert, err := cs.certsRepo.RetrieveBySerial(ctx, u.GetId(), serialID)
 	if err != nil {
-		return Cert{}, errors.Wrap(repoerr.ErrNotFound, err)
+		return Cert{}, errors.Wrap(svcerr.ErrNotFound, err)
 	}
 
 	vcert, err := cs.pki.Read(serialID)

--- a/certs/service.go
+++ b/certs/service.go
@@ -187,7 +187,7 @@ func (cs *certsService) ViewCert(ctx context.Context, token, serialID string) (C
 
 	cert, err := cs.certsRepo.RetrieveBySerial(ctx, u.GetId(), serialID)
 	if err != nil {
-		return Cert{}, errors.Wrap(svcerr.ErrNotFound, err)
+		return Cert{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}
 
 	vcert, err := cs.pki.Read(serialID)

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -106,66 +106,78 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 
 	w.Header().Set("Content-Type", ContentType)
 	switch {
-	case errors.Contains(err, svcerr.ErrMalformedEntity),
-		errors.Contains(err, errors.ErrMalformedEntity),
-		errors.Contains(err, apiutil.ErrMissingID),
-		errors.Contains(err, apiutil.ErrEmptyList),
-		errors.Contains(err, apiutil.ErrMissingMemberType),
-		errors.Contains(err, apiutil.ErrMissingMemberKind),
-		errors.Contains(err, apiutil.ErrLimitSize),
-		errors.Contains(err, apiutil.ErrBearerKey),
-		errors.Contains(err, apiutil.ErrNameSize),
-		errors.Contains(err, apiutil.ErrInvalidIDFormat),
-		errors.Contains(err, svcerr.ErrInvalidStatus),
-		errors.Contains(err, apiutil.ErrValidation),
-		errors.Contains(err, apiutil.ErrInvitationState),
-		errors.Contains(err, apiutil.ErrInvalidRole),
-		errors.Contains(err, apiutil.ErrMissingEmail),
-		errors.Contains(err, apiutil.ErrMissingHost),
-		errors.Contains(err, apiutil.ErrMissingIdentity),
-		errors.Contains(err, apiutil.ErrMissingSecret),
-		errors.Contains(err, apiutil.ErrMissingPass),
-		errors.Contains(err, apiutil.ErrMissingConfPass),
-		errors.Contains(err, apiutil.ErrInvalidResetPass),
-		errors.Contains(err, apiutil.ErrMissingRelation),
-		errors.Contains(err, apiutil.ErrPasswordFormat),
-		errors.Contains(err, apiutil.ErrInvalidLevel),
-		errors.Contains(err, apiutil.ErrMalformedPolicy),
-		errors.Contains(err, apiutil.ErrInvalidAPIKey),
-		errors.Contains(err, apiutil.ErrMissingName),
-		errors.Contains(err, apiutil.ErrBootstrapState),
-		errors.Contains(err, apiutil.ErrMissingCertData),
-		errors.Contains(err, apiutil.ErrInvalidCertData),
-		errors.Contains(err, apiutil.ErrInvalidContact),
-		errors.Contains(err, apiutil.ErrInvalidTopic),
-		errors.Contains(err, apiutil.ErrInvalidQueryParams):
-		w.WriteHeader(http.StatusBadRequest)
-	case errors.Contains(err, svcerr.ErrAuthentication),
-		errors.Contains(err, svcerr.ErrLogin),
-		errors.Contains(err, apiutil.ErrBearerToken):
-		w.WriteHeader(http.StatusUnauthorized)
-	case errors.Contains(err, svcerr.ErrNotFound):
-		w.WriteHeader(http.StatusNotFound)
-	case errors.Contains(err, svcerr.ErrConflict),
-		errors.Contains(err, errors.ErrStatusAlreadyAssigned):
-		w.WriteHeader(http.StatusConflict)
 	case errors.Contains(err, svcerr.ErrAuthorization),
 		errors.Contains(err, svcerr.ErrDomainAuthorization),
 		errors.Contains(err, bootstrap.ErrExternalKey),
 		errors.Contains(err, bootstrap.ErrExternalKeySecure):
+		err = unwrap(err)
 		w.WriteHeader(http.StatusForbidden)
-	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
-		w.WriteHeader(http.StatusUnsupportedMediaType)
+
+	case errors.Contains(err, svcerr.ErrAuthentication),
+		errors.Contains(err, apiutil.ErrBearerToken),
+		errors.Contains(err, svcerr.ErrLogin):
+		err = unwrap(err)
+		w.WriteHeader(http.StatusUnauthorized)
+	case errors.Contains(err, svcerr.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMalformedPolicy),
+		errors.Contains(err, apiutil.ErrMissingSecret),
+		errors.Contains(err, errors.ErrMalformedEntity),
+		errors.Contains(err, apiutil.ErrMissingID),
+		errors.Contains(err, apiutil.ErrMissingName),
+		errors.Contains(err, apiutil.ErrMissingEmail),
+		errors.Contains(err, apiutil.ErrMissingHost),
+		errors.Contains(err, apiutil.ErrInvalidResetPass),
+		errors.Contains(err, apiutil.ErrEmptyList),
+		errors.Contains(err, apiutil.ErrMissingMemberKind),
+		errors.Contains(err, apiutil.ErrMissingMemberType),
+		errors.Contains(err, apiutil.ErrLimitSize),
+		errors.Contains(err, apiutil.ErrBearerKey),
+		errors.Contains(err, svcerr.ErrInvalidStatus),
+		errors.Contains(err, apiutil.ErrNameSize),
+		errors.Contains(err, apiutil.ErrInvalidIDFormat),
+		errors.Contains(err, apiutil.ErrInvalidQueryParams),
+		errors.Contains(err, apiutil.ErrMissingRelation),
+		errors.Contains(err, apiutil.ErrValidation),
+		errors.Contains(err, apiutil.ErrMissingIdentity),
+		errors.Contains(err, apiutil.ErrMissingPass),
+		errors.Contains(err, apiutil.ErrMissingConfPass),
+		errors.Contains(err, apiutil.ErrPasswordFormat),
+		errors.Contains(err, svcerr.ErrInvalidRole),
+		errors.Contains(err, svcerr.ErrInvalidPolicy),
+		errors.Contains(err, apiutil.ErrInvitationState),
+		errors.Contains(err, apiutil.ErrInvalidAPIKey),
+		errors.Contains(err, svcerr.ErrViewEntity),
+		errors.Contains(err, apiutil.ErrBootstrapState),
+		errors.Contains(err, apiutil.ErrMissingCertData),
+		errors.Contains(err, apiutil.ErrMissingCertData),
+		errors.Contains(err, apiutil.ErrInvalidCertData),
+		errors.Contains(err, apiutil.ErrInvalidContact),
+		errors.Contains(err, apiutil.ErrInvalidTopic),
+		errors.Contains(err, apiutil.ErrInvalidCertData):
+		err = unwrap(err)
+		w.WriteHeader(http.StatusBadRequest)
+
 	case errors.Contains(err, svcerr.ErrCreateEntity),
 		errors.Contains(err, svcerr.ErrUpdateEntity),
-		errors.Contains(err, svcerr.ErrFailedUpdateRole),
-		errors.Contains(err, svcerr.ErrViewEntity),
-		errors.Contains(err, svcerr.ErrAddPolicies),
-		errors.Contains(err, svcerr.ErrDeletePolicies),
-		errors.Contains(err, svcerr.ErrRemoveEntity):
+		errors.Contains(err, svcerr.ErrRemoveEntity),
+		errors.Contains(err, svcerr.ErrEnableClient):
+		err = unwrap(err)
 		w.WriteHeader(http.StatusUnprocessableEntity)
-	case errors.Contains(err, bootstrap.ErrThings):
-		w.WriteHeader(http.StatusServiceUnavailable)
+
+	case errors.Contains(err, svcerr.ErrNotFound),
+		errors.Contains(err, bootstrap.ErrBootstrap):
+		err = unwrap(err)
+		w.WriteHeader(http.StatusNotFound)
+
+	case errors.Contains(err, errors.ErrStatusAlreadyAssigned),
+		errors.Contains(err, svcerr.ErrConflict):
+		err = unwrap(err)
+		w.WriteHeader(http.StatusConflict)
+
+	case errors.Contains(err, apiutil.ErrUnsupportedContentType):
+		err = unwrap(err)
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}
@@ -179,4 +191,12 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}
+}
+
+func unwrap(err error) error {
+	wrapper, err := errors.Unwrap(err)
+	if wrapper != nil {
+		return wrapper
+	}
+	return err
 }

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -149,10 +149,10 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Contains(err, svcerr.ErrViewEntity),
 		errors.Contains(err, apiutil.ErrBootstrapState),
 		errors.Contains(err, apiutil.ErrMissingCertData),
-		errors.Contains(err, apiutil.ErrMissingCertData),
 		errors.Contains(err, apiutil.ErrInvalidCertData),
 		errors.Contains(err, apiutil.ErrInvalidContact),
 		errors.Contains(err, apiutil.ErrInvalidTopic),
+		errors.Contains(err, bootstrap.ErrAddBootstrap),
 		errors.Contains(err, apiutil.ErrInvalidCertData):
 		err = unwrap(err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -149,7 +149,6 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Contains(err, svcerr.ErrViewEntity),
 		errors.Contains(err, apiutil.ErrBootstrapState),
 		errors.Contains(err, apiutil.ErrMissingCertData),
-		errors.Contains(err, apiutil.ErrInvalidCertData),
 		errors.Contains(err, apiutil.ErrInvalidContact),
 		errors.Contains(err, apiutil.ErrInvalidTopic),
 		errors.Contains(err, bootstrap.ErrAddBootstrap),

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -234,6 +234,7 @@ func TestEncodeError(t *testing.T) {
 				apiutil.ErrMissingMemberKind,
 				apiutil.ErrLimitSize,
 				apiutil.ErrNameSize,
+				svcerr.ErrViewEntity,
 			},
 			code: http.StatusBadRequest,
 		},
@@ -298,7 +299,6 @@ func TestEncodeError(t *testing.T) {
 			errs: []error{
 				svcerr.ErrCreateEntity,
 				svcerr.ErrUpdateEntity,
-				svcerr.ErrViewEntity,
 				svcerr.ErrRemoveEntity,
 			},
 			code: http.StatusUnprocessableEntity,

--- a/internal/groups/service.go
+++ b/internal/groups/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/absmach/magistrala/internal/apiutil"
 	mgclients "github.com/absmach/magistrala/pkg/clients"
 	"github.com/absmach/magistrala/pkg/errors"
-	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
 	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	"github.com/absmach/magistrala/pkg/groups"
 	"golang.org/x/sync/errgroup"
@@ -117,7 +116,7 @@ func (svc service) ViewGroup(ctx context.Context, token, id string) (groups.Grou
 
 	group, err := svc.groups.RetrieveByID(ctx, id)
 	if err != nil {
-		return groups.Group{}, errors.Wrap(repoerr.ErrViewEntity, err)
+		return groups.Group{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}
 
 	return group, nil
@@ -467,7 +466,7 @@ func (svc service) assignParentGroup(ctx context.Context, domain, parentGroupID 
 	var deletePolicies magistrala.DeletePoliciesReq
 	for _, group := range groupsPage.Groups {
 		if group.Parent != "" {
-			return errors.Wrap(repoerr.ErrConflict, fmt.Errorf("%s group already have parent", group.ID))
+			return errors.Wrap(svcerr.ErrConflict, fmt.Errorf("%s group already have parent", group.ID))
 		}
 		addPolicies.AddPoliciesReq = append(addPolicies.AddPoliciesReq, &magistrala.AddPolicyReq{
 			Domain:      domain,
@@ -513,7 +512,7 @@ func (svc service) unassignParentGroup(ctx context.Context, domain, parentGroupI
 	var deletePolicies magistrala.DeletePoliciesReq
 	for _, group := range groupsPage.Groups {
 		if group.Parent != "" && group.Parent != parentGroupID {
-			return errors.Wrap(repoerr.ErrConflict, fmt.Errorf("%s group doesn't have same parent", group.ID))
+			return errors.Wrap(svcerr.ErrConflict, fmt.Errorf("%s group doesn't have same parent", group.ID))
 		}
 		addPolicies.AddPoliciesReq = append(addPolicies.AddPoliciesReq, &magistrala.AddPolicyReq{
 			Domain:      domain,

--- a/invitations/api/endpoint_test.go
+++ b/invitations/api/endpoint_test.go
@@ -296,7 +296,6 @@ func TestListInvitation(t *testing.T) {
 			token:       tc.token,
 			contentType: tc.contentType,
 		}
-
 		res, err := req.make()
 		assert.Nil(t, err, tc.desc)
 		assert.Equal(t, tc.status, res.StatusCode, tc.desc)

--- a/pkg/errors/service/types.go
+++ b/pkg/errors/service/types.go
@@ -29,7 +29,7 @@ var (
 	ErrConflict = errors.New("entity already exists")
 
 	// ErrCreateEntity indicates error in creating entity or entities.
-	ErrCreateEntity = errors.New("failed to create entity in the db")
+	ErrCreateEntity = errors.New("failed to create entity")
 
 	// ErrRemoveEntity indicates error in removing entity.
 	ErrRemoveEntity = errors.New("failed to remove entity")
@@ -55,18 +55,23 @@ var (
 	// ErrFailedPolicyUpdate indicates a failure to update user policy.
 	ErrFailedPolicyUpdate = errors.New("failed to update user policy")
 
-	// ErrAddPolicies indicates failed to add policies.
-	ErrAddPolicies = errors.New("failed to add policies")
-
-	// ErrDeletePolicies indicates failed to delete policies.
-	ErrDeletePolicies = errors.New("failed to delete policies")
-
-	// ErrIssueToken indicates a failure to issue token.
-	ErrIssueToken = errors.New("failed to issue token")
-
 	// ErrPasswordFormat indicates weak password.
 	ErrPasswordFormat = errors.New("password does not meet the requirements")
 
 	// ErrFailedUpdateRole indicates a failure to update user role.
 	ErrFailedUpdateRole = errors.New("failed to update user role")
+
+	// ErrFailedPermissionsList indicates a failure to list permissions.
+	ErrFailedPermissionsList = errors.New("failed to list permissions")
+	// ErrEnableClient indicates error in enabling client.
+	ErrEnableClient = errors.New("failed to enable client")
+
+	// ErrDisableClient indicates error in disabling client.
+	ErrDisableClient = errors.New("failed to disable client")
+
+	// ErrAddPolicies indicates error in adding policies.
+	ErrAddPolicies = errors.New("failed to add policies")
+
+	// ErrDeletePolicies indicates error in removing policies.
+	ErrDeletePolicies = errors.New("failed to remove policies")
 )

--- a/pkg/errors/service/types.go
+++ b/pkg/errors/service/types.go
@@ -63,6 +63,7 @@ var (
 
 	// ErrFailedPermissionsList indicates a failure to list permissions.
 	ErrFailedPermissionsList = errors.New("failed to list permissions")
+
 	// ErrEnableClient indicates error in enabling client.
 	ErrEnableClient = errors.New("failed to enable client")
 

--- a/pkg/sdk/go/certs_test.go
+++ b/pkg/sdk/go/certs_test.go
@@ -181,7 +181,7 @@ func TestViewCert(t *testing.T) {
 			certID: "43",
 			token:  token,
 			cRes:   c,
-			err:    errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, svcerr.ErrNotFound), http.StatusNotFound),
+			err:    errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, svcerr.ErrViewEntity), http.StatusBadRequest),
 			svcerr: errors.Wrap(svcerr.ErrNotFound, repoerr.ErrNotFound),
 		},
 		{

--- a/pkg/sdk/go/certs_test.go
+++ b/pkg/sdk/go/certs_test.go
@@ -175,13 +175,15 @@ func TestViewCert(t *testing.T) {
 			certID: validID,
 			token:  token,
 			cRes:   c,
+			err:    nil,
+			svcerr: nil,
 		},
 		{
 			desc:   "get non-existent cert",
 			certID: "43",
 			token:  token,
 			cRes:   c,
-			err:    errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, svcerr.ErrViewEntity), http.StatusBadRequest),
+			err:    errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, svcerr.ErrNotFound), http.StatusNotFound),
 			svcerr: errors.Wrap(svcerr.ErrNotFound, repoerr.ErrNotFound),
 		},
 		{
@@ -230,14 +232,8 @@ func TestViewCertByThing(t *testing.T) {
 		{
 			desc:    "get existing cert",
 			thingID: thingID,
-			token:   authmocks.InvalidValue,
-			err:     errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
-		},
-		{
-			desc:    "revoke non-existing cert",
-			thingID: "2",
 			token:   token,
-			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedCertRevocation, http.StatusNotFound),
+			page:    certs.Page{Certs: []certs.Cert{c}},
 		},
 		{
 			desc:    "get non-existent cert",
@@ -254,18 +250,7 @@ func TestViewCertByThing(t *testing.T) {
 			token:   "",
 			page:    certs.Page{Certs: []certs.Cert{}},
 			err:     errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, apiutil.ErrBearerToken), http.StatusUnauthorized),
-		},
-		{
-			desc:    "revoke existing cert",
-			thingID: thingID,
-			token:   token,
-			err:     nil,
-		},
-		{
-			desc:    "revoke deleted cert",
-			thingID: thingID,
-			token:   token,
-			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedToRemoveCertFromDB, http.StatusNotFound),
+			svcerr:  errors.Wrap(svcerr.ErrAuthentication, apiutil.ErrBearerToken),
 		},
 	}
 	for _, tc := range cases {
@@ -308,7 +293,7 @@ func TestRevokeCert(t *testing.T) {
 			thingID:     thingID,
 			token:       authmocks.InvalidValue,
 			svcResponse: certs.Revoke{RevocationTime: time.Now()},
-			err:         errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:         errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			svcerr:      errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication),
 		},
 		{
@@ -316,7 +301,7 @@ func TestRevokeCert(t *testing.T) {
 			thingID:     "2",
 			token:       token,
 			svcResponse: certs.Revoke{RevocationTime: time.Now()},
-			err:         errors.NewSDKErrorWithStatus(errors.Wrap(certs.ErrFailedCertRevocation, svcerr.ErrNotFound), http.StatusNotFound),
+			err:         errors.NewSDKErrorWithStatus(certs.ErrFailedCertRevocation, http.StatusNotFound),
 			svcerr:      errors.Wrap(certs.ErrFailedCertRevocation, svcerr.ErrNotFound),
 		},
 		{
@@ -338,7 +323,7 @@ func TestRevokeCert(t *testing.T) {
 			thingID:     thingID,
 			token:       token,
 			svcResponse: certs.Revoke{RevocationTime: time.Now()},
-			err:         errors.NewSDKErrorWithStatus(errors.Wrap(certs.ErrFailedToRemoveCertFromDB, svcerr.ErrNotFound), http.StatusNotFound),
+			err:         errors.NewSDKErrorWithStatus(certs.ErrFailedToRemoveCertFromDB, http.StatusNotFound),
 			svcerr:      errors.Wrap(certs.ErrFailedToRemoveCertFromDB, svcerr.ErrNotFound),
 		},
 	}

--- a/pkg/sdk/go/certs_test.go
+++ b/pkg/sdk/go/certs_test.go
@@ -230,8 +230,14 @@ func TestViewCertByThing(t *testing.T) {
 		{
 			desc:    "get existing cert",
 			thingID: thingID,
+			token:   authmocks.InvalidValue,
+			err:     errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
+		},
+		{
+			desc:    "revoke non-existing cert",
+			thingID: "2",
 			token:   token,
-			page:    certs.Page{Certs: []certs.Cert{c}},
+			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedCertRevocation, http.StatusNotFound),
 		},
 		{
 			desc:    "get non-existent cert",
@@ -248,7 +254,18 @@ func TestViewCertByThing(t *testing.T) {
 			token:   "",
 			page:    certs.Page{Certs: []certs.Cert{}},
 			err:     errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, apiutil.ErrBearerToken), http.StatusUnauthorized),
-			svcerr:  errors.Wrap(svcerr.ErrAuthentication, apiutil.ErrBearerToken),
+		},
+		{
+			desc:    "revoke existing cert",
+			thingID: thingID,
+			token:   token,
+			err:     nil,
+		},
+		{
+			desc:    "revoke deleted cert",
+			thingID: thingID,
+			token:   token,
+			err:     errors.NewSDKErrorWithStatus(certs.ErrFailedToRemoveCertFromDB, http.StatusNotFound),
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/sdk/go/channels_test.go
+++ b/pkg/sdk/go/channels_test.go
@@ -110,7 +110,7 @@ func TestCreateChannel(t *testing.T) {
 				Status:   mgclients.EnabledStatus.String(),
 			},
 			token: token,
-			err:   errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrCreateEntity, svcerr.ErrCreateEntity), http.StatusUnprocessableEntity),
+			err:   errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "create channel with missing name",
@@ -203,7 +203,7 @@ func TestListChannels(t *testing.T) {
 			token:    invalidToken,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -324,14 +324,14 @@ func TestViewChannel(t *testing.T) {
 			token:     "wrongtoken",
 			channelID: channel.ID,
 			response:  sdk.Channel{Children: []*sdk.Channel{}},
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
 			desc:      "view channel for wrong id",
 			token:     validToken,
 			channelID: wrongID,
 			response:  sdk.Channel{Children: []*sdk.Channel{}},
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 
@@ -464,7 +464,7 @@ func TestUpdateChannel(t *testing.T) {
 			},
 			response: sdk.Channel{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update channel description with invalid token",
@@ -474,7 +474,7 @@ func TestUpdateChannel(t *testing.T) {
 			},
 			response: sdk.Channel{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update channel metadata with invalid token",
@@ -486,7 +486,7 @@ func TestUpdateChannel(t *testing.T) {
 			},
 			response: sdk.Channel{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update channel that can't be marshalled",
@@ -616,7 +616,7 @@ func TestListChannelsByThing(t *testing.T) {
 			clientID: testsutil.GenerateUUID(t),
 			page:     sdk.PageMetadata{},
 			response: []sdk.Channel(nil),
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 	}
 
@@ -659,7 +659,7 @@ func TestEnableChannel(t *testing.T) {
 	repoCall1 := grepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(mggroups.Group{}, repoerr.ErrNotFound)
 	repoCall2 := grepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
 	_, err := mgsdk.EnableChannel("wrongID", validToken)
-	assert.Equal(t, errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrNotFound), http.StatusNotFound), err, fmt.Sprintf("Enable channel with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
+	assert.Equal(t, errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest), err, fmt.Sprintf("Enable channel with wrong id: expected %v got %v", svcerr.ErrViewEntity, err))
 	ok := repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
 	assert.True(t, ok, "RetrieveByID was not called on enabling channel")
 	repoCall.Unset()
@@ -711,7 +711,7 @@ func TestDisableChannel(t *testing.T) {
 	repoCall1 := grepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
 	repoCall2 := grepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(mggroups.Group{}, repoerr.ErrNotFound)
 	_, err := mgsdk.DisableChannel("wrongID", validToken)
-	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrNotFound), http.StatusNotFound), fmt.Sprintf("Disable channel with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest), fmt.Sprintf("Disable channel with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
 	ok := repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
 	assert.True(t, ok, "Memberships was not called on disabling channel with wrong id")
 	repoCall.Unset()

--- a/pkg/sdk/go/groups_test.go
+++ b/pkg/sdk/go/groups_test.go
@@ -98,7 +98,7 @@ func TestCreateGroup(t *testing.T) {
 				ParentID: wrongID,
 				Status:   clients.EnabledStatus.String(),
 			},
-			err: errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrCreateEntity, svcerr.ErrCreateEntity), http.StatusUnprocessableEntity),
+			err: errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc:  "create group with missing name",
@@ -203,7 +203,7 @@ func TestListGroups(t *testing.T) {
 			token:    invalidToken,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -334,7 +334,7 @@ func TestListParentGroups(t *testing.T) {
 			token:    invalidToken,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -466,7 +466,7 @@ func TestListChildrenGroups(t *testing.T) {
 			token:    invalidToken,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -583,14 +583,14 @@ func TestViewGroup(t *testing.T) {
 			token:    "wrongtoken",
 			groupID:  group.ID,
 			response: sdk.Group{Children: []*sdk.Group{}},
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
 			desc:     "view group for wrong id",
 			token:    validToken,
 			groupID:  wrongID,
 			response: sdk.Group{Children: []*sdk.Group{}},
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 
@@ -723,7 +723,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 			response: sdk.Group{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update group description with invalid token",
@@ -733,7 +733,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 			response: sdk.Group{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update group metadata with invalid token",
@@ -745,7 +745,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 			response: sdk.Group{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc: "update a group that can't be marshalled",
@@ -798,7 +798,7 @@ func TestEnableGroup(t *testing.T) {
 	repoCall1 := grepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(mggroups.Group{}, repoerr.ErrNotFound)
 	repoCall2 := grepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
 	_, err := mgsdk.EnableGroup("wrongID", validToken)
-	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrNotFound), http.StatusNotFound), fmt.Sprintf("Enable group with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest), fmt.Sprintf("Enable group with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
 	ok := repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
 	assert.True(t, ok, "RetrieveByID was not called on enabling group")
 	repoCall.Unset()
@@ -851,7 +851,7 @@ func TestDisableGroup(t *testing.T) {
 	repoCall1 := grepo.On("ChangeStatus", mock.Anything, mock.Anything).Return(nil)
 	repoCall2 := grepo.On("RetrieveByID", mock.Anything, mock.Anything).Return(mggroups.Group{}, repoerr.ErrNotFound)
 	_, err := mgsdk.DisableGroup("wrongID", validToken)
-	assert.Equal(t, err, errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrNotFound), http.StatusNotFound), fmt.Sprintf("Disable group with wrong id: expected %v got %v", svcerr.ErrNotFound, err))
+	assert.Equal(t, err, errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest), fmt.Sprintf("Disable group with wrong id: expected %v got %v", svcerr.ErrViewEntity, err))
 	ok := repoCall1.Parent.AssertCalled(t, "RetrieveByID", mock.Anything, "wrongID")
 	assert.True(t, ok, "Memberships was not called on disabling group with wrong id")
 	repoCall.Unset()

--- a/pkg/sdk/go/things_test.go
+++ b/pkg/sdk/go/things_test.go
@@ -18,7 +18,6 @@ import (
 	mglog "github.com/absmach/magistrala/logger"
 	mgclients "github.com/absmach/magistrala/pkg/clients"
 	"github.com/absmach/magistrala/pkg/errors"
-	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
 	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	gmocks "github.com/absmach/magistrala/pkg/groups/mocks"
 	sdk "github.com/absmach/magistrala/pkg/sdk/go"
@@ -97,7 +96,7 @@ func TestCreateThing(t *testing.T) {
 			response: sdk.Thing{},
 			token:    token,
 			repoErr:  sdk.ErrFailedCreation,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedCreation, repoerr.ErrCreateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc:     "register empty thing",
@@ -105,7 +104,7 @@ func TestCreateThing(t *testing.T) {
 			response: sdk.Thing{},
 			token:    token,
 			repoErr:  errors.ErrMalformedEntity,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedCreation, repoerr.ErrMalformedEntity), http.StatusBadRequest),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusBadRequest),
 		},
 		{
 			desc: "register a thing that can't be marshalled",
@@ -246,7 +245,7 @@ func TestCreateThings(t *testing.T) {
 			things:   thingsList,
 			response: []sdk.Thing{},
 			token:    token,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedCreation, sdk.ErrFailedCreation), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc:     "register empty things",
@@ -361,7 +360,7 @@ func TestListThings(t *testing.T) {
 			token:    authmocks.InvalidValue,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -369,7 +368,7 @@ func TestListThings(t *testing.T) {
 			token:    "",
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 			response: nil,
 		},
 		{
@@ -573,7 +572,7 @@ func TestListThingsByChannel(t *testing.T) {
 			channelID: testsutil.GenerateUUID(t),
 			page:      sdk.PageMetadata{},
 			response:  []sdk.Thing(nil),
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:      "list things with an invalid id",
@@ -581,7 +580,7 @@ func TestListThingsByChannel(t *testing.T) {
 			channelID: wrongID,
 			page:      sdk.PageMetadata{},
 			response:  []sdk.Thing(nil),
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 
@@ -639,21 +638,21 @@ func TestThing(t *testing.T) {
 			response: sdk.Thing{},
 			token:    invalidToken,
 			thingID:  generateUUID(t),
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc:     "view thing with valid token and invalid thing id",
 			response: sdk.Thing{},
 			token:    validToken,
 			thingID:  wrongID,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
 			desc:     "view thing with an invalid token and invalid thing id",
 			response: sdk.Thing{},
 			token:    invalidToken,
 			thingID:  wrongID,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 	}
 
@@ -718,14 +717,14 @@ func TestUpdateThing(t *testing.T) {
 			thing:    thing1,
 			response: sdk.Thing{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc:     "update thing name with invalid id",
 			thing:    thing2,
 			response: sdk.Thing{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update thing that can't be marshalled",
@@ -803,14 +802,14 @@ func TestUpdateThingTags(t *testing.T) {
 			thing:    thing1,
 			response: sdk.Thing{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 		},
 		{
 			desc:     "update thing name with invalid id",
 			thing:    thing2,
 			response: sdk.Thing{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update thing that can't be marshalled",
@@ -884,7 +883,7 @@ func TestUpdateThingSecret(t *testing.T) {
 			token:     "non-existent",
 			response:  sdk.Thing{},
 			repoErr:   svcerr.ErrAuthorization,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusForbidden),
 		},
 		{
 			desc:      "update thing secret with wrong old secret",
@@ -893,7 +892,7 @@ func TestUpdateThingSecret(t *testing.T) {
 			token:     validToken,
 			response:  sdk.Thing{},
 			repoErr:   apiutil.ErrMissingSecret,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, apiutil.ErrMissingSecret), http.StatusBadRequest),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusBadRequest),
 		},
 	}
 	for _, tc := range cases {
@@ -956,7 +955,7 @@ func TestEnableThing(t *testing.T) {
 			thing:    enabledThing1,
 			response: sdk.Thing{},
 			repoErr:  sdk.ErrFailedEnable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedEnable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrEnableClient, http.StatusBadRequest),
 		},
 		{
 			desc:     "enable non-existing thing",
@@ -965,7 +964,7 @@ func TestEnableThing(t *testing.T) {
 			thing:    sdk.Thing{},
 			response: sdk.Thing{},
 			repoErr:  sdk.ErrFailedEnable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedEnable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrEnableClient, http.StatusBadRequest),
 		},
 	}
 
@@ -1091,7 +1090,7 @@ func TestDisableThing(t *testing.T) {
 			thing:    disabledThing1,
 			response: sdk.Thing{},
 			repoErr:  sdk.ErrFailedDisable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedDisable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrDisableClient, http.StatusBadRequest),
 		},
 		{
 			desc:     "disable non-existing thing",
@@ -1100,7 +1099,7 @@ func TestDisableThing(t *testing.T) {
 			token:    validToken,
 			response: sdk.Thing{},
 			repoErr:  sdk.ErrFailedDisable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedDisable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrDisableClient, http.StatusBadRequest),
 		},
 	}
 
@@ -1218,14 +1217,14 @@ func TestShareThing(t *testing.T) {
 			channelID: generateUUID(t),
 			thingID:   "thingID",
 			token:     invalidToken,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:      "share thing with valid token for unauthorized user",
 			channelID: generateUUID(t),
 			thingID:   "thingID",
 			token:     validToken,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrAuthorization), http.StatusForbidden),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
 			repoErr:   svcerr.ErrAuthorization,
 		},
 	}

--- a/pkg/sdk/go/tokens_test.go
+++ b/pkg/sdk/go/tokens_test.go
@@ -69,7 +69,7 @@ func TestIssueToken(t *testing.T) {
 			login:    sdk.Login{Identity: "invalid", Secret: "secret"},
 			token:    &magistrala.Token{},
 			dbClient: wrongClient,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/sdk/go/tokens_test.go
+++ b/pkg/sdk/go/tokens_test.go
@@ -69,7 +69,7 @@ func TestIssueToken(t *testing.T) {
 			login:    sdk.Login{Identity: "invalid", Secret: "secret"},
 			token:    &magistrala.Token{},
 			dbClient: wrongClient,
-			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -18,7 +18,6 @@ import (
 	mglog "github.com/absmach/magistrala/logger"
 	mgclients "github.com/absmach/magistrala/pkg/clients"
 	"github.com/absmach/magistrala/pkg/errors"
-	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
 	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	gmocks "github.com/absmach/magistrala/pkg/groups/mocks"
 	oauth2mocks "github.com/absmach/magistrala/pkg/oauth2/mocks"
@@ -89,7 +88,7 @@ func TestCreateClient(t *testing.T) {
 			client:   user,
 			response: sdk.User{},
 			token:    token,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedCreation, sdk.ErrFailedCreation), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrCreateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc:     "register empty user",
@@ -257,7 +256,7 @@ func TestListClients(t *testing.T) {
 			token:    invalidToken,
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 			response: nil,
 		},
 		{
@@ -265,7 +264,7 @@ func TestListClients(t *testing.T) {
 			token:    "",
 			offset:   offset,
 			limit:    limit,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 			response: nil,
 		},
 		{
@@ -273,7 +272,7 @@ func TestListClients(t *testing.T) {
 			token:    token,
 			offset:   offset,
 			limit:    0,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 			response: nil,
 		},
 		{
@@ -404,21 +403,21 @@ func TestClient(t *testing.T) {
 			response: sdk.User{},
 			token:    invalidToken,
 			clientID: generateUUID(t),
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "view client with valid token and invalid client id",
 			response: sdk.User{},
 			token:    validToken,
 			clientID: wrongID,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
 			desc:     "view client with an invalid token and invalid client id",
 			response: sdk.User{},
 			token:    invalidToken,
 			clientID: wrongID,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 	}
 
@@ -477,7 +476,7 @@ func TestProfile(t *testing.T) {
 			desc:     "view client with an invalid token",
 			response: sdk.User{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 	}
 
@@ -544,14 +543,14 @@ func TestUpdateClient(t *testing.T) {
 			client:   client1,
 			response: sdk.User{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update client name with invalid id",
 			client:   client2,
 			response: sdk.User{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update a user that can't be marshalled",
@@ -635,14 +634,14 @@ func TestUpdateClientTags(t *testing.T) {
 			client:   client1,
 			response: sdk.User{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update client name with invalid id",
 			client:   client2,
 			response: sdk.User{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update a user that can't be marshalled",
@@ -725,14 +724,14 @@ func TestUpdateClientIdentity(t *testing.T) {
 			client:   user,
 			response: sdk.User{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update client name with invalid id",
 			client:   client2,
 			response: sdk.User{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update a user that can't be marshalled",
@@ -748,7 +747,7 @@ func TestUpdateClientIdentity(t *testing.T) {
 			},
 			response: sdk.User{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrUpdateEntity, svcerr.ErrUpdateEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 	}
 
@@ -812,7 +811,7 @@ func TestUpdateClientSecret(t *testing.T) {
 			token:     "non-existent",
 			response:  sdk.User{},
 			repoErr:   svcerr.ErrAuthentication,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:      "update client secret with wrong old secret",
@@ -821,7 +820,7 @@ func TestUpdateClientSecret(t *testing.T) {
 			token:     validToken,
 			response:  sdk.User{},
 			repoErr:   apiutil.ErrMissingSecret,
-			err:       errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrViewEntity, repoerr.ErrMissingSecret), http.StatusBadRequest),
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 
@@ -893,14 +892,14 @@ func TestUpdateClientRole(t *testing.T) {
 			client:   client2,
 			response: sdk.User{},
 			token:    invalidToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, svcerr.ErrAuthentication), http.StatusUnauthorized),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
 			desc:     "update client name with invalid id",
 			client:   client2,
 			response: sdk.User{},
 			token:    validToken,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrFailedUpdateRole, svcerr.ErrFailedUpdateRole), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrUpdateEntity, http.StatusUnprocessableEntity),
 		},
 		{
 			desc: "update a user that can't be marshalled",
@@ -985,7 +984,7 @@ func TestEnableClient(t *testing.T) {
 			client:   enabledClient1,
 			response: sdk.User{},
 			repoErr:  sdk.ErrFailedEnable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedEnable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrEnableClient, http.StatusBadRequest),
 		},
 		{
 			desc:     "enable non-existing client",
@@ -994,7 +993,7 @@ func TestEnableClient(t *testing.T) {
 			client:   sdk.User{},
 			response: sdk.User{},
 			repoErr:  sdk.ErrFailedEnable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedEnable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrEnableClient, http.StatusBadRequest),
 		},
 	}
 
@@ -1114,7 +1113,7 @@ func TestDisableClient(t *testing.T) {
 			client:   disabledClient1,
 			response: sdk.User{},
 			repoErr:  sdk.ErrFailedDisable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedDisable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
 			desc:     "disable non-existing client",
@@ -1123,7 +1122,7 @@ func TestDisableClient(t *testing.T) {
 			token:    validToken,
 			response: sdk.User{},
 			repoErr:  sdk.ErrFailedDisable,
-			err:      errors.NewSDKErrorWithStatus(errors.Wrap(sdk.ErrFailedDisable, svcerr.ErrViewEntity), http.StatusUnprocessableEntity),
+			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 	}
 

--- a/things/service_test.go
+++ b/things/service_test.go
@@ -43,8 +43,7 @@ var (
 	invalid           = "invalid"
 	validID           = "d4ebb847-5d0e-4e46-bdd9-b6aceaaa3a22"
 	wrongID           = testsutil.GenerateUUID(&testing.T{})
-	errAddPolicies    = errors.New("failed to add policies")
-	errRemovePolicies = errors.New("failed to remove the policies")
+	errRemovePolicies = errors.New("failed to delete policies")
 )
 
 func newService() (things.Service, *mocks.Repository, *authmocks.AuthClient, *mocks.Cache) {
@@ -1774,7 +1773,7 @@ func TestShare(t *testing.T) {
 			authorizeResponse:   &magistrala.AuthorizeRes{Authorized: true},
 			addPoliciesResponse: &magistrala.AddPoliciesRes{},
 			addPoliciesErr:      svcerr.ErrInvalidPolicy,
-			err:                 errAddPolicies,
+			err:                 svcerr.ErrInvalidPolicy,
 		},
 		{
 			desc:                "share thing with failed authorization from add policies",
@@ -1783,7 +1782,7 @@ func TestShare(t *testing.T) {
 			identifyResponse:    &magistrala.IdentityRes{Id: validID, DomainId: testsutil.GenerateUUID(t)},
 			authorizeResponse:   &magistrala.AuthorizeRes{Authorized: true},
 			addPoliciesResponse: &magistrala.AddPoliciesRes{Added: false},
-			err:                 nil,
+			err:                 svcerr.ErrUpdateEntity,
 		},
 	}
 
@@ -1852,7 +1851,7 @@ func TestUnShare(t *testing.T) {
 			authorizeResponse:      &magistrala.AuthorizeRes{Authorized: true},
 			deletePoliciesResponse: &magistrala.DeletePoliciesRes{},
 			deletePoliciesErr:      svcerr.ErrInvalidPolicy,
-			err:                    errRemovePolicies,
+			err:                    svcerr.ErrInvalidPolicy,
 		},
 		{
 			desc:                   "share thing with failed delete from delete policies",

--- a/twins/api/http/endpoint_twins_test.go
+++ b/twins/api/http/endpoint_twins_test.go
@@ -469,7 +469,7 @@ func TestViewTwin(t *testing.T) {
 			desc:        "view twin by passing invalid token",
 			id:          twin.ID,
 			auth:        authmocks.InvalidValue,
-			status:      http.StatusUnauthorized,
+			status:      http.StatusForbidden,
 			res:         twinRes{},
 			err:         svcerr.ErrAuthentication,
 			identifyErr: svcerr.ErrAuthentication,

--- a/users/service.go
+++ b/users/service.go
@@ -294,7 +294,7 @@ func (svc service) ResetSecret(ctx context.Context, resetToken, secret string) e
 
 	secret, err = svc.hasher.Hash(secret)
 	if err != nil {
-		return errors.Wrap(svcerr.ErrUpdateEntity, err)
+		return errors.Wrap(svcerr.ErrMalformedEntity, err)
 	}
 	c = mgclients.Client{
 		ID: c.ID,

--- a/users/service.go
+++ b/users/service.go
@@ -575,7 +575,7 @@ func (svc service) OAuthCallback(ctx context.Context, state mgoauth2.State, clie
 			if errors.Contains(err, repoerr.ErrNotFound) {
 				return &magistrala.Token{}, errors.Wrap(svcerr.ErrNotFound, errUserNotSignedUp)
 			}
-			return &magistrala.Token{}, errors.Wrap(svcerr.ErrNotFound, err)
+			return &magistrala.Token{}, errors.Wrap(svcerr.ErrViewEntity, err)
 		}
 		claims := &magistrala.IssueReq{
 			UserId: rclient.ID,

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -1024,7 +1024,7 @@ func TestUpdateClientRole(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: true},
 			addPolicyResponse: &magistrala.AddPolicyRes{Added: false},
 			token:             validToken,
-			err:               svcerr.ErrAddPolicies,
+			err:               svcerr.ErrAuthorization,
 		},
 		{
 			desc:              "update client role with failed to add policy",
@@ -1053,7 +1053,7 @@ func TestUpdateClientRole(t *testing.T) {
 			deletePolicyResponse: &magistrala.DeletePolicyRes{Deleted: false},
 			updateRoleResponse:   mgclients.Client{},
 			token:                validToken,
-			err:                  svcerr.ErrUpdateEntity,
+			err:                  svcerr.ErrAuthorization,
 		},
 		{
 			desc:                 "update client role to user role with failed to delete policy with error",
@@ -1063,7 +1063,7 @@ func TestUpdateClientRole(t *testing.T) {
 			updateRoleResponse:   mgclients.Client{},
 			token:                validToken,
 			deletePolicyErr:      svcerr.ErrMalformedEntity,
-			err:                  svcerr.ErrUpdateEntity,
+			err:                  svcerr.ErrDeletePolicies,
 		},
 		{
 			desc:                 "Update client with failed repo update and roll back",

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -2349,7 +2349,7 @@ func TestResetSecret(t *testing.T) {
 					Identity: "",
 				},
 			},
-			err: repoerr.ErrNotFound,
+			err: nil,
 		},
 		{
 			desc:                 "reset secret with failed to update secret",
@@ -2547,7 +2547,7 @@ func TestOAuthCallback(t *testing.T) {
 			saveResponse:      mgclients.Client{},
 			saveErr:           repoerr.ErrConflict,
 			issueResponse:     &magistrala.Token{},
-			err:               svcerr.ErrConflict,
+			err:               errors.New("user already exists"),
 		},
 	}
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -1024,7 +1024,7 @@ func TestUpdateClientRole(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: true},
 			addPolicyResponse: &magistrala.AddPolicyRes{Added: false},
 			token:             validToken,
-			err:               svcerr.ErrAuthorization,
+			err:               svcerr.ErrAddPolicies,
 		},
 		{
 			desc:              "update client role with failed to add policy",
@@ -1053,7 +1053,7 @@ func TestUpdateClientRole(t *testing.T) {
 			deletePolicyResponse: &magistrala.DeletePolicyRes{Deleted: false},
 			updateRoleResponse:   mgclients.Client{},
 			token:                validToken,
-			err:                  svcerr.ErrFailedPolicyUpdate,
+			err:                  svcerr.ErrUpdateEntity,
 		},
 		{
 			desc:                 "update client role to user role with failed to delete policy with error",
@@ -1063,7 +1063,7 @@ func TestUpdateClientRole(t *testing.T) {
 			updateRoleResponse:   mgclients.Client{},
 			token:                validToken,
 			deletePolicyErr:      svcerr.ErrMalformedEntity,
-			err:                  svcerr.ErrDeletePolicies,
+			err:                  svcerr.ErrUpdateEntity,
 		},
 		{
 			desc:                 "Update client with failed repo update and roll back",
@@ -2547,7 +2547,7 @@ func TestOAuthCallback(t *testing.T) {
 			saveResponse:      mgclients.Client{},
 			saveErr:           repoerr.ErrConflict,
 			issueResponse:     &magistrala.Token{},
-			err:               errors.New("user already exists"),
+			err:               svcerr.ErrConflict,
 		},
 	}
 


### PR DESCRIPTION
# What type of PR is this?

This is a feature that removes removes repository errors from the api response and only the service error and api errors are sent as part of the response. All errors are logged and can be evaluated from the service logs.

## What does this do?

Ensures only errors from the service and api are sent as part of the API response, and leaves repo errors at service level.

## Which issue(s) does this PR fix/relate to?

- Resolves #2117
- Related to #1998 

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No

### Notes

