### PR TITLE
MG-2142 - Consume Things connect/disconnect event in bootstrap

### DIFF
--- a/bootstrap/api/logging.go
+++ b/bootstrap/api/logging.go
@@ -257,6 +257,24 @@ func (lm *loggingMiddleware) RemoveChannelHandler(ctx context.Context, id string
 	return lm.svc.RemoveChannelHandler(ctx, id)
 }
 
+func (lm *loggingMiddleware) ConnectThingHandler(ctx context.Context, channelID, thingID string) (err error) {
+	defer func(begin time.Time) {
+		args := []any{
+			slog.String("duration", time.Since(begin).String()),
+			slog.String("channel_id", channelID),
+			slog.String("thing_id", thingID),
+		}
+		if err != nil {
+			args = append(args, slog.Any("error", err))
+			lm.logger.Warn("Connect thing handler failed to complete successfully", args...)
+			return
+		}
+		lm.logger.Info("Connect thing handler completed successfully", args...)
+	}(time.Now())
+
+	return lm.svc.ConnectThingHandler(ctx, channelID, thingID)
+}
+
 func (lm *loggingMiddleware) DisconnectThingHandler(ctx context.Context, channelID, thingID string) (err error) {
 	defer func(begin time.Time) {
 		args := []any{

--- a/bootstrap/api/metrics.go
+++ b/bootstrap/api/metrics.go
@@ -150,6 +150,16 @@ func (mm *metricsMiddleware) RemoveChannelHandler(ctx context.Context, id string
 	return mm.svc.RemoveChannelHandler(ctx, id)
 }
 
+// ConnectThingHandler instruments ConnectThingHandler method with metrics.
+func (mm *metricsMiddleware) ConnectThingHandler(ctx context.Context, channelID, thingID string) (err error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "connect_thing_handler").Add(1)
+		mm.latency.With("method", "connect_thing_handler").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.ConnectThingHandler(ctx, channelID, thingID)
+}
+
 // DisconnectThingHandler instruments DisconnectThingHandler method with metrics.
 func (mm *metricsMiddleware) DisconnectThingHandler(ctx context.Context, channelID, thingID string) (err error) {
 	defer func(begin time.Time) {

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -112,9 +112,9 @@ type ConfigRepository interface {
 	// RemoveChannel removes channel with the given ID.
 	RemoveChannel(ctx context.Context, id string) error
 
-	// ConnectHandler changes state of the Config when the corresponding Thing is connected to the Channel.
+	// ConnectThing changes state of the Config when the corresponding Thing is connected to the Channel.
 	ConnectThing(ctx context.Context, channelID, thingID string) error
 
-	// DisconnectHandler changes state of the Config when the corresponding Thing is disconnected from the Channel.
+	// DisconnectThing changes state of the Config when the corresponding Thing is disconnected from the Channel.
 	DisconnectThing(ctx context.Context, channelID, thingID string) error
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -114,9 +114,9 @@ type ConfigRepository interface {
 
 	// ConnectHandler changes state of the Config when the corresponding Thing is
 	// connected to the Channel.
-	ConnectThing(ctx context.Context, mgChannel, mgThing string) error
+	ConnectThing(ctx context.Context, channelID, thingID string) error
 
 	// DisconnectHandler changes state of the Config when the corresponding Thing is
 	// disconnected from the Channel.
-	DisconnectThing(ctx context.Context, mgChannel, mgThing string) error
+	DisconnectThing(ctx context.Context, channelID, thingID string) error
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -112,7 +112,11 @@ type ConfigRepository interface {
 	// RemoveChannel removes channel with the given ID.
 	RemoveChannel(ctx context.Context, id string) error
 
+	// ConnectHandler changes state of the Config when the corresponding Thing is
+	// connected to the Channel.
+	ConnectThing(ctx context.Context, mgChannel, mgThing string) error
+
 	// DisconnectHandler changes state of the Config when the corresponding Thing is
 	// disconnected from the Channel.
-	DisconnectThing(ctx context.Context, channelID, thingID string) error
+	DisconnectThing(ctx context.Context, mgChannel, mgThing string) error
 }

--- a/bootstrap/configs.go
+++ b/bootstrap/configs.go
@@ -112,11 +112,9 @@ type ConfigRepository interface {
 	// RemoveChannel removes channel with the given ID.
 	RemoveChannel(ctx context.Context, id string) error
 
-	// ConnectHandler changes state of the Config when the corresponding Thing is
-	// connected to the Channel.
+	// ConnectHandler changes state of the Config when the corresponding Thing is connected to the Channel.
 	ConnectThing(ctx context.Context, channelID, thingID string) error
 
-	// DisconnectHandler changes state of the Config when the corresponding Thing is
-	// disconnected from the Channel.
+	// DisconnectHandler changes state of the Config when the corresponding Thing is disconnected from the Channel.
 	DisconnectThing(ctx context.Context, channelID, thingID string) error
 }

--- a/bootstrap/events/consumer/events.go
+++ b/bootstrap/events/consumer/events.go
@@ -19,6 +19,6 @@ type updateChannelEvent struct {
 
 // Connection event is either connect or disconnect event.
 type connectionEvent struct {
-	thingID   string
-	channelID string
+	mgThing   []string
+	mgChannel string
 }

--- a/bootstrap/events/consumer/events.go
+++ b/bootstrap/events/consumer/events.go
@@ -18,7 +18,7 @@ type updateChannelEvent struct {
 }
 
 // Connection event is either connect or disconnect event.
-type disconnectEvent struct {
+type connectionEvent struct {
 	thingID   string
 	channelID string
 }

--- a/bootstrap/events/consumer/events.go
+++ b/bootstrap/events/consumer/events.go
@@ -19,6 +19,6 @@ type updateChannelEvent struct {
 
 // Connection event is either connect or disconnect event.
 type connectionEvent struct {
-	thingID   []string
+	thingIDs  []string
 	channelID string
 }

--- a/bootstrap/events/consumer/events.go
+++ b/bootstrap/events/consumer/events.go
@@ -19,6 +19,6 @@ type updateChannelEvent struct {
 
 // Connection event is either connect or disconnect event.
 type connectionEvent struct {
-	mgThing   []string
-	mgChannel string
+	thingID   []string
+	channelID string
 }

--- a/bootstrap/events/consumer/streams.go
+++ b/bootstrap/events/consumer/streams.go
@@ -45,15 +45,15 @@ func (es *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		err = es.svc.RemoveConfigHandler(ctx, rte.id)
 	case thingConnect:
 		cte := decodeConnectThing(msg)
-		for _, mgThing := range cte.mgThing {
-			if err = es.svc.ConnectThingHandler(ctx, cte.mgChannel, mgThing); err != nil {
+		for _, thingID := range cte.thingID {
+			if err = es.svc.ConnectThingHandler(ctx, cte.channelID, thingID); err != nil {
 				return err
 			}
 		}
 	case thingDisconnect:
 		dte := decodeDisconnectThing(msg)
-		for _, mgThing := range dte.mgThing {
-			if err = es.svc.DisconnectThingHandler(ctx, dte.mgChannel, mgThing); err != nil {
+		for _, thingID := range dte.thingID {
+			if err = es.svc.DisconnectThingHandler(ctx, dte.channelID, thingID); err != nil {
 				return err
 			}
 		}
@@ -105,8 +105,8 @@ func decodeConnectThing(event map[string]interface{}) connectionEvent {
 	}
 
 	return connectionEvent{
-		mgChannel: read(event, "group_id", ""),
-		mgThing:   ReadStringSlice(event, "member_ids"),
+		channelID: read(event, "group_id", ""),
+		thingID:   ReadStringSlice(event, "member_ids"),
 	}
 }
 
@@ -115,8 +115,8 @@ func decodeDisconnectThing(event map[string]interface{}) connectionEvent {
 		return connectionEvent{}
 	}
 	return connectionEvent{
-		mgChannel: read(event, "group_id", ""),
-		mgThing:   ReadStringSlice(event, "member_ids"),
+		channelID: read(event, "group_id", ""),
+		thingID:   ReadStringSlice(event, "member_ids"),
 	}
 }
 

--- a/bootstrap/events/consumer/streams.go
+++ b/bootstrap/events/consumer/streams.go
@@ -103,7 +103,7 @@ func decodeRemoveChannel(event map[string]interface{}) removeEvent {
 }
 
 func decodeConnectThing(event map[string]interface{}) connectionEvent {
-	if event["memberKind"] != memberKind && event["relation"] != relation {
+	if read(event, "memberKind", "") != memberKind && read(event, "relation", "") != relation {
 		return connectionEvent{}
 	}
 
@@ -114,7 +114,7 @@ func decodeConnectThing(event map[string]interface{}) connectionEvent {
 }
 
 func decodeDisconnectThing(event map[string]interface{}) connectionEvent {
-	if event["memberKind"] != memberKind && event["relation"] != relation {
+	if read(event, "memberKind", "") != memberKind && read(event, "relation", "") != relation {
 		return connectionEvent{}
 	}
 	return connectionEvent{

--- a/bootstrap/events/consumer/streams.go
+++ b/bootstrap/events/consumer/streams.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/absmach/magistrala/bootstrap"
+	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	"github.com/absmach/magistrala/pkg/events"
 )
 
@@ -48,14 +49,26 @@ func (es *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		err = es.svc.RemoveConfigHandler(ctx, rte.id)
 	case thingConnect:
 		cte := decodeConnectThing(msg)
+		if cte.channelID == "" {
+			return svcerr.ErrMalformedEntity
+		}
 		for _, thingID := range cte.thingID {
-			if err = es.svc.ConnectThingHandler(ctx, cte.channelID, thingID); err != nil {
+			if thingID == "" {
+				return svcerr.ErrMalformedEntity
+			}
+			if err := es.svc.ConnectThingHandler(ctx, cte.channelID, thingID); err != nil {
 				return err
 			}
 		}
 	case thingDisconnect:
 		dte := decodeDisconnectThing(msg)
+		if dte.channelID == "" {
+			return svcerr.ErrMalformedEntity
+		}
 		for _, thingID := range dte.thingID {
+			if thingID == "" {
+				return svcerr.ErrMalformedEntity
+			}
 			if err = es.svc.DisconnectThingHandler(ctx, dte.channelID, thingID); err != nil {
 				return err
 			}

--- a/bootstrap/events/consumer/streams.go
+++ b/bootstrap/events/consumer/streams.go
@@ -49,10 +49,10 @@ func (es *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		err = es.svc.RemoveConfigHandler(ctx, rte.id)
 	case thingConnect:
 		cte := decodeConnectThing(msg)
-		if cte.channelID == "" {
+		if cte.channelID == "" || len(cte.thingIDs) == 0 {
 			return svcerr.ErrMalformedEntity
 		}
-		for _, thingID := range cte.thingID {
+		for _, thingID := range cte.thingIDs {
 			if thingID == "" {
 				return svcerr.ErrMalformedEntity
 			}
@@ -62,10 +62,10 @@ func (es *eventHandler) Handle(ctx context.Context, event events.Event) error {
 		}
 	case thingDisconnect:
 		dte := decodeDisconnectThing(msg)
-		if dte.channelID == "" {
+		if dte.channelID == "" || len(dte.thingIDs) == 0 {
 			return svcerr.ErrMalformedEntity
 		}
-		for _, thingID := range dte.thingID {
+		for _, thingID := range dte.thingIDs {
 			if thingID == "" {
 				return svcerr.ErrMalformedEntity
 			}
@@ -122,7 +122,7 @@ func decodeConnectThing(event map[string]interface{}) connectionEvent {
 
 	return connectionEvent{
 		channelID: read(event, "group_id", ""),
-		thingID:   ReadStringSlice(event, "member_ids"),
+		thingIDs:  ReadStringSlice(event, "member_ids"),
 	}
 }
 
@@ -132,7 +132,7 @@ func decodeDisconnectThing(event map[string]interface{}) connectionEvent {
 	}
 	return connectionEvent{
 		channelID: read(event, "group_id", ""),
-		thingID:   ReadStringSlice(event, "member_ids"),
+		thingIDs:  ReadStringSlice(event, "member_ids"),
 	}
 }
 

--- a/bootstrap/events/consumer/streams.go
+++ b/bootstrap/events/consumer/streams.go
@@ -20,6 +20,9 @@ const (
 	channelPrefix = "group."
 	channelUpdate = channelPrefix + "update"
 	channelRemove = channelPrefix + "remove"
+
+	memberKind = "things"
+	relation   = "group"
 )
 
 type eventHandler struct {
@@ -100,7 +103,7 @@ func decodeRemoveChannel(event map[string]interface{}) removeEvent {
 }
 
 func decodeConnectThing(event map[string]interface{}) connectionEvent {
-	if event["memberKind"] != "things" && event["relation"] != "group" {
+	if event["memberKind"] != memberKind && event["relation"] != relation {
 		return connectionEvent{}
 	}
 
@@ -111,7 +114,7 @@ func decodeConnectThing(event map[string]interface{}) connectionEvent {
 }
 
 func decodeDisconnectThing(event map[string]interface{}) connectionEvent {
-	if event["memberKind"] != "things" && event["relation"] != "group" {
+	if event["memberKind"] != memberKind && event["relation"] != relation {
 		return connectionEvent{}
 	}
 	return connectionEvent{

--- a/bootstrap/events/producer/events.go
+++ b/bootstrap/events/producer/events.go
@@ -278,27 +278,27 @@ func (uche updateChannelHandlerEvent) Encode() (map[string]interface{}, error) {
 }
 
 type connectThingEvent struct {
-	mgThing   string
-	mgChannel string
+	thingID   string
+	channelID string
 }
 
 func (cte connectThingEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
-		"thing_id":   cte.mgThing,
-		"channel_id": cte.mgChannel,
+		"thing_id":   cte.thingID,
+		"channel_id": cte.channelID,
 		"operation":  thingConnect,
 	}, nil
 }
 
 type disconnectThingEvent struct {
-	mgThing   string
-	mgChannel string
+	thingID   string
+	channelID string
 }
 
 func (dte disconnectThingEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
-		"thing_id":   dte.mgThing,
-		"channel_id": dte.mgChannel,
+		"thing_id":   dte.thingID,
+		"channel_id": dte.channelID,
 		"operation":  thingDisconnect,
 	}, nil
 }

--- a/bootstrap/events/producer/events.go
+++ b/bootstrap/events/producer/events.go
@@ -23,6 +23,7 @@ const (
 	thingBootstrap         = thingPrefix + "bootstrap"
 	thingStateChange       = thingPrefix + "change_state"
 	thingUpdateConnections = thingPrefix + "update_connections"
+	thingConnect           = thingPrefix + "connect"
 	thingDisconnect        = thingPrefix + "disconnect"
 
 	channelPrefix        = "group."
@@ -276,15 +277,28 @@ func (uche updateChannelHandlerEvent) Encode() (map[string]interface{}, error) {
 	return val, nil
 }
 
+type connectThingEvent struct {
+	mgThing   string
+	mgChannel string
+}
+
+func (cte connectThingEvent) Encode() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"thing_id":   cte.mgThing,
+		"channel_id": cte.mgChannel,
+		"operation":  thingConnect,
+	}, nil
+}
+
 type disconnectThingEvent struct {
-	thingID   string
-	channelID string
+	mgThing   string
+	mgChannel string
 }
 
 func (dte disconnectThingEvent) Encode() (map[string]interface{}, error) {
 	return map[string]interface{}{
-		"thing_id":   dte.thingID,
-		"channel_id": dte.channelID,
+		"thing_id":   dte.mgThing,
+		"channel_id": dte.mgChannel,
 		"operation":  thingDisconnect,
 	}, nil
 }

--- a/bootstrap/events/producer/streams.go
+++ b/bootstrap/events/producer/streams.go
@@ -213,8 +213,8 @@ func (es *eventStore) ConnectThingHandler(ctx context.Context, channelID, thingI
 	}
 
 	ev := connectThingEvent{
-		mgThing:   thingID,
-		mgChannel: channelID,
+		thingID:   thingID,
+		channelID: channelID,
 	}
 
 	return es.Publish(ctx, ev)
@@ -226,8 +226,8 @@ func (es *eventStore) DisconnectThingHandler(ctx context.Context, channelID, thi
 	}
 
 	ev := disconnectThingEvent{
-		mgThing:   thingID,
-		mgChannel: channelID,
+		thingID:   thingID,
+		channelID: channelID,
 	}
 
 	return es.Publish(ctx, ev)

--- a/bootstrap/events/producer/streams.go
+++ b/bootstrap/events/producer/streams.go
@@ -207,14 +207,27 @@ func (es *eventStore) UpdateChannelHandler(ctx context.Context, channel bootstra
 	return es.Publish(ctx, ev)
 }
 
+func (es *eventStore) ConnectThingHandler(ctx context.Context, channelID, thingID string) error {
+	if err := es.svc.ConnectThingHandler(ctx, channelID, thingID); err != nil {
+		return err
+	}
+
+	ev := connectThingEvent{
+		mgThing:   thingID,
+		mgChannel: channelID,
+	}
+
+	return es.Publish(ctx, ev)
+}
+
 func (es *eventStore) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
 	if err := es.svc.DisconnectThingHandler(ctx, channelID, thingID); err != nil {
 		return err
 	}
 
 	ev := disconnectThingEvent{
-		thingID,
-		channelID,
+		mgThing:   thingID,
+		mgChannel: channelID,
 	}
 
 	return es.Publish(ctx, ev)

--- a/bootstrap/events/producer/streams_test.go
+++ b/bootstrap/events/producer/streams_test.go
@@ -1098,7 +1098,7 @@ func TestConnectThingHandler(t *testing.T) {
 
 	lastID := "0"
 	for _, tc := range cases {
-		svcCall := boot.On("ConnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
+		repoCall := boot.On("ConnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
 		err := svc.ConnectThingHandler(context.Background(), tc.channelID, tc.thingID)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 
@@ -1117,7 +1117,7 @@ func TestConnectThingHandler(t *testing.T) {
 		}
 
 		test(t, tc.event, event, tc.desc)
-		svcCall.Unset()
+		repoCall.Unset()
 	}
 }
 
@@ -1179,7 +1179,7 @@ func TestDisconnectThingHandler(t *testing.T) {
 
 	lastID := "0"
 	for _, tc := range cases {
-		svcCall := boot.On("DisconnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
+		repoCall := boot.On("DisconnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
 		err := svc.DisconnectThingHandler(context.Background(), tc.channelID, tc.thingID)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 
@@ -1198,7 +1198,7 @@ func TestDisconnectThingHandler(t *testing.T) {
 		}
 
 		test(t, tc.event, event, tc.desc)
-		svcCall.Unset()
+		repoCall.Unset()
 	}
 }
 

--- a/bootstrap/events/producer/streams_test.go
+++ b/bootstrap/events/producer/streams_test.go
@@ -48,6 +48,7 @@ const (
 	thingBootstrap         = thingPrefix + "bootstrap"
 	thingStateChange       = thingPrefix + "change_state"
 	thingUpdateConnections = thingPrefix + "update_connections"
+	thingConnect           = thingPrefix + "connect"
 	thingDisconnect        = thingPrefix + "disconnect"
 
 	channelPrefix        = "group."
@@ -1039,6 +1040,87 @@ func TestRemoveConfigHandler(t *testing.T) {
 	}
 }
 
+func TestConnectThingHandler(t *testing.T) {
+	err := redisClient.FlushAll(context.Background()).Err()
+	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	svc, boot, _, _ := newService(t, redisURL)
+
+	err = redisClient.FlushAll(context.Background()).Err()
+	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
+
+	cases := []struct {
+		desc      string
+		channelID string
+		thingID   string
+		err       error
+		event     map[string]interface{}
+	}{
+		{
+			desc:      "connect thing handler successfully",
+			channelID: channel.ID,
+			thingID:   "1",
+			err:       nil,
+			event: map[string]interface{}{
+				"channel_id":  channel.ID,
+				"thing_id":    "1",
+				"operation":   thingConnect,
+				"timestamp":   time.Now().UnixNano(),
+				"occurred_at": time.Now().UnixNano(),
+			},
+		},
+		{
+			desc:      "add non-existing channel handler",
+			channelID: "unknown",
+			err:       nil,
+			event:     nil,
+		},
+		{
+			desc:      "add channel handler with empty ID",
+			channelID: "",
+			err:       nil,
+			event:     nil,
+		},
+		{
+			desc:      "add channel handler successfully",
+			channelID: channel.ID,
+			thingID:   "1",
+			err:       nil,
+			event: map[string]interface{}{
+				"channel_id":  channel.ID,
+				"thing_id":    "1",
+				"operation":   thingConnect,
+				"timestamp":   time.Now().UnixNano(),
+				"occurred_at": time.Now().UnixNano(),
+			},
+		},
+	}
+
+	lastID := "0"
+	for _, tc := range cases {
+		svcCall := boot.On("ConnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
+		err := svc.ConnectThingHandler(context.Background(), tc.channelID, tc.thingID)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+
+		streams := redisClient.XRead(context.Background(), &redis.XReadArgs{
+			Streams: []string{streamID, lastID},
+			Count:   1,
+			Block:   time.Second,
+		}).Val()
+
+		var event map[string]interface{}
+		if len(streams) > 0 && len(streams[0].Messages) > 0 {
+			msg := streams[0].Messages[0]
+			event = msg.Values
+			event["timestamp"] = msg.ID
+			lastID = msg.ID
+		}
+
+		test(t, tc.event, event, tc.desc)
+		svcCall.Unset()
+	}
+}
+
 func TestDisconnectThingHandler(t *testing.T) {
 	err := redisClient.FlushAll(context.Background()).Err()
 	assert.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
@@ -1097,7 +1179,7 @@ func TestDisconnectThingHandler(t *testing.T) {
 
 	lastID := "0"
 	for _, tc := range cases {
-		repoCall := boot.On("DisconnectThing", context.Background(), mock.Anything, mock.Anything).Return(tc.err)
+		svcCall := boot.On("DisconnectThing", context.Background(), tc.channelID, tc.thingID).Return(tc.err)
 		err := svc.DisconnectThingHandler(context.Background(), tc.channelID, tc.thingID)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 
@@ -1116,7 +1198,7 @@ func TestDisconnectThingHandler(t *testing.T) {
 		}
 
 		test(t, tc.event, event, tc.desc)
-		repoCall.Unset()
+		svcCall.Unset()
 	}
 }
 

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -35,9 +35,9 @@ func (_m *ConfigRepository) ChangeState(ctx context.Context, owner string, id st
 	return r0
 }
 
-// ConnectThing provides a mock function with given fields: ctx, mgChannel, mgThing
-func (_m *ConfigRepository) ConnectThing(ctx context.Context, mgChannel string, mgThing string) error {
-	ret := _m.Called(ctx, mgChannel, mgThing)
+// ConnectThing provides a mock function with given fields: ctx, channelID, thingID
+func (_m *ConfigRepository) ConnectThing(ctx context.Context, channelID string, thingID string) error {
+	ret := _m.Called(ctx, channelID, thingID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConnectThing")
@@ -45,7 +45,7 @@ func (_m *ConfigRepository) ConnectThing(ctx context.Context, mgChannel string, 
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, mgChannel, mgThing)
+		r0 = rf(ctx, channelID, thingID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -53,9 +53,9 @@ func (_m *ConfigRepository) ConnectThing(ctx context.Context, mgChannel string, 
 	return r0
 }
 
-// DisconnectThing provides a mock function with given fields: ctx, mgChannel, mgThing
-func (_m *ConfigRepository) DisconnectThing(ctx context.Context, mgChannel string, mgThing string) error {
-	ret := _m.Called(ctx, mgChannel, mgThing)
+// DisconnectThing provides a mock function with given fields: ctx, channelID, thingID
+func (_m *ConfigRepository) DisconnectThing(ctx context.Context, channelID string, thingID string) error {
+	ret := _m.Called(ctx, channelID, thingID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DisconnectThing")
@@ -63,7 +63,7 @@ func (_m *ConfigRepository) DisconnectThing(ctx context.Context, mgChannel strin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, mgChannel, mgThing)
+		r0 = rf(ctx, channelID, thingID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/bootstrap/mocks/configs.go
+++ b/bootstrap/mocks/configs.go
@@ -35,9 +35,27 @@ func (_m *ConfigRepository) ChangeState(ctx context.Context, owner string, id st
 	return r0
 }
 
-// DisconnectThing provides a mock function with given fields: ctx, channelID, thingID
-func (_m *ConfigRepository) DisconnectThing(ctx context.Context, channelID string, thingID string) error {
-	ret := _m.Called(ctx, channelID, thingID)
+// ConnectThing provides a mock function with given fields: ctx, mgChannel, mgThing
+func (_m *ConfigRepository) ConnectThing(ctx context.Context, mgChannel string, mgThing string) error {
+	ret := _m.Called(ctx, mgChannel, mgThing)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConnectThing")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, mgChannel, mgThing)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DisconnectThing provides a mock function with given fields: ctx, mgChannel, mgThing
+func (_m *ConfigRepository) DisconnectThing(ctx context.Context, mgChannel string, mgThing string) error {
+	ret := _m.Called(ctx, mgChannel, mgThing)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DisconnectThing")
@@ -45,7 +63,7 @@ func (_m *ConfigRepository) DisconnectThing(ctx context.Context, channelID strin
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, channelID, thingID)
+		r0 = rf(ctx, mgChannel, mgThing)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/bootstrap/mocks/service.go
+++ b/bootstrap/mocks/service.go
@@ -91,9 +91,27 @@ func (_m *Service) ChangeState(ctx context.Context, token string, id string, sta
 	return r0
 }
 
-// DisconnectThingHandler provides a mock function with given fields: ctx, channelID, thingID
-func (_m *Service) DisconnectThingHandler(ctx context.Context, channelID string, thingID string) error {
-	ret := _m.Called(ctx, channelID, thingID)
+// ConnectThingHandler provides a mock function with given fields: ctx, mgChannel, mgThing
+func (_m *Service) ConnectThingHandler(ctx context.Context, mgChannel string, mgThing string) error {
+	ret := _m.Called(ctx, mgChannel, mgThing)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConnectThingHandler")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, mgChannel, mgThing)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DisconnectThingHandler provides a mock function with given fields: ctx, mgChannel, mgThing
+func (_m *Service) DisconnectThingHandler(ctx context.Context, mgChannel string, mgThing string) error {
+	ret := _m.Called(ctx, mgChannel, mgThing)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DisconnectThingHandler")
@@ -101,7 +119,7 @@ func (_m *Service) DisconnectThingHandler(ctx context.Context, channelID string,
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, channelID, thingID)
+		r0 = rf(ctx, mgChannel, mgThing)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/bootstrap/mocks/service.go
+++ b/bootstrap/mocks/service.go
@@ -91,9 +91,9 @@ func (_m *Service) ChangeState(ctx context.Context, token string, id string, sta
 	return r0
 }
 
-// ConnectThingHandler provides a mock function with given fields: ctx, mgChannel, mgThing
-func (_m *Service) ConnectThingHandler(ctx context.Context, mgChannel string, mgThing string) error {
-	ret := _m.Called(ctx, mgChannel, mgThing)
+// ConnectThingHandler provides a mock function with given fields: ctx, channelID, ThingID
+func (_m *Service) ConnectThingHandler(ctx context.Context, channelID string, ThingID string) error {
+	ret := _m.Called(ctx, channelID, ThingID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConnectThingHandler")
@@ -101,7 +101,7 @@ func (_m *Service) ConnectThingHandler(ctx context.Context, mgChannel string, mg
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, mgChannel, mgThing)
+		r0 = rf(ctx, channelID, ThingID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -109,9 +109,9 @@ func (_m *Service) ConnectThingHandler(ctx context.Context, mgChannel string, mg
 	return r0
 }
 
-// DisconnectThingHandler provides a mock function with given fields: ctx, mgChannel, mgThing
-func (_m *Service) DisconnectThingHandler(ctx context.Context, mgChannel string, mgThing string) error {
-	ret := _m.Called(ctx, mgChannel, mgThing)
+// DisconnectThingHandler provides a mock function with given fields: ctx, channelID, ThingID
+func (_m *Service) DisconnectThingHandler(ctx context.Context, channelID string, ThingID string) error {
+	ret := _m.Called(ctx, channelID, ThingID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DisconnectThingHandler")
@@ -119,7 +119,7 @@ func (_m *Service) DisconnectThingHandler(ctx context.Context, mgChannel string,
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, mgChannel, mgThing)
+		r0 = rf(ctx, channelID, ThingID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"log/slog"
 	"strings"
 	"time"
@@ -58,14 +59,13 @@ func (cr configRepository) Save(ctx context.Context, cfg bootstrap.Config, chsCo
 	}
 	dbcfg := toDBConfig(cfg)
 
-	defer func(thingID string, err error) (string, error) {
+	defer func(thingID string, err error) {
 		if err != nil {
 			if errRollback := cr.rollback(err, tx); errRollback != nil {
-				return thingID, errors.Wrap(err, errRollback)
+				log.Println(errRollback)
 			}
-			return "", err
+			log.Println(err)
 		}
-		return thingID, err
 	}(thingID, err)
 
 	if _, err := tx.NamedExec(q, dbcfg); err != nil {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -17,7 +17,6 @@ import (
 	"github.com/absmach/magistrala/pkg/clients"
 	"github.com/absmach/magistrala/pkg/errors"
 	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
-	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -474,13 +473,13 @@ func (cr configRepository) ConnectThing(ctx context.Context, channelID, thingID 
 	var exists bool
 	var state bootstrap.State
 	if err := cr.db.QueryRowxContext(ctx, qCheck, thingID).Scan(&exists, &state); err != nil {
-		return svcerr.ErrAddPolicies
+		return repoerr.ErrNotFound
 	}
 	if !exists {
-		return svcerr.ErrAddPolicies
+		return repoerr.ErrNotFound
 	}
 	if state == bootstrap.Active {
-		return svcerr.ErrAddPolicies
+		return repoerr.ErrConflict
 	}
 
 	q := `UPDATE configs SET state = $1 WHERE EXISTS (

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -464,19 +464,19 @@ func (cr configRepository) RemoveChannel(ctx context.Context, id string) error {
 	return nil
 }
 
-func (cr configRepository) ConnectThing(ctx context.Context, mgChannel, mgThing string) error {
+func (cr configRepository) ConnectThing(ctx context.Context, channelID, thingID string) error {
 	q := `UPDATE configs SET state = $1 WHERE EXISTS (
 		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)`
-	if _, err := cr.db.ExecContext(ctx, q, bootstrap.Active, mgThing, mgChannel); err != nil {
+	if _, err := cr.db.ExecContext(ctx, q, bootstrap.Active, thingID, channelID); err != nil {
 		return errors.Wrap(errConnectThing, err)
 	}
 	return nil
 }
 
-func (cr configRepository) DisconnectThing(ctx context.Context, mgChannel, mgThing string) error {
+func (cr configRepository) DisconnectThing(ctx context.Context, channelID, thingID string) error {
 	q := `UPDATE configs SET state = $1 WHERE EXISTS (
 		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)`
-	if _, err := cr.db.ExecContext(ctx, q, bootstrap.Inactive, mgThing, mgChannel); err != nil {
+	if _, err := cr.db.ExecContext(ctx, q, bootstrap.Inactive, thingID, channelID); err != nil {
 		return errors.Wrap(errDisconnectThing, err)
 	}
 	return nil

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -458,14 +458,12 @@ func (cr configRepository) RemoveChannel(ctx context.Context, id string) error {
 
 func (cr configRepository) ConnectThing(ctx context.Context, channelID, thingID string) error {
 	q := `UPDATE configs SET state = $1 WHERE EXISTS (
-		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)
-		RETURNING *`
-	rows, err := cr.db.QueryContext(ctx, q, bootstrap.Active, thingID, channelID)
+		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)`
+	result, err := cr.db.ExecContext(ctx, q, bootstrap.Active, thingID, channelID)
 	if err != nil {
 		return errors.Wrap(errConnectThing, err)
 	}
-	defer rows.Close()
-	if ok := rows.Next(); !ok {
+	if rows, _ := result.RowsAffected(); rows == 0 {
 		return repoerr.ErrNotFound
 	}
 	return nil
@@ -473,14 +471,12 @@ func (cr configRepository) ConnectThing(ctx context.Context, channelID, thingID 
 
 func (cr configRepository) DisconnectThing(ctx context.Context, channelID, thingID string) error {
 	q := `UPDATE configs SET state = $1 WHERE EXISTS (
-		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)
-		RETURNING *`
-	rows, err := cr.db.QueryContext(ctx, q, bootstrap.Inactive, thingID, channelID)
+		SELECT 1 FROM connections WHERE config_id = $2 AND channel_id = $3)`
+	result, err := cr.db.ExecContext(ctx, q, bootstrap.Inactive, thingID, channelID)
 	if err != nil {
 		return errors.Wrap(errDisconnectThing, err)
 	}
-	defer rows.Close()
-	if ok := rows.Next(); !ok {
+	if rows, _ := result.RowsAffected(); rows == 0 {
 		return repoerr.ErrNotFound
 	}
 	return nil

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -36,8 +36,7 @@ var (
 		State:   bootstrap.Inactive,
 	}
 
-	channels      = []string{"1", "2"}
-	emptyChannels = []string{}
+	channels = []string{"1", "2"}
 )
 
 func TestSave(t *testing.T) {
@@ -727,12 +726,12 @@ func TestConnectThing(t *testing.T) {
 			err:         nil,
 		},
 		{
-			desc:        "connect with empty channel",
+			desc:        "connect already connected thing",
 			owner:       config.Owner,
-			id:          saved,
-			channels:    emptyThing.Channels,
-			connections: emptyChannels,
-			err:         repoerr.ErrMalformedEntity,
+			id:          connectedThing.ThingID,
+			channels:    c.Channels,
+			connections: channels,
+			err:         nil,
 		},
 		{
 			desc:        "connect non-existent thing",
@@ -741,14 +740,6 @@ func TestConnectThing(t *testing.T) {
 			channels:    c.Channels,
 			connections: channels,
 			err:         repoerr.ErrNotFound,
-		},
-		{
-			desc:        "connect already connected thing",
-			owner:       config.Owner,
-			id:          connectedThing.ThingID,
-			channels:    c.Channels,
-			connections: channels,
-			err:         repoerr.ErrConflict,
 		},
 		{
 			desc:        "connect random thing",
@@ -764,7 +755,7 @@ func TestConnectThing(t *testing.T) {
 			id:          emptyThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         repoerr.ErrMalformedEntity,
+			err:         repoerr.ErrNotFound,
 		},
 	}
 	for _, tc := range cases {
@@ -848,7 +839,7 @@ func TestDisconnectThing(t *testing.T) {
 			id:          wrongID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         nil,
+			err:         repoerr.ErrNotFound,
 		},
 		{
 			desc:        "disconnect random thing",
@@ -856,7 +847,7 @@ func TestDisconnectThing(t *testing.T) {
 			id:          randomThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         nil,
+			err:         repoerr.ErrNotFound,
 		},
 		{
 			desc:        "disconnect empty thing",
@@ -864,7 +855,7 @@ func TestDisconnectThing(t *testing.T) {
 			id:          emptyThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         repoerr.ErrMalformedEntity,
+			err:         repoerr.ErrNotFound,
 		},
 	}
 

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -36,7 +36,8 @@ var (
 		State:   bootstrap.Inactive,
 	}
 
-	channels = []string{"1", "2"}
+	channels      = []string{"1", "2"}
+	emptyChannels = []string{}
 )
 
 func TestSave(t *testing.T) {
@@ -707,6 +708,7 @@ func TestConnectThing(t *testing.T) {
 	emptyThing.ThingKey = ""
 	emptyThing.ExternalID = ""
 	emptyThing.ExternalKey = ""
+	emptyThing.Channels = []bootstrap.Channel{}
 
 	cases := []struct {
 		desc        string
@@ -723,6 +725,14 @@ func TestConnectThing(t *testing.T) {
 			channels:    c.Channels,
 			connections: channels,
 			err:         nil,
+		},
+		{
+			desc:        "connect with empty channel",
+			owner:       config.Owner,
+			id:          saved,
+			channels:    emptyThing.Channels,
+			connections: emptyChannels,
+			err:         repoerr.ErrMalformedEntity,
 		},
 		{
 			desc:        "connect non-existent thing",

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/absmach/magistrala/internal/testsutil"
 	"github.com/absmach/magistrala/pkg/errors"
 	repoerr "github.com/absmach/magistrala/pkg/errors/repository"
-	svcerr "github.com/absmach/magistrala/pkg/errors/service"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -731,7 +730,7 @@ func TestConnectThing(t *testing.T) {
 			id:          wrongID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         svcerr.ErrAddPolicies,
+			err:         repoerr.ErrNotFound,
 		},
 		{
 			desc:        "connect already connected thing",
@@ -739,7 +738,7 @@ func TestConnectThing(t *testing.T) {
 			id:          connectedThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         svcerr.ErrAddPolicies,
+			err:         repoerr.ErrConflict,
 		},
 		{
 			desc:        "connect random thing",
@@ -747,7 +746,7 @@ func TestConnectThing(t *testing.T) {
 			id:          randomThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         svcerr.ErrAddPolicies,
+			err:         repoerr.ErrNotFound,
 		},
 		{
 			desc:        "connect empty thing",
@@ -755,15 +754,7 @@ func TestConnectThing(t *testing.T) {
 			id:          emptyThing.ThingID,
 			channels:    c.Channels,
 			connections: channels,
-			err:         svcerr.ErrMalformedEntity,
-		},
-		{
-			desc:        "connect thing with failed database update operation",
-			owner:       config.Owner,
-			id:          saved,
-			channels:    c.Channels,
-			connections: channels,
-			err:         svcerr.ErrAddPolicies,
+			err:         repoerr.ErrMalformedEntity,
 		},
 	}
 	for _, tc := range cases {

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -98,10 +98,10 @@ type Service interface {
 	RemoveChannelHandler(ctx context.Context, id string) error
 
 	// ConnectHandler changes state of the Config to active when connect event occurs.
-	ConnectThingHandler(ctx context.Context, mgChannel, mgThing string) error
+	ConnectThingHandler(ctx context.Context, channelID, ThingID string) error
 
 	// DisconnectHandler changes state of the Config to inactive when disconnect event occurs.
-	DisconnectThingHandler(ctx context.Context, mgChannel, mgThing string) error
+	DisconnectThingHandler(ctx context.Context, channelID, ThingID string) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -377,15 +377,15 @@ func (bs bootstrapService) RemoveChannelHandler(ctx context.Context, id string) 
 	return nil
 }
 
-func (bs bootstrapService) ConnectThingHandler(ctx context.Context, mgChannel, mgThing string) error {
-	if err := bs.configs.ConnectThing(ctx, mgChannel, mgThing); err != nil {
+func (bs bootstrapService) ConnectThingHandler(ctx context.Context, channelID, thingID string) error {
+	if err := bs.configs.ConnectThing(ctx, channelID, thingID); err != nil {
 		return errors.Wrap(errConnectThing, err)
 	}
 	return nil
 }
 
-func (bs bootstrapService) DisconnectThingHandler(ctx context.Context, mgChannel, mgThing string) error {
-	if err := bs.configs.DisconnectThing(ctx, mgChannel, mgThing); err != nil {
+func (bs bootstrapService) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
+	if err := bs.configs.DisconnectThing(ctx, channelID, thingID); err != nil {
 		return errors.Wrap(errDisconnectThing, err)
 	}
 	return nil

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -41,6 +41,7 @@ var (
 	errRemoveConfig       = errors.New("failed to remove bootstrap configuration")
 	errRemoveChannel      = errors.New("failed to remove channel")
 	errCreateThing        = errors.New("failed to create thing")
+	errConnectThing       = errors.New("failed to connect thing")
 	errDisconnectThing    = errors.New("failed to disconnect thing")
 	errCheckChannels      = errors.New("failed to check if channels exists")
 	errConnectionChannels = errors.New("failed to check channels connections")
@@ -96,8 +97,11 @@ type Service interface {
 	// RemoveChannelHandler removes Channel with id received from an event.
 	RemoveChannelHandler(ctx context.Context, id string) error
 
-	// DisconnectHandler changes state of the Config when connect/disconnect event occurs.
-	DisconnectThingHandler(ctx context.Context, channelID, thingID string) error
+	// ConnectHandler changes state of the Config to active when connect event occurs.
+	ConnectThingHandler(ctx context.Context, mgChannel, mgThing string) error
+
+	// DisconnectHandler changes state of the Config to inactive when disconnect event occurs.
+	DisconnectThingHandler(ctx context.Context, mgChannel, mgThing string) error
 }
 
 // ConfigReader is used to parse Config into format which will be encoded
@@ -373,8 +377,15 @@ func (bs bootstrapService) RemoveChannelHandler(ctx context.Context, id string) 
 	return nil
 }
 
-func (bs bootstrapService) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
-	if err := bs.configs.DisconnectThing(ctx, channelID, thingID); err != nil {
+func (bs bootstrapService) ConnectThingHandler(ctx context.Context, mgChannel, mgThing string) error {
+	if err := bs.configs.ConnectThing(ctx, mgChannel, mgThing); err != nil {
+		return errors.Wrap(errConnectThing, err)
+	}
+	return nil
+}
+
+func (bs bootstrapService) DisconnectThingHandler(ctx context.Context, mgChannel, mgThing string) error {
+	if err := bs.configs.DisconnectThing(ctx, mgChannel, mgThing); err != nil {
 		return errors.Wrap(errDisconnectThing, err)
 	}
 	return nil

--- a/bootstrap/service.go
+++ b/bootstrap/service.go
@@ -97,10 +97,10 @@ type Service interface {
 	// RemoveChannelHandler removes Channel with id received from an event.
 	RemoveChannelHandler(ctx context.Context, id string) error
 
-	// ConnectHandler changes state of the Config to active when connect event occurs.
+	// ConnectThingHandler changes state of the Config to active when connect event occurs.
 	ConnectThingHandler(ctx context.Context, channelID, ThingID string) error
 
-	// DisconnectHandler changes state of the Config to inactive when disconnect event occurs.
+	// DisconnectThingHandler changes state of the Config to inactive when disconnect event occurs.
 	DisconnectThingHandler(ctx context.Context, channelID, ThingID string) error
 }
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -708,6 +708,7 @@ func TestBootstrap(t *testing.T) {
 		repoCall.Unset()
 	}
 }
+
 func TestChangeState(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -907,6 +908,7 @@ func TestRemoveConfigHandler(t *testing.T) {
 		repoCall.Unset()
 	}
 }
+
 func TestConnectThingsHandler(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -929,16 +931,46 @@ func TestConnectThingsHandler(t *testing.T) {
 		err       error
 	}{
 		{
-			desc:      "connect",
+			desc:      "connect a thing",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
 			err:       nil,
 		},
 		{
-			desc:      "connect connected",
+			desc:      "connect connected thing",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
 			err:       nil,
+		},
+		{
+			desc:      "connect for a disconnected thing",
+			channelID: channel.ID,
+			thingID:   config.ThingID,
+			err:       err,
+		},
+		{
+			desc:      "connect for an invalid thing",
+			channelID: channel.ID,
+			thingID:   unknown,
+			err:       err,
+		},
+		{
+			desc:      "connect for a random thing",
+			channelID: channel.ID,
+			thingID:   unknown,
+			err:       err,
+		},
+		{
+			desc:      "connect for an empty thing",
+			channelID: channel.ID,
+			thingID:   "",
+			err:       err,
+		},
+		{
+			desc:      "connect with failed connection",
+			channelID: channel.ID,
+			thingID:   config.ThingID,
+			err:       err,
 		},
 	}
 
@@ -949,6 +981,7 @@ func TestConnectThingsHandler(t *testing.T) {
 		repoCall.Unset()
 	}
 }
+
 func TestDisconnectThingsHandler(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -981,6 +1014,30 @@ func TestDisconnectThingsHandler(t *testing.T) {
 			channelID: channel.ID,
 			thingID:   config.ThingID,
 			err:       nil,
+		},
+		{
+			desc:      "disconnect for an invalid thing",
+			channelID: channel.ID,
+			thingID:   unknown,
+			err:       err,
+		},
+		{
+			desc:      "disconnect for a random thing",
+			channelID: channel.ID,
+			thingID:   unknown,
+			err:       err,
+		},
+		{
+			desc:      "disconnect for an empty thing",
+			channelID: channel.ID,
+			thingID:   "",
+			err:       err,
+		},
+		{
+			desc:      "disconnect with failed disconnection",
+			channelID: channel.ID,
+			thingID:   config.ThingID,
+			err:       err,
 		},
 	}
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -799,43 +799,13 @@ func TestConnectThingsHandler(t *testing.T) {
 		err       error
 	}{
 		{
-			desc:      "connect a thing",
+			desc:      "connect",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
 			err:       nil,
 		},
 		{
-			desc:      "connect connected thing",
-			channelID: channel.ID,
-			thingID:   config.ThingID,
-			err:       svcerr.ErrAddPolicies,
-		},
-		{
-			desc:      "connect for a disconnected thing",
-			channelID: channel.ID,
-			thingID:   config.ThingID,
-			err:       nil,
-		},
-		{
-			desc:      "connect for an invalid thing",
-			channelID: channel.ID,
-			thingID:   unknown,
-			err:       svcerr.ErrAddPolicies,
-		},
-		{
-			desc:      "connect for an invalid channel",
-			channelID: unknown,
-			thingID:   config.ThingID,
-			err:       svcerr.ErrAuthorization,
-		},
-		{
-			desc:      "connect for a random thing",
-			channelID: channel.ID,
-			thingID:   unknown,
-			err:       svcerr.ErrAddPolicies,
-		},
-		{
-			desc:      "connect with failed connection",
+			desc:      "connect connected",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
 			err:       svcerr.ErrAddPolicies,
@@ -870,37 +840,13 @@ func TestDisconnectThingsHandler(t *testing.T) {
 			thingID:   config.ThingID,
 			err:       nil,
 		},
-		{
-			desc:      "disconnect for an invalid thing",
-			channelID: channel.ID,
-			thingID:   unknown,
-			err:       svcerr.ErrDeletePolicies,
-		},
-		{
-			desc:      "disconnect for a random thing",
-			channelID: channel.ID,
-			thingID:   unknown,
-			err:       svcerr.ErrDeletePolicies,
-		},
-		{
-			desc:      "disconnect for an empty thing",
-			channelID: channel.ID,
-			thingID:   "",
-			err:       svcerr.ErrDeletePolicies,
-		},
-		{
-			desc:      "disconnect with failed disconnection",
-			channelID: channel.ID,
-			thingID:   config.ThingID,
-			err:       svcerr.ErrDeletePolicies,
-		},
 	}
 
 	for _, tc := range cases {
-		repoCall := boot.On("DisconnectThing", context.Background(), mock.Anything, mock.Anything).Return(tc.err)
+		svcCall := boot.On("DisconnectThing", context.Background(), mock.Anything, mock.Anything).Return(tc.err)
 		err := svc.DisconnectThingHandler(context.Background(), tc.channelID, tc.thingID)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
-		repoCall.Unset()
+		svcCall.Unset()
 	}
 }
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -144,20 +144,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestView(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, auth, _ := newService()
 	cases := []struct {
 		desc  string
 		id    string
@@ -195,25 +182,12 @@ func TestView(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	svc, boot, auth, sdk := newService()
+	svc, boot, auth, _ := newService()
 	c := config
 
 	ch := channel
 	ch.ID = "2"
 	c.Channels = append(c.Channels, ch)
-
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, c)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
 
 	modifiedCreated := c
 	modifiedCreated.Content = "new-config"
@@ -259,24 +233,8 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdateCert(t *testing.T) {
-	svc, boot, auth, sdk := newService()
+	svc, boot, auth, _ := newService()
 	c := config
-
-	ch := channel
-	ch.ID = "2"
-	c.Channels = append(c.Channels, ch)
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, c)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
 
 	cases := []struct {
 		desc           string
@@ -584,20 +542,7 @@ func TestList(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, auth, _ := newService()
 	cases := []struct {
 		desc  string
 		id    string
@@ -641,20 +586,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestBootstrap(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, _, _ := newService()
 	e, err := enc([]byte(config.ExternalKey))
 	assert.Nil(t, err, fmt.Sprintf("Encrypting external key expected to succeed: %s.\n", err))
 
@@ -711,19 +643,6 @@ func TestBootstrap(t *testing.T) {
 
 func TestChangeState(t *testing.T) {
 	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(toGroup(config.Channels[0]), nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
 	cases := []struct {
 		desc  string
 		state bootstrap.State
@@ -785,19 +704,7 @@ func TestChangeState(t *testing.T) {
 }
 
 func TestUpdateChannelHandler(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
+	svc, boot, _, _ := newService()
 	ch := bootstrap.Channel{
 		ID:       channel.ID,
 		Name:     "new name",
@@ -830,20 +737,7 @@ func TestUpdateChannelHandler(t *testing.T) {
 }
 
 func TestRemoveChannelHandler(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, _, _ := newService()
 	cases := []struct {
 		desc string
 		id   string
@@ -870,20 +764,7 @@ func TestRemoveChannelHandler(t *testing.T) {
 }
 
 func TestRemoveConfigHandler(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, _, _ := newService()
 	cases := []struct {
 		desc string
 		id   string
@@ -910,20 +791,7 @@ func TestRemoveConfigHandler(t *testing.T) {
 }
 
 func TestConnectThingsHandler(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, _, _ := newService()
 	cases := []struct {
 		desc      string
 		thingID   string
@@ -940,55 +808,37 @@ func TestConnectThingsHandler(t *testing.T) {
 			desc:      "connect connected thing",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
-			err:       nil,
+			err:       svcerr.ErrAddPolicies,
 		},
 		{
 			desc:      "connect for a disconnected thing",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
-			err:       err,
+			err:       nil,
 		},
 		{
 			desc:      "connect for an invalid thing",
 			channelID: channel.ID,
 			thingID:   unknown,
-			err:       err,
+			err:       svcerr.ErrAddPolicies,
 		},
 		{
-			desc:      "connect for an invalid chanel",
+			desc:      "connect for an invalid channel",
 			channelID: unknown,
 			thingID:   config.ThingID,
-			err:       err,
+			err:       svcerr.ErrAuthorization,
 		},
 		{
 			desc:      "connect for a random thing",
 			channelID: channel.ID,
 			thingID:   unknown,
-			err:       err,
-		},
-		{
-			desc:      "connect for an empty thing",
-			channelID: channel.ID,
-			thingID:   "",
-			err:       err,
-		},
-		{
-			desc:      "connect for an empty channel",
-			channelID: "",
-			thingID:   config.ThingID,
-			err:       err,
-		},
-		{
-			desc:      "connect for an empty thing and channel",
-			channelID: "",
-			thingID:   "",
-			err:       err,
+			err:       svcerr.ErrAddPolicies,
 		},
 		{
 			desc:      "connect with failed connection",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
-			err:       err,
+			err:       svcerr.ErrAddPolicies,
 		},
 	}
 
@@ -1001,20 +851,7 @@ func TestConnectThingsHandler(t *testing.T) {
 }
 
 func TestDisconnectThingsHandler(t *testing.T) {
-	svc, boot, auth, sdk := newService()
-	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
-	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
-	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
-	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
-	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	_, err := svc.Add(context.Background(), validToken, config)
-	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
-	repoCall.Unset()
-	repoCall1.Unset()
-	repoCall2.Unset()
-	repoCall3.Unset()
-	repoCall4.Unset()
-
+	svc, boot, _, _ := newService()
 	cases := []struct {
 		desc      string
 		thingID   string
@@ -1037,25 +874,25 @@ func TestDisconnectThingsHandler(t *testing.T) {
 			desc:      "disconnect for an invalid thing",
 			channelID: channel.ID,
 			thingID:   unknown,
-			err:       err,
+			err:       svcerr.ErrDeletePolicies,
 		},
 		{
 			desc:      "disconnect for a random thing",
 			channelID: channel.ID,
 			thingID:   unknown,
-			err:       err,
+			err:       svcerr.ErrDeletePolicies,
 		},
 		{
 			desc:      "disconnect for an empty thing",
 			channelID: channel.ID,
 			thingID:   "",
-			err:       err,
+			err:       svcerr.ErrDeletePolicies,
 		},
 		{
 			desc:      "disconnect with failed disconnection",
 			channelID: channel.ID,
 			thingID:   config.ThingID,
-			err:       err,
+			err:       svcerr.ErrDeletePolicies,
 		},
 	}
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -955,6 +955,12 @@ func TestConnectThingsHandler(t *testing.T) {
 			err:       err,
 		},
 		{
+			desc:      "connect for an invalid chanel",
+			channelID: unknown,
+			thingID:   config.ThingID,
+			err:       err,
+		},
+		{
 			desc:      "connect for a random thing",
 			channelID: channel.ID,
 			thingID:   unknown,
@@ -963,6 +969,18 @@ func TestConnectThingsHandler(t *testing.T) {
 		{
 			desc:      "connect for an empty thing",
 			channelID: channel.ID,
+			thingID:   "",
+			err:       err,
+		},
+		{
+			desc:      "connect for an empty channel",
+			channelID: "",
+			thingID:   config.ThingID,
+			err:       err,
+		},
+		{
+			desc:      "connect for an empty thing and channel",
+			channelID: "",
 			thingID:   "",
 			err:       err,
 		},

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -150,7 +150,7 @@ func TestView(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -166,7 +166,7 @@ func TestView(t *testing.T) {
 	}{
 		{
 			desc:  "view an existing config",
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
@@ -207,7 +207,7 @@ func TestUpdate(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, c)
+	_, err := svc.Add(context.Background(), validToken, c)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -215,7 +215,7 @@ func TestUpdate(t *testing.T) {
 	repoCall3.Unset()
 	repoCall4.Unset()
 
-	modifiedCreated := saved
+	modifiedCreated := c
 	modifiedCreated.Content = "new-config"
 	modifiedCreated.Name = "new name"
 
@@ -242,7 +242,7 @@ func TestUpdate(t *testing.T) {
 		},
 		{
 			desc:   "update a config with wrong credentials",
-			config: saved,
+			config: c,
 			token:  invalidToken,
 			err:    svcerr.ErrAuthentication,
 		},
@@ -270,7 +270,7 @@ func TestUpdateCert(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, c)
+	_, err := svc.Add(context.Background(), validToken, c)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -290,21 +290,21 @@ func TestUpdateCert(t *testing.T) {
 	}{
 		{
 			desc:       "update certs for the valid config",
-			thingID:    saved.ThingID,
+			thingID:    c.ThingID,
 			clientCert: "newCert",
 			clientKey:  "newKey",
 			caCert:     "newCert",
 			token:      validToken,
 			expectedConfig: bootstrap.Config{
-				Name:        saved.Name,
-				ThingKey:    saved.ThingKey,
-				Channels:    saved.Channels,
-				ExternalID:  saved.ExternalID,
-				ExternalKey: saved.ExternalKey,
-				Content:     saved.Content,
-				State:       saved.State,
-				Owner:       saved.Owner,
-				ThingID:     saved.ThingID,
+				Name:        c.Name,
+				ThingKey:    c.ThingKey,
+				Channels:    c.Channels,
+				ExternalID:  c.ExternalID,
+				ExternalKey: c.ExternalKey,
+				Content:     c.Content,
+				State:       c.State,
+				Owner:       c.Owner,
+				ThingID:     c.ThingID,
 				ClientCert:  "newCert",
 				CACert:      "newCert",
 				ClientKey:   "newKey",
@@ -323,7 +323,7 @@ func TestUpdateCert(t *testing.T) {
 		},
 		{
 			desc:           "update config cert with wrong credentials",
-			thingID:        saved.ThingID,
+			thingID:        c.ThingID,
 			clientCert:     "newCert",
 			clientKey:      "newKey",
 			caCert:         "newCert",
@@ -590,7 +590,7 @@ func TestRemove(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -606,19 +606,19 @@ func TestRemove(t *testing.T) {
 	}{
 		{
 			desc:  "view a config with wrong credentials",
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: invalidToken,
 			err:   svcerr.ErrAuthentication,
 		},
 		{
 			desc:  "remove an existing config",
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
 		{
 			desc:  "remove removed config",
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
@@ -647,7 +647,7 @@ func TestBootstrap(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -655,7 +655,7 @@ func TestBootstrap(t *testing.T) {
 	repoCall3.Unset()
 	repoCall4.Unset()
 
-	e, err := enc([]byte(saved.ExternalKey))
+	e, err := enc([]byte(config.ExternalKey))
 	assert.Nil(t, err, fmt.Sprintf("Encrypting external key expected to succeed: %s.\n", err))
 
 	cases := []struct {
@@ -670,30 +670,30 @@ func TestBootstrap(t *testing.T) {
 			desc:        "bootstrap using invalid external id",
 			config:      bootstrap.Config{},
 			externalID:  "invalid",
-			externalKey: saved.ExternalKey,
+			externalKey: config.ExternalKey,
 			err:         svcerr.ErrNotFound,
 			encrypted:   false,
 		},
 		{
 			desc:        "bootstrap using invalid external key",
 			config:      bootstrap.Config{},
-			externalID:  saved.ExternalID,
+			externalID:  config.ExternalID,
 			externalKey: "invalid",
 			err:         bootstrap.ErrExternalKey,
 			encrypted:   false,
 		},
 		{
 			desc:        "bootstrap an existing config",
-			config:      saved,
-			externalID:  saved.ExternalID,
-			externalKey: saved.ExternalKey,
+			config:      config,
+			externalID:  config.ExternalID,
+			externalKey: config.ExternalKey,
 			err:         nil,
 			encrypted:   false,
 		},
 		{
 			desc:        "bootstrap encrypted",
-			config:      saved,
-			externalID:  saved.ExternalID,
+			config:      config,
+			externalID:  config.ExternalID,
 			externalKey: hex.EncodeToString(e),
 			err:         nil,
 			encrypted:   true,
@@ -708,7 +708,6 @@ func TestBootstrap(t *testing.T) {
 		repoCall.Unset()
 	}
 }
-
 func TestChangeState(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -716,7 +715,7 @@ func TestChangeState(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(toGroup(config.Channels[0]), nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -734,7 +733,7 @@ func TestChangeState(t *testing.T) {
 		{
 			desc:  "change state with wrong credentials",
 			state: bootstrap.Active,
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: invalidToken,
 			err:   svcerr.ErrAuthentication,
 		},
@@ -748,21 +747,21 @@ func TestChangeState(t *testing.T) {
 		{
 			desc:  "change state to Active",
 			state: bootstrap.Active,
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
 		{
 			desc:  "change state to current state",
 			state: bootstrap.Active,
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
 		{
 			desc:  "change state to Inactive",
 			state: bootstrap.Inactive,
-			id:    saved.ThingID,
+			id:    config.ThingID,
 			token: validToken,
 			err:   nil,
 		},
@@ -851,7 +850,7 @@ func TestRemoveChannelHandler(t *testing.T) {
 	}{
 		{
 			desc: "remove an existing channel",
-			id:   channel.ID,
+			id:   config.Channels[0].ID,
 			err:  nil,
 		},
 		{
@@ -869,14 +868,14 @@ func TestRemoveChannelHandler(t *testing.T) {
 	}
 }
 
-func TestRemoveCoinfigHandler(t *testing.T) {
+func TestRemoveConfigHandler(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
 	repoCall1 := sdk.On("Thing", mock.Anything, mock.Anything).Return(mgsdk.Thing{ID: config.ThingID, Credentials: mgsdk.Credentials{Secret: config.ThingKey}}, nil)
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -891,7 +890,7 @@ func TestRemoveCoinfigHandler(t *testing.T) {
 	}{
 		{
 			desc: "remove an existing config",
-			id:   saved.ThingID,
+			id:   config.ThingID,
 			err:  nil,
 		},
 		{
@@ -908,7 +907,6 @@ func TestRemoveCoinfigHandler(t *testing.T) {
 		repoCall.Unset()
 	}
 }
-
 func TestConnectThingsHandler(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -916,7 +914,7 @@ func TestConnectThingsHandler(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -933,13 +931,13 @@ func TestConnectThingsHandler(t *testing.T) {
 		{
 			desc:      "connect",
 			channelID: channel.ID,
-			thingID:   saved.ThingID,
+			thingID:   config.ThingID,
 			err:       nil,
 		},
 		{
 			desc:      "connect connected",
 			channelID: channel.ID,
-			thingID:   saved.ThingID,
+			thingID:   config.ThingID,
 			err:       nil,
 		},
 	}
@@ -951,7 +949,6 @@ func TestConnectThingsHandler(t *testing.T) {
 		repoCall.Unset()
 	}
 }
-
 func TestDisconnectThingsHandler(t *testing.T) {
 	svc, boot, auth, sdk := newService()
 	repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: validToken}).Return(&magistrala.IdentityRes{Id: validID}, nil)
@@ -959,7 +956,7 @@ func TestDisconnectThingsHandler(t *testing.T) {
 	repoCall2 := sdk.On("Channel", mock.Anything, mock.Anything).Return(mgsdk.Channel{}, nil)
 	repoCall3 := boot.On("ListExisting", context.Background(), mock.Anything, mock.Anything, mock.Anything).Return(config.Channels, nil)
 	repoCall4 := boot.On("Save", context.Background(), mock.Anything, mock.Anything).Return(mock.Anything, nil)
-	saved, err := svc.Add(context.Background(), validToken, config)
+	_, err := svc.Add(context.Background(), validToken, config)
 	assert.Nil(t, err, fmt.Sprintf("Saving config expected to succeed: %s.\n", err))
 	repoCall.Unset()
 	repoCall1.Unset()
@@ -976,13 +973,13 @@ func TestDisconnectThingsHandler(t *testing.T) {
 		{
 			desc:      "disconnect",
 			channelID: channel.ID,
-			thingID:   saved.ThingID,
+			thingID:   config.ThingID,
 			err:       nil,
 		},
 		{
 			desc:      "disconnect disconnected",
 			channelID: channel.ID,
-			thingID:   saved.ThingID,
+			thingID:   config.ThingID,
 			err:       nil,
 		},
 	}

--- a/bootstrap/tracing/tracing.go
+++ b/bootstrap/tracing/tracing.go
@@ -158,6 +158,17 @@ func (tm *tracingMiddleware) RemoveChannelHandler(ctx context.Context, id string
 	return tm.svc.RemoveChannelHandler(ctx, id)
 }
 
+// ConnectThingHandler traces the "ConnectThingHandler" operation of the wrapped bootstrap.Service.
+func (tm *tracingMiddleware) ConnectThingHandler(ctx context.Context, channelID, thingID string) error {
+	ctx, span := tm.tracer.Start(ctx, "svc_connect_thing_handler", trace.WithAttributes(
+		attribute.String("channel_id", channelID),
+		attribute.String("thing_id", thingID),
+	))
+	defer span.End()
+
+	return tm.svc.ConnectThingHandler(ctx, channelID, thingID)
+}
+
 // DisconnectThingHandler traces the "DisconnectThingHandler" operation of the wrapped bootstrap.Service.
 func (tm *tracingMiddleware) DisconnectThingHandler(ctx context.Context, channelID, thingID string) error {
 	ctx, span := tm.tracer.Start(ctx, "svc_disconnect_thing_handler", trace.WithAttributes(

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,6 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
@@ -191,5 +190,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	mvdan.cc/gofumpt v0.6.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
@@ -190,4 +191,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	mvdan.cc/gofumpt v0.6.0 // indirect
 )

--- a/internal/groups/events/events.go
+++ b/internal/groups/events/events.go
@@ -39,14 +39,18 @@ var (
 )
 
 type assignEvent struct {
-	memberIDs []string
-	groupID   string
+	memberIDs  []string
+	relation   string
+	memberKind string
+	groupID    string
 }
 
 func (cge assignEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  groupAssign,
 		"member_ids": cge.memberIDs,
+		"relation":   cge.relation,
+		"memberKind": cge.memberKind,
 		"group_id":   cge.groupID,
 	}
 
@@ -54,14 +58,18 @@ func (cge assignEvent) Encode() (map[string]interface{}, error) {
 }
 
 type unassignEvent struct {
-	memberIDs []string
-	groupID   string
+	memberIDs  []string
+	relation   string
+	memberKind string
+	groupID    string
 }
 
 func (cge unassignEvent) Encode() (map[string]interface{}, error) {
 	val := map[string]interface{}{
 		"operation":  groupUnassign,
 		"member_ids": cge.memberIDs,
+		"relation":   cge.relation,
+		"memberKind": cge.memberKind,
 		"group_id":   cge.groupID,
 	}
 

--- a/internal/groups/events/streams.go
+++ b/internal/groups/events/streams.go
@@ -145,8 +145,10 @@ func (es eventStore) Assign(ctx context.Context, token, groupID, relation, membe
 	}
 
 	event := assignEvent{
-		groupID:   groupID,
-		memberIDs: memberIDs,
+		groupID:    groupID,
+		relation:   relation,
+		memberKind: memberKind,
+		memberIDs:  memberIDs,
 	}
 
 	if err := es.Publish(ctx, event); err != nil {
@@ -162,8 +164,10 @@ func (es eventStore) Unassign(ctx context.Context, token, groupID, relation, mem
 	}
 
 	event := unassignEvent{
-		groupID:   groupID,
-		memberIDs: memberIDs,
+		groupID:    groupID,
+		relation:   relation,
+		memberKind: memberKind,
+		memberIDs:  memberIDs,
 	}
 
 	if err := es.Publish(ctx, event); err != nil {


### PR DESCRIPTION
### What type of PR is this?

This is a feature because it adds the connectEvent struct to the consumer package.

### What does this do?
- If `channel` and `thing` are connected , change state of config to `Active`
- If `channel` and `thing` are disconnected,  change state of config to `Inactive`

### Which issue(s) does this PR fix/relate to?

- Resolves absmach/supermq#2142

## Have you included tests for your changes?

Yes, I have included tests for my changes.

## Did you document any new/modified feature?

No