### PR TITLE
NOISSUE: add `status` field to `ListMembers` response

### DIFF
--- a/users/service.go
+++ b/users/service.go
@@ -528,6 +528,7 @@ func (svc service) ListMembers(ctx context.Context, token, objectKind, objectID 
 			Name:      c.Name,
 			CreatedAt: c.CreatedAt,
 			UpdatedAt: c.UpdatedAt,
+			Status:    c.Status,
 		}
 	}
 


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--
Pull request title should be `MG-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/magistrala/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?

This is a bug fix.

## What does this do?

This PR introduces a `status` filter within the `ListMembers` method, allowing for correct filtering of members based on their status when listing members by group 

## Which issue(s) does this PR fix/relate to?
No issue

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No

### Notes
`ListMembers` response before the fix

![image](https://github.com/absmach/magistrala/assets/44696487/f32c6f7e-a68b-4f54-b871-a779ed851c45)
