### PR TITLE
MG-1967 - Handle errors in Things gRPC server and client

### DIFF
--- a/things/api/grpc/server.go
+++ b/things/api/grpc/server.go
@@ -20,8 +20,8 @@ import (
 var _ magistrala.AuthzServiceServer = (*grpcServer)(nil)
 
 type grpcServer struct {
-	magistrala.UnimplementedAuthzServiceServer
 	authorize kitgrpc.Handler
+	magistrala.UnimplementedAuthzServiceServer
 }
 
 // NewServer returns new AuthServiceServer instance.


### PR DESCRIPTION
# What type of PR is this?
This is a feature that handles authorization errors in Things gRPC server and client to prevent exposing back-end logs for improper authorization requests.



## What does this do?
Handles authorization errors in Things gRPC server and client


## Which issue(s) does this PR fix/relate to?

- Related Issue #1967 

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No

