### PR TITLE
MG-2069 - Remove relation requirement from entity unassignment

### DIFF
--- a/api/openapi/auth.yml
+++ b/api/openapi/auth.yml
@@ -286,7 +286,7 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        "200":
+        "204":
           description: Users successfully unassigned from domain.
         "400":
           description: Failed due to malformed domain's ID.

--- a/api/openapi/users.yml
+++ b/api/openapi/users.yml
@@ -1787,6 +1787,10 @@ components:
                 type: string
                 format: email
                 description: User email.
+              host:
+                type: string
+                example: examplehost
+                description: Email host.
 
     PasswordReset:
       description: Password reset request data, new password and token that is appended on password reset link received in email.
@@ -1799,11 +1803,13 @@ components:
                 type: string
                 format: password
                 description: New password.
+                example: 12345678
                 minimum: 8
               confirm_password:
                 type: string
                 format: password
                 description: New confirmation password.
+                example: 12345678
                 minimum: 8
               token:
                 type: string

--- a/auth/api/http/domains/endpoint_test.go
+++ b/auth/api/http/domains/endpoint_test.go
@@ -1163,15 +1163,6 @@ func TestUnassignDomainUsers(t *testing.T) {
 			status:      http.StatusBadRequest,
 			err:         apiutil.ErrValidation,
 		},
-		{
-			desc:        "unassign domain users with empty relation",
-			data:        fmt.Sprintf(`{"relation": "%s", "user_ids" : ["%s", "%s"]}`, "", validID, validID),
-			domainID:    domain.ID,
-			contentType: contentType,
-			token:       validToken,
-			status:      http.StatusBadRequest,
-			err:         apiutil.ErrValidation,
-		},
 	}
 
 	for _, tc := range cases {

--- a/auth/api/http/domains/requests.go
+++ b/auth/api/http/domains/requests.go
@@ -205,10 +205,6 @@ func (req unassignUsersReq) validate() error {
 		return apiutil.ErrMalformedPolicy
 	}
 
-	if req.Relation == "" {
-		return apiutil.ErrMalformedPolicy
-	}
-
 	return nil
 }
 

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -378,20 +378,11 @@ func (repo domainRepo) DeletePolicies(ctx context.Context, pcs ...auth.Policy) (
 			AND subject_relation = :subject_relation
 			AND object_type = :object_type
 			AND object_id = :object_id
-		;`
+		`
 		if pc.Relation != "" {
-			q = `
-			DELETE FROM
-				policies
-			WHERE
-				subject_type = :subject_type
-				AND subject_id = :subject_id
-				AND subject_relation = :subject_relation
-				AND relation = :relation
-				AND object_type = :object_type
-				AND object_id = :object_id
-			;`
+			q = fmt.Sprintf("%s AND relation = :relation", q)
 		}
+		q = fmt.Sprintf("%s;", q)
 
 		dbpc := toDBPolicy(pc)
 		row, err := tx.NamedQuery(q, dbpc)

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -370,6 +370,17 @@ func (repo domainRepo) DeletePolicies(ctx context.Context, pcs ...auth.Policy) (
 
 	for _, pc := range pcs {
 		q := `
+		DELETE FROM
+			policies
+		WHERE
+			subject_type = :subject_type
+			AND subject_id = :subject_id
+			AND subject_relation = :subject_relation
+			AND object_type = :object_type
+			AND object_id = :object_id
+		;`
+		if pc.Relation != "" {
+			q = `
 			DELETE FROM
 				policies
 			WHERE
@@ -380,6 +391,7 @@ func (repo domainRepo) DeletePolicies(ctx context.Context, pcs ...auth.Policy) (
 				AND object_type = :object_type
 				AND object_id = :object_id
 			;`
+		}
 
 		dbpc := toDBPolicy(pc)
 		row, err := tx.NamedQuery(q, dbpc)

--- a/auth/postgres/domains_test.go
+++ b/auth/postgres/domains_test.go
@@ -83,6 +83,17 @@ func TestDeletePolicyCopy(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			desc: "delete a  policy with empty relation",
+			pc: auth.Policy{
+				SubjectType: "unknown",
+				SubjectID:   "unknown",
+				Relation:    "",
+				ObjectType:  "unknown",
+				ObjectID:    "unknown",
+			},
+			err: nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/auth/service.go
+++ b/auth/service.go
@@ -759,21 +759,21 @@ func (svc service) UnassignUsers(ctx context.Context, token, id string, userIds 
 			}
 		}
 
-		for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {  
-            // Remove only non-admins.  
-            if err := svc.removeDomainPolicies(ctx, id, rel, ids...); err != nil {  
-                return errors.Wrap(errRemovePolicies, err)  
-            }  
-        }  
+		for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {
+			// Remove only non-admins.
+			if err := svc.removeDomainPolicies(ctx, id, rel, ids...); err != nil {
+				return errors.Wrap(errRemovePolicies, err)
+			}
+		}
 	}
 
 	// If user is admin, remove all policies from all users.
-	for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {  
-		// Remove only non-admins.  
-		if err := svc.removeDomainPolicies(ctx, id, rel, userIds...); err != nil {  
-			return errors.Wrap(errRemovePolicies, err)  
-		}  
-	}  
+	for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {
+		// Remove only non-admins.
+		if err := svc.removeDomainPolicies(ctx, id, rel, userIds...); err != nil {
+			return errors.Wrap(errRemovePolicies, err)
+		}
+	}
 
 	return nil
 }

--- a/auth/service.go
+++ b/auth/service.go
@@ -759,36 +759,21 @@ func (svc service) UnassignUsers(ctx context.Context, token, id string, userIds 
 			}
 		}
 
-		// Remove only non-admins.
-		if err := svc.removeDomainPolicies(ctx, id, MemberRelation, ids...); err != nil {
-			return errors.Wrap(errRemovePolicies, err)
-		}
-
-		if err := svc.removeDomainPolicies(ctx, id, ViewerRelation, ids...); err != nil {
-			return errors.Wrap(errRemovePolicies, err)
-		}
-
-		if err := svc.removeDomainPolicies(ctx, id, EditorRelation, ids...); err != nil {
-			return errors.Wrap(errRemovePolicies, err)
-		}
+		for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {  
+            // Remove only non-admins.  
+            if err := svc.removeDomainPolicies(ctx, id, rel, ids...); err != nil {  
+                return errors.Wrap(errRemovePolicies, err)  
+            }  
+        }  
 	}
 
 	// If user is admin, remove all policies from all users.
-	if err := svc.removeDomainPolicies(ctx, id, MemberRelation, userIds...); err != nil {
-		return errors.Wrap(errRemovePolicies, err)
-	}
-
-	if err := svc.removeDomainPolicies(ctx, id, ViewerRelation, userIds...); err != nil {
-		return errors.Wrap(errRemovePolicies, err)
-	}
-
-	if err := svc.removeDomainPolicies(ctx, id, EditorRelation, userIds...); err != nil {
-		return errors.Wrap(errRemovePolicies, err)
-	}
-
-	if err := svc.removeDomainPolicies(ctx, id, AdministratorRelation, userIds...); err != nil {
-		return errors.Wrap(errRemovePolicies, err)
-	}
+	for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {  
+		// Remove only non-admins.  
+		if err := svc.removeDomainPolicies(ctx, id, rel, userIds...); err != nil {  
+			return errors.Wrap(errRemovePolicies, err)  
+		}  
+	}  
 
 	return nil
 }

--- a/auth/service.go
+++ b/auth/service.go
@@ -759,7 +759,7 @@ func (svc service) UnassignUsers(ctx context.Context, token, id string, userIds 
 			}
 		}
 
-		userIds = ids 
+		userIds = ids
 	}
 
 	for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {

--- a/auth/service.go
+++ b/auth/service.go
@@ -759,15 +759,9 @@ func (svc service) UnassignUsers(ctx context.Context, token, id string, userIds 
 			}
 		}
 
-		for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {
-			// Remove only non-admins.
-			if err := svc.removeDomainPolicies(ctx, id, rel, ids...); err != nil {
-				return errors.Wrap(errRemovePolicies, err)
-			}
-		}
+		userIds = ids 
 	}
 
-	// If user is admin, remove all policies from all users.
 	for _, rel := range []string{MemberRelation, ViewerRelation, EditorRelation} {
 		// Remove only non-admins.
 		if err := svc.removeDomainPolicies(ctx, id, rel, userIds...); err != nil {

--- a/things/api/http/requests.go
+++ b/things/api/http/requests.go
@@ -245,10 +245,6 @@ func (req unassignUsersRequest) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	if req.Relation == "" {
-		return apiutil.ErrMissingRelation
-	}
-
 	if req.groupID == "" {
 		return apiutil.ErrMissingID
 	}

--- a/things/api/http/requests_test.go
+++ b/things/api/http/requests_test.go
@@ -603,7 +603,7 @@ func TestUnassignUsersRequestValidate(t *testing.T) {
 				UserIDs:  []string{validID},
 				Relation: "",
 			},
-			err: apiutil.ErrMissingRelation,
+			err: nil,
 		},
 	}
 	for _, c := range cases {

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -330,9 +330,6 @@ func (req unassignUsersReq) validate() error {
 		return apiutil.ErrMissingID
 	}
 
-	if req.Relation == "" {
-		return apiutil.ErrMissingRelation
-	}
 	if len(req.UserIDs) == 0 {
 		return apiutil.ErrEmptyList
 	}

--- a/users/api/requests_test.go
+++ b/users/api/requests_test.go
@@ -816,7 +816,7 @@ func TestUnassignUsersRequestValidate(t *testing.T) {
 				UserIDs:  []string{validID},
 				Relation: "",
 			},
-			err: apiutil.ErrMissingRelation,
+			err: nil,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
# What type of PR is this?

This is a refactor because it changes the following functionality: Unassign entity.

## What does this do?

Removes the relation requirement from unassigning an entity. When the relation is provided, only the user with that relation is removed, when not provided - all relations are removed.

## Which issue(s) does this PR fix/relate to?

- Related Issue #2069
- Resolves #2069

## Have you included tests for your changes?

Yes, I have included tests for my changes.

## Did you document any new/modified feature?

No

### Notes

Signed-off-by: WashingtonKK <washingtonkigan@gmail.com>
