### PR TITLE
MG-2056 - List Domains not showing domains

### DIFF
--- a/auth/api/http/domains/decode.go
+++ b/auth/api/http/domains/decode.go
@@ -146,7 +146,7 @@ func decodeListUserDomainsRequest(ctx context.Context, r *http.Request) (interfa
 }
 
 func decodePageRequest(_ context.Context, r *http.Request) (page, error) {
-	s, err := apiutil.ReadStringQuery(r, api.StatusKey, auth.All)
+	s, err := apiutil.ReadStringQuery(r, api.StatusKey, api.DefClientStatus)
 	if err != nil {
 		return page{}, errors.Wrap(apiutil.ErrValidation, err)
 	}

--- a/auth/api/http/domains/endpoint.go
+++ b/auth/api/http/domains/endpoint.go
@@ -7,7 +7,9 @@ import (
 	"context"
 
 	"github.com/absmach/magistrala/auth"
+	"github.com/absmach/magistrala/internal/apiutil"
 	"github.com/absmach/magistrala/pkg/clients"
+	"github.com/absmach/magistrala/pkg/errors"
 	"github.com/go-kit/kit/endpoint"
 )
 
@@ -93,7 +95,7 @@ func listDomainsEndpoint(svc auth.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listDomainsReq)
 		if err := req.validate(); err != nil {
-			return nil, err
+			return nil, errors.Wrap(apiutil.ErrValidation, err)
 		}
 
 		page := auth.Page{


### PR DESCRIPTION
# What type of PR is this?

This is a refactor as it lists enabled domains by default.

## What does this do?

This PR modifies the default behavior of the domain listing feature. Previously, all domains were listed regardless of their status. With this change, only enabled domains will be listed by default.

## Which issue(s) does this PR fix/relate to?

- Resolves #2056 

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No