### PR TITLE
MG-2235 - Check gRPC Service is Healthy During Setup

### DIFF
--- a/auth/api/grpc/endpoint_test.go
+++ b/auth/api/grpc/endpoint_test.go
@@ -63,7 +63,7 @@ func startGRPCServer(svc auth.Service, port int) {
 }
 
 func TestIssue(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -132,7 +132,7 @@ func TestIssue(t *testing.T) {
 }
 
 func TestRefresh(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -178,7 +178,7 @@ func TestRefresh(t *testing.T) {
 }
 
 func TestIdentify(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -222,7 +222,7 @@ func TestIdentify(t *testing.T) {
 }
 
 func TestAuthorize(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -344,7 +344,7 @@ func TestAuthorize(t *testing.T) {
 }
 
 func TestAddPolicy(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -398,7 +398,7 @@ func TestAddPolicy(t *testing.T) {
 }
 
 func TestAddPolicies(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -460,7 +460,7 @@ func TestAddPolicies(t *testing.T) {
 }
 
 func TestDeletePolicy(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -513,7 +513,7 @@ func TestDeletePolicy(t *testing.T) {
 }
 
 func TestDeletePolicies(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -576,7 +576,7 @@ func TestDeletePolicies(t *testing.T) {
 }
 
 func TestListObjects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -626,7 +626,7 @@ func TestListObjects(t *testing.T) {
 }
 
 func TestListAllObjects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -676,7 +676,7 @@ func TestListAllObjects(t *testing.T) {
 }
 
 func TestCountObects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -726,7 +726,7 @@ func TestCountObects(t *testing.T) {
 }
 
 func TestListSubjects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -776,7 +776,7 @@ func TestListSubjects(t *testing.T) {
 }
 
 func TestListAllSubjects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf(`"Unexpected error creating client connection %s"`, err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -826,7 +826,7 @@ func TestListAllSubjects(t *testing.T) {
 }
 
 func TestCountSubjects(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 
@@ -881,7 +881,7 @@ func TestCountSubjects(t *testing.T) {
 }
 
 func TestListPermissions(t *testing.T) {
-	conn, err := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.Nil(t, err, fmt.Sprintf("Unexpected error creating client connection %s", err))
 	client := grpcapi.NewClient(conn, time.Second)
 

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -107,7 +107,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/cassandra-reader/main.go
+++ b/cmd/cassandra-reader/main.go
@@ -76,7 +76,7 @@ func main() {
 		return
 	}
 
-	ac, acHandler, err := auth.Setup(authConfig)
+	ac, acHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1
@@ -93,7 +93,7 @@ func main() {
 		return
 	}
 
-	tc, tcHandler, err := auth.SetupAuthz(authConfig)
+	tc, tcHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/certs/main.go
+++ b/cmd/certs/main.go
@@ -126,7 +126,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/coap/main.go
+++ b/cmd/coap/main.go
@@ -94,7 +94,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.SetupAuthz(authConfig)
+	authClient, authHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -94,7 +94,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.SetupAuthz(authConfig)
+	authClient, authHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/influxdb-reader/main.go
+++ b/cmd/influxdb-reader/main.go
@@ -75,7 +75,7 @@ func main() {
 		return
 	}
 
-	ac, acHandler, err := auth.Setup(authConfig)
+	ac, acHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1
@@ -92,7 +92,7 @@ func main() {
 		return
 	}
 
-	tc, tcHandler, err := auth.SetupAuthz(authConfig)
+	tc, tcHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/invitations/main.go
+++ b/cmd/invitations/main.go
@@ -98,7 +98,7 @@ func main() {
 		exitCode = 1
 		return
 	}
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/mongodb-reader/main.go
+++ b/cmd/mongodb-reader/main.go
@@ -84,7 +84,7 @@ func main() {
 		return
 	}
 
-	ac, acHandler, err := auth.Setup(authConfig)
+	ac, acHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1
@@ -101,7 +101,7 @@ func main() {
 		return
 	}
 
-	tc, tcHandler, err := auth.SetupAuthz(authConfig)
+	tc, tcHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/mqtt/main.go
+++ b/cmd/mqtt/main.go
@@ -171,7 +171,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.SetupAuthz(authConfig)
+	authClient, authHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/postgres-reader/main.go
+++ b/cmd/postgres-reader/main.go
@@ -90,7 +90,7 @@ func main() {
 		return
 	}
 
-	ac, acHandler, err := auth.Setup(authConfig)
+	ac, acHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1
@@ -107,7 +107,7 @@ func main() {
 		return
 	}
 
-	tc, tcHandler, err := auth.SetupAuthz(authConfig)
+	tc, tcHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/smpp-notifier/main.go
+++ b/cmd/smpp-notifier/main.go
@@ -139,7 +139,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/smtp-notifier/main.go
+++ b/cmd/smtp-notifier/main.go
@@ -140,7 +140,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/things/main.go
+++ b/cmd/things/main.go
@@ -158,7 +158,7 @@ func main() {
 			return
 		}
 
-		authServiceClient, authHandler, err := auth.Setup(authConfig)
+		authServiceClient, authHandler, err := auth.Setup(ctx, authConfig)
 		if err != nil {
 			logger.Error(err.Error())
 			exitCode = 1

--- a/cmd/timescale-reader/main.go
+++ b/cmd/timescale-reader/main.go
@@ -90,7 +90,7 @@ func main() {
 		return
 	}
 
-	ac, acHandler, err := auth.Setup(authConfig)
+	ac, acHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1
@@ -107,7 +107,7 @@ func main() {
 		return
 	}
 
-	tc, tcHandler, err := auth.SetupAuthz(authConfig)
+	tc, tcHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/twins/main.go
+++ b/cmd/twins/main.go
@@ -134,7 +134,7 @@ func main() {
 			return
 		}
 
-		authServiceClient, authHandler, err := auth.Setup(authConfig)
+		authServiceClient, authHandler, err := auth.Setup(ctx, authConfig)
 		if err != nil {
 			logger.Error(err.Error())
 			exitCode = 1

--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -154,7 +154,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.Setup(authConfig)
+	authClient, authHandler, err := auth.Setup(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/cmd/ws/main.go
+++ b/cmd/ws/main.go
@@ -96,7 +96,7 @@ func main() {
 		return
 	}
 
-	authClient, authHandler, err := auth.SetupAuthz(authConfig)
+	authClient, authHandler, err := auth.SetupAuthz(ctx, authConfig)
 	if err != nil {
 		logger.Error(err.Error())
 		exitCode = 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -175,6 +175,7 @@ services:
     container_name: magistrala-invitations
     restart: on-failure
     depends_on:
+      - auth
       - invitations-db
     environment:
       MG_INVITATIONS_LOG_LEVEL: ${MG_INVITATIONS_LOG_LEVEL}
@@ -255,6 +256,7 @@ services:
     env_file:
       - .env
     depends_on:
+      - auth
       - things
       - users
       - mqtt-adapter

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -4,20 +4,37 @@
 package auth
 
 import (
+	"context"
+
 	"github.com/absmach/magistrala"
 	authgrpc "github.com/absmach/magistrala/auth/api/grpc"
+	"github.com/absmach/magistrala/pkg/errors"
 	thingsauth "github.com/absmach/magistrala/things/api/grpc"
+	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 )
+
+var errHealthCheckFailed = errors.New("health check failed")
 
 // Setup loads Auth gRPC configuration and creates new Auth gRPC client.
 //
 // For example:
 //
-//	authClient, authHandler, err := auth.Setup(auth.Config{})
-func Setup(cfg Config) (magistrala.AuthServiceClient, Handler, error) {
+//	authClient, authHandler, err := auth.Setup(ctx, auth.Config{})
+func Setup(ctx context.Context, cfg Config) (magistrala.AuthServiceClient, Handler, error) {
 	client, err := newHandler(cfg)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	health := grpchealth.NewHealthClient(client.Connection())
+	resp, err := health.Check(ctx, &grpchealth.HealthCheckRequest{
+		Service: "auth",
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(errHealthCheckFailed, err)
+	}
+	if resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
+		return nil, nil, errors.Wrap(errHealthCheckFailed, errors.New("service is not serving"))
 	}
 
 	return authgrpc.NewClient(client.Connection(), cfg.Timeout), client, nil
@@ -27,11 +44,22 @@ func Setup(cfg Config) (magistrala.AuthServiceClient, Handler, error) {
 //
 // For example:
 //
-//	authzClient, authzHandler, err := auth.Setup(auth.Config{})
-func SetupAuthz(cfg Config) (magistrala.AuthzServiceClient, Handler, error) {
+//	authzClient, authzHandler, err := auth.Setup(ctx, auth.Config{})
+func SetupAuthz(ctx context.Context, cfg Config) (magistrala.AuthzServiceClient, Handler, error) {
 	client, err := newHandler(cfg)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	health := grpchealth.NewHealthClient(client.Connection())
+	resp, err := health.Check(ctx, &grpchealth.HealthCheckRequest{
+		Service: "things",
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(errHealthCheckFailed, err)
+	}
+	if resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
+		return nil, nil, errors.Wrap(errHealthCheckFailed, errors.New("service is not serving"))
 	}
 
 	return thingsauth.NewClient(client.Connection(), cfg.Timeout), client, nil

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -13,7 +13,7 @@ import (
 	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-var errHealthCheckFailed = errors.New("health check failed")
+var errSvcNotServing = errors.New("service is not serving")
 
 // Setup loads Auth gRPC configuration and creates new Auth gRPC client.
 //
@@ -30,11 +30,8 @@ func Setup(ctx context.Context, cfg Config) (magistrala.AuthServiceClient, Handl
 	resp, err := health.Check(ctx, &grpchealth.HealthCheckRequest{
 		Service: "auth",
 	})
-	if err != nil {
-		return nil, nil, errors.Wrap(errHealthCheckFailed, err)
-	}
-	if resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
-		return nil, nil, errors.Wrap(errHealthCheckFailed, errors.New("service is not serving"))
+	if err != nil || resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
+		return nil, nil, errSvcNotServing
 	}
 
 	return authgrpc.NewClient(client.Connection(), cfg.Timeout), client, nil
@@ -55,11 +52,8 @@ func SetupAuthz(ctx context.Context, cfg Config) (magistrala.AuthzServiceClient,
 	resp, err := health.Check(ctx, &grpchealth.HealthCheckRequest{
 		Service: "things",
 	})
-	if err != nil {
-		return nil, nil, errors.Wrap(errHealthCheckFailed, err)
-	}
-	if resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
-		return nil, nil, errors.Wrap(errHealthCheckFailed, errors.New("service is not serving"))
+	if err != nil || resp.GetStatus() != grpchealth.HealthCheckResponse_SERVING {
+		return nil, nil, errSvcNotServing
 	}
 
 	return thingsauth.NewClient(client.Connection(), cfg.Timeout), client, nil

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -4,6 +4,7 @@
 package auth_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -39,7 +40,7 @@ func TestSetupAuth(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			client, handler, err := auth.Setup(c.config)
+			client, handler, err := auth.Setup(context.Background(), c.config)
 			assert.True(t, errors.Contains(err, c.err), fmt.Sprintf("expected %s to contain %s", err, c.err))
 			if err == nil {
 				assert.NotNil(t, client)
@@ -75,7 +76,7 @@ func TestSetupAuthz(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			client, handler, err := auth.SetupAuthz(c.config)
+			client, handler, err := auth.SetupAuthz(context.Background(), c.config)
 			assert.True(t, errors.Contains(err, c.err), fmt.Sprintf("expected %s to contain %s", err, c.err))
 			if err == nil {
 				assert.NotNil(t, client)

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -58,7 +58,7 @@ func TestSetupAuth(t *testing.T) {
 				URL:     "",
 				Timeout: time.Second,
 			},
-			err: errors.New("health check failed"),
+			err: errors.New("service is not serving"),
 		},
 	}
 
@@ -109,7 +109,7 @@ func TestSetupAuthz(t *testing.T) {
 				URL:     "",
 				Timeout: time.Second,
 			},
-			err: errors.New("health check failed"),
+			err: errors.New("service is not serving"),
 		},
 	}
 

--- a/pkg/auth/connect.go
+++ b/pkg/auth/connect.go
@@ -143,9 +143,10 @@ func connect(cfg Config) (*grpc.ClientConn, security, error) {
 		grpc.WithWriteBufferSize(buffSize),
 	)
 
-	conn, err := grpc.Dial(cfg.URL, opts...)
+	conn, err := grpc.NewClient(cfg.URL, opts...)
 	if err != nil {
 		return nil, secure, errors.Wrap(errGrpcConnect, err)
 	}
+
 	return conn, secure, nil
 }

--- a/pkg/auth/connect_test.go
+++ b/pkg/auth/connect_test.go
@@ -56,7 +56,7 @@ func TestHandler(t *testing.T) {
 				URL:     "",
 				Timeout: time.Second,
 			},
-			err: errors.New("failed to connect to grpc server"),
+			secure: "without TLS",
 		},
 		{
 			desc: "failed with invalid server CA file",

--- a/things/api/grpc/endpoint_test.go
+++ b/things/api/grpc/endpoint_test.go
@@ -51,7 +51,7 @@ func TestAuthorize(t *testing.T) {
 	svc := new(mocks.Service)
 	startGRPCServer(svc, port)
 	authAddr := fmt.Sprintf("localhost:%d", port)
-	conn, _ := grpc.Dial(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, _ := grpc.NewClient(authAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	client := grpcapi.NewClient(conn, time.Second)
 
 	cases := []struct {


### PR DESCRIPTION
Signed-off-by: Rodney Osodo <28790446+rodneyosodo@users.noreply.github.com>
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `MG-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/magistrala/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?

This is a bug fix because it fixes the following issue: #2235

<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

When connecting to the grpc server ensure the server is healthy before returning AuthClient during setup
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Resolves #2235 

## Have you included tests for your changes?

Yes, I have modified testes and tested manually

The logs below are for test where I simulated the things auth server is unhealthy

```go
go func() {
	if s.Name == "things" {
		s.health.SetServingStatus(s.Name, grpchealth.HealthCheckResponse_NOT_SERVING)
		time.Sleep(20 * time.Second)
		s.health.SetServingStatus(s.Name, grpchealth.HealthCheckResponse_SERVING)
	}
}()
```
<details>
<summary>Logs</summary>

```bash

2024/05/20 13:05:03 The binary was build using Nats as the message broker
2024/05/20 13:05:03 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:07.477911143Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:08 The binary was build using Nats as the message broker
2024/05/20 13:05:08 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:08.540289122Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:09 The binary was build using Nats as the message broker
2024/05/20 13:05:09 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:09.822231503Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:10 The binary was build using Nats as the message broker
2024/05/20 13:05:10 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:10.87364065Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:12 The binary was build using Nats as the message broker
2024/05/20 13:05:12 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:12.159471781Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:14 The binary was build using Nats as the message broker
2024/05/20 13:05:14 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:14.377178361Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:18 The binary was build using Nats as the message broker
2024/05/20 13:05:18 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:18.045618441Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:24 The binary was build using Nats as the message broker
2024/05/20 13:05:24 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:24.845535079Z","level":"ERROR","msg":"health check failed : service is not serving"}
2024/05/20 13:05:38 The binary was build using Nats as the message broker
2024/05/20 13:05:38 The binary was build using Nats as the message broker
{"time":"2024-05-20T13:05:38.051349708Z","level":"INFO","msg":"Successfully connected to things grpc server without TLS"}
{"time":"2024-05-20T13:05:38.053738507Z","level":"INFO","msg":"coap_adapter service started using http, exposed port coap-adapter:5683"}
{"time":"2024-05-20T13:05:38.053787321Z","level":"INFO","msg":"coap_adapter service  server listening at coap-adapter:5683 without TLS"}
{"time":"2024-05-20T13:05:38.053738527Z","level":"INFO","msg":"coap_adapter service http server listening at coap-adapter:5683 without TLS"}

```

</details>

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?

I have updated go docs for the setup function

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
