### PR TITLE
MG-2125 - Unable to enable thing using bootstrap

### DIFF
--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -325,7 +325,7 @@ func (bs bootstrapService) ChangeState(ctx context.Context, token, id string, st
 				ThingID:   cfg.ThingID,
 			}
 			if err := bs.sdk.Connect(conIDs, token); err != nil {
-				// Ignore conflict errors as they indicate the connection already exists
+				// Ignore conflict errors as they indicate the connection already exists.
 				if errors.Contains(err, svcerr.ErrConflict) {
 					continue
 				}

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -25,9 +25,6 @@ var (
 	// ErrExternalKey indicates a non-existent bootstrap configuration for given external key.
 	ErrExternalKey = errors.New("failed to get bootstrap configuration for given external key")
 
-	// ErrConflict indicates that the entity that the client is trying to create already exists.
-	ErrConflict = errors.New("Entity already exists")
-
 	// ErrExternalKeySecure indicates error in getting bootstrap configuration for given encrypted external key.
 	ErrExternalKeySecure = errors.New("failed to get bootstrap configuration for given encrypted external key")
 

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -325,6 +325,7 @@ func (bs bootstrapService) ChangeState(ctx context.Context, token, id string, st
 				ThingID:   cfg.ThingID,
 			}
 			if err := bs.sdk.Connect(conIDs, token); err != nil {
+				// Ignore conflict errors as they indicate the connection already exists
 				if errors.Contains(err, svcerr.ErrConflict) {
 					continue
 				}

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -25,6 +25,9 @@ var (
 	// ErrExternalKey indicates a non-existent bootstrap configuration for given external key.
 	ErrExternalKey = errors.New("failed to get bootstrap configuration for given external key")
 
+	// ErrConflict indicates that the entity that the client is trying to create already exists.
+	ErrConflict = errors.New("Entity already exists")
+
 	// ErrExternalKeySecure indicates error in getting bootstrap configuration for given encrypted external key.
 	ErrExternalKeySecure = errors.New("failed to get bootstrap configuration for given encrypted external key")
 
@@ -325,6 +328,9 @@ func (bs bootstrapService) ChangeState(ctx context.Context, token, id string, st
 				ThingID:   cfg.ThingID,
 			}
 			if err := bs.sdk.Connect(conIDs, token); err != nil {
+				if errors.Contains(err, svcerr.ErrConflict) {
+					continue
+				}
 				return ErrThings
 			}
 		}


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix.

## What does this do?

This PR introduces ```svcerr.ErrConflict``` into the `Connect` function. The ```svcerr.ErrConflict``` error is triggered when an attempt is made to establish a connection that already exists. In this case, instead of halting the process, the `Connect` function skips the current iteration and returns ```HTTP/1.1 200 OK``` (because the desired end state - a connection existing- is already true for the current channel) and moves on to the next channel. This ensures that all channels in ```conIDs``` are processed, and any existing connections do not interrupt the operation. 

## Which issue(s) does this PR fix/relate to?

- Related Issue #2125 
- Resolves #2125

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No, I have not updated the documentation because the changes are related to error handling and do not introduce new functionality.