### PR TITLE
MG-2330 - Fix non admins search with identity

### DIFF
--- a/api/openapi/users.yml
+++ b/api/openapi/users.yml
@@ -397,6 +397,32 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
+    /users/search:
+    get:
+      operationId: searchUsers
+      summary: Search users
+      description: |
+        Search users by name and identity.
+      tags:
+        - Users
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+        - $ref: "#/components/parameters/UserName"
+        - $ref: "#/components/parameters/UserIdentity"
+        - $ref: "#/components/parameters/UserID"
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          $ref: "#/components/responses/UserPageRes"
+        "400":
+          description: Failed due to malformed query parameters.
+        "401":
+          description: Missing or invalid access token provided.
+        "500":
+          $ref: "#/components/responses/ServiceError"
+
   /password/reset-request:
     post:
       operationId: requestPasswordReset

--- a/cli/users.go
+++ b/cli/users.go
@@ -488,7 +488,7 @@ var cmdUsers = []cobra.Command{
 				Limit:    Limit,
 				Name:     values.Get("name"),
 				Identity: values.Get("identity"),
-				ID:		  values.Get("id")
+				ID:		  values.Get("id"),
 			}
 
 			users, err := sdk.SearchUsers(pm, args[1])

--- a/cli/users.go
+++ b/cli/users.go
@@ -481,7 +481,7 @@ var cmdUsers = []cobra.Command{
 
 			values, err := url.ParseQuery(args[0])
 			if err != nil {
-				logError(fmt.Errorf("Failed to parse query: %s", err))
+				logErrorCmd(*cmd, fmt.Errorf("failed to parse query: %s", err))
 			}
 
 			pm := mgxsdk.PageMetadata{
@@ -489,7 +489,7 @@ var cmdUsers = []cobra.Command{
 				Limit:    Limit,
 				Name:     values.Get("name"),
 				Identity: values.Get("identity"),
-				ID:		  values.Get("id"),
+				ID:       values.Get("id"),
 			}
 
 			if off, err := strconv.Atoi(values.Get("offset")); err == nil {

--- a/cli/users.go
+++ b/cli/users.go
@@ -488,7 +488,6 @@ var cmdUsers = []cobra.Command{
 				Offset:   Offset,
 				Limit:    Limit,
 				Name:     values.Get("name"),
-				Identity: values.Get("identity"),
 				ID:       values.Get("id"),
 			}
 
@@ -514,7 +513,7 @@ var cmdUsers = []cobra.Command{
 // NewUsersCmd returns users command.
 func NewUsersCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "users [create | get | update | token | password | enable | disable | delete | channels | things | groups]",
+		Use:   "users [create | get | update | token | password | enable | disable | delete | channels | things | groups | search]",
 		Short: "Users management",
 		Long:  `Users management: create accounts and tokens"`,
 	}

--- a/cli/users.go
+++ b/cli/users.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	mgclients "github.com/absmach/magistrala/pkg/clients"
 	mgxsdk "github.com/absmach/magistrala/pkg/sdk/go"
@@ -489,6 +490,14 @@ var cmdUsers = []cobra.Command{
 				Name:     values.Get("name"),
 				Identity: values.Get("identity"),
 				ID:		  values.Get("id"),
+			}
+
+			if off, err := strconv.Atoi(values.Get("offset")); err == nil {
+				pm.Offset = uint64(off)
+			}
+
+			if lim, err := strconv.Atoi(values.Get("limit")); err == nil {
+				pm.Limit = uint64(lim)
 			}
 
 			users, err := sdk.SearchUsers(pm, args[1])

--- a/cli/users.go
+++ b/cli/users.go
@@ -465,6 +465,7 @@ var cmdUsers = []cobra.Command{
 			logJSONCmd(*cmd, users)
 		},
 	},
+
 	{
 		Use:   "search <query> <user_auth_token>",
 		Short: "Search users",
@@ -473,7 +474,7 @@ var cmdUsers = []cobra.Command{
 			"\tmagistrala-cli users search <query> <user_auth_token>\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 2 {
-				logUsage(cmd.Use)
+				logUsageCmd(*cmd, cmd.Use)
 				return
 			}
 
@@ -487,15 +488,16 @@ var cmdUsers = []cobra.Command{
 				Limit:    Limit,
 				Name:     values.Get("name"),
 				Identity: values.Get("identity"),
+				ID:		  values.Get("id")
 			}
 
 			users, err := sdk.SearchUsers(pm, args[1])
 			if err != nil {
-				logError(err)
+				logErrorCmd(*cmd, err)
 				return
 			}
 
-			logJSON(users)
+			logJSONCmd(*cmd, users)
 		},
 	},
 }

--- a/cli/users.go
+++ b/cli/users.go
@@ -5,6 +5,8 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 
 	mgclients "github.com/absmach/magistrala/pkg/clients"
 	mgxsdk "github.com/absmach/magistrala/pkg/sdk/go"
@@ -461,6 +463,39 @@ var cmdUsers = []cobra.Command{
 			}
 
 			logJSONCmd(*cmd, users)
+		},
+	},
+	{
+		Use:   "search <query> <user_auth_token>",
+		Short: "Search users",
+		Long: "Search users by query\n" +
+			"Usage:\n" +
+			"\tmagistrala-cli users search <query> <user_auth_token>\n",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 2 {
+				logUsage(cmd.Use)
+				return
+			}
+
+			values, err := url.ParseQuery(args[0])
+			if err != nil {
+				logError(fmt.Errorf("Failed to parse query: %s", err))
+			}
+
+			pm := mgxsdk.PageMetadata{
+				Offset:   Offset,
+				Limit:    Limit,
+				Name:     values.Get("name"),
+				Identity: values.Get("identity"),
+			}
+
+			users, err := sdk.SearchUsers(pm, args[1])
+			if err != nil {
+				logError(err)
+				return
+			}
+
+			logJSON(users)
 		},
 	},
 }

--- a/cli/users.go
+++ b/cli/users.go
@@ -485,10 +485,10 @@ var cmdUsers = []cobra.Command{
 			}
 
 			pm := mgxsdk.PageMetadata{
-				Offset:   Offset,
-				Limit:    Limit,
-				Name:     values.Get("name"),
-				ID:       values.Get("id"),
+				Offset: Offset,
+				Limit:  Limit,
+				Name:   values.Get("name"),
+				ID:     values.Get("id"),
 			}
 
 			if off, err := strconv.Atoi(values.Get("offset")); err == nil {

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -160,7 +160,9 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Contains(err, apiutil.ErrInvalidEntityType),
 		errors.Contains(err, apiutil.ErrMissingEntityType),
 		errors.Contains(err, apiutil.ErrInvalidTimeFormat),
-		errors.Contains(err, svcerr.ErrSearch):
+		errors.Contains(err, svcerr.ErrSearch),
+		errors.Contains(err, apiutil.ErrEmptySearchQuery),
+		errors.Contains(err, apiutil.ErrLenSearchQuery):
 		err = unwrap(err)
 		w.WriteHeader(http.StatusBadRequest)
 

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -178,7 +178,7 @@ var (
 	ErrInvalidEntityType = errors.New("invalid entity type")
 
 	// ErrInvalidTimeFormat indicates invalid time format i.e not unix time.
-	ErrInvalidTimeFormat = errors.New("invalid time format use unix time")\
+	ErrInvalidTimeFormat = errors.New("invalid time format use unix time")
 
 	// ErrEmptySearchQuery indicates search query should not be empty.
 	ErrEmptySearchQuery = errors.New("search query must not be empty")

--- a/pkg/apiutil/errors.go
+++ b/pkg/apiutil/errors.go
@@ -178,5 +178,11 @@ var (
 	ErrInvalidEntityType = errors.New("invalid entity type")
 
 	// ErrInvalidTimeFormat indicates invalid time format i.e not unix time.
-	ErrInvalidTimeFormat = errors.New("invalid time format use unix time")
+	ErrInvalidTimeFormat = errors.New("invalid time format use unix time")\
+
+	// ErrEmptySearchQuery indicates search query should not be empty.
+	ErrEmptySearchQuery = errors.New("search query must not be empty")
+
+	// ErrLenSearchQuery indicates search query length.
+	ErrLenSearchQuery = errors.New("search query must be at least 3 characters")
 )

--- a/pkg/clients/postgres/clients.go
+++ b/pkg/clients/postgres/clients.go
@@ -482,7 +482,7 @@ func PageQuery(pm clients.Page) (string, error) {
 	if pm.Name != "" {
 		query = append(query, "name ILIKE '%' || :name || '%'")
 	}
-	if pm.Identity != "" && pm.Role != clients.UserRole {
+	if pm.Identity != "" {
 		query = append(query, "identity ILIKE '%' || :identity || '%'")
 	}
 	if pm.Id != "" {

--- a/pkg/clients/postgres/clients.go
+++ b/pkg/clients/postgres/clients.go
@@ -482,7 +482,7 @@ func PageQuery(pm clients.Page) (string, error) {
 	if pm.Name != "" {
 		query = append(query, "name ILIKE '%' || :name || '%'")
 	}
-	if pm.Identity != "" {
+	if pm.Identity != "" && pm.Role != clients.UserRole {
 		query = append(query, "identity ILIKE '%' || :identity || '%'")
 	}
 	if pm.Id != "" {

--- a/pkg/clients/postgres/clients_test.go
+++ b/pkg/clients/postgres/clients_test.go
@@ -1231,7 +1231,7 @@ func TestSearchClients(t *testing.T) {
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),
 				Page: mgclients.Page{
-					Total:  0,
+					Total:  nClients,
 					Offset: 0,
 					Limit:  10,
 				},

--- a/pkg/clients/postgres/clients_test.go
+++ b/pkg/clients/postgres/clients_test.go
@@ -1227,6 +1227,7 @@ func TestSearchClients(t *testing.T) {
 				Identity: namegen.Generate(),
 				Offset:   0,
 				Limit:    10,
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),

--- a/pkg/clients/postgres/clients_test.go
+++ b/pkg/clients/postgres/clients_test.go
@@ -1142,7 +1142,6 @@ func TestSearchClients(t *testing.T) {
 				Limit:    10,
 				Order:    "name",
 				Dir:      "asc",
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: findClients(expectedClients, expectedClients[0].Name[:4], 0, 10),
@@ -1160,7 +1159,6 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name,
 				Offset:   0,
 				Limit:    10,
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client{expectedClients[0]},
@@ -1178,7 +1176,6 @@ func TestSearchClients(t *testing.T) {
 				Identity: fmt.Sprintf("%s' OR '1'='1", expectedClients[0].Name[:1]),
 				Offset:   0,
 				Limit:    10,
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),
@@ -1230,7 +1227,6 @@ func TestSearchClients(t *testing.T) {
 				Identity: namegen.Generate(),
 				Offset:   0,
 				Limit:    10,
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),
@@ -1274,7 +1270,6 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name[:1],
 				Offset:   0,
 				Limit:    10,
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{},
 			err:      nil,
@@ -1287,7 +1282,6 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name[:1],
 				Offset:   0,
 				Limit:    10,
-				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{},
 			err:      nil,

--- a/pkg/clients/postgres/clients_test.go
+++ b/pkg/clients/postgres/clients_test.go
@@ -1235,7 +1235,7 @@ func TestSearchClients(t *testing.T) {
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),
 				Page: mgclients.Page{
-					Total:  nClients,
+					Total:  0,
 					Offset: 0,
 					Limit:  10,
 				},

--- a/pkg/clients/postgres/clients_test.go
+++ b/pkg/clients/postgres/clients_test.go
@@ -1142,6 +1142,7 @@ func TestSearchClients(t *testing.T) {
 				Limit:    10,
 				Order:    "name",
 				Dir:      "asc",
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: findClients(expectedClients, expectedClients[0].Name[:4], 0, 10),
@@ -1159,6 +1160,7 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name,
 				Offset:   0,
 				Limit:    10,
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client{expectedClients[0]},
@@ -1176,6 +1178,7 @@ func TestSearchClients(t *testing.T) {
 				Identity: fmt.Sprintf("%s' OR '1'='1", expectedClients[0].Name[:1]),
 				Offset:   0,
 				Limit:    10,
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{
 				Clients: []mgclients.Client(nil),
@@ -1271,6 +1274,7 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name[:1],
 				Offset:   0,
 				Limit:    10,
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{},
 			err:      nil,
@@ -1283,6 +1287,7 @@ func TestSearchClients(t *testing.T) {
 				Identity: expectedClients[0].Name[:1],
 				Offset:   0,
 				Limit:    10,
+				Role:     mgclients.AllRole,
 			},
 			response: mgclients.ClientsPage{},
 			err:      nil,

--- a/pkg/sdk/go/sdk.go
+++ b/pkg/sdk/go/sdk.go
@@ -336,6 +336,18 @@ type SDK interface {
 	//  fmt.Println(things)
 	ListUserThings(userID string, pm PageMetadata, token string) (ThingsPage, errors.SDKError)
 
+	// SeachUsers filters users and returns a page result.
+	//
+	// example:
+	//  pm := sdk.PageMetadata{
+	//	Offset: 0,
+	//	Limit:  10,
+	//	Name:   "John Doe",
+	//  }
+	//  users, _ := sdk.SearchUsers(pm, "token")
+	//  fmt.Println(users)
+	SearchUsers(pm PageMetadata, token string) (UsersPage, errors.SDKError)
+
 	// CreateThing registers new thing and returns its id.
 	//
 	// example:

--- a/pkg/sdk/go/users.go
+++ b/pkg/sdk/go/users.go
@@ -347,7 +347,6 @@ func (sdk mgSDK) SearchUsers(pm PageMetadata, token string) (UsersPage, errors.S
 	return cp, nil
 }
 
-
 func (sdk mgSDK) EnableUser(id, token string) (User, errors.SDKError) {
 	return sdk.changeClientStatus(token, id, enableEndpoint)
 }

--- a/pkg/sdk/go/users.go
+++ b/pkg/sdk/go/users.go
@@ -328,6 +328,26 @@ func (sdk mgSDK) ListUserThings(userID string, pm PageMetadata, token string) (T
 	return tp, nil
 }
 
+func (sdk mgSDK) SearchUsers(pm PageMetadata, token string) (UsersPage, errors.SDKError) {
+	url, err := sdk.withQueryParams(sdk.usersURL, fmt.Sprintf("%s/search", usersEndpoint), pm)
+	if err != nil {
+		return UsersPage{}, errors.NewSDKError(err)
+	}
+
+	_, body, sdkerr := sdk.processRequest(http.MethodGet, url, token, nil, nil, http.StatusOK)
+	if sdkerr != nil {
+		return UsersPage{}, sdkerr
+	}
+
+	var cp UsersPage
+	if err := json.Unmarshal(body, &cp); err != nil {
+		return UsersPage{}, errors.NewSDKError(err)
+	}
+
+	return cp, nil
+}
+
+
 func (sdk mgSDK) EnableUser(id, token string) (User, errors.SDKError) {
 	return sdk.changeClientStatus(token, id, enableEndpoint)
 }

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -542,6 +542,131 @@ func TestListUsers(t *testing.T) {
 	}
 }
 
+func TestSearchClients(t *testing.T) {
+	ts, crepo, _, auth := setupUsers()
+	defer ts.Close()
+
+	var cls []sdk.User
+	conf := sdk.Config{
+		UsersURL: ts.URL,
+	}
+	mgsdk := sdk.NewSDK(conf)
+
+	for i := 10; i < 100; i++ {
+		cl := sdk.User{
+			ID:   generateUUID(t),
+			Name: fmt.Sprintf("client_%d", i),
+			Credentials: sdk.Credentials{
+				Identity: fmt.Sprintf("identity_%d", i),
+				Secret:   fmt.Sprintf("password_%d", i),
+			},
+			Metadata: sdk.Metadata{"name": fmt.Sprintf("client_%d", i)},
+			Status:   mgclients.EnabledStatus.String(),
+		}
+		if i == 50 {
+			cl.Status = mgclients.DisabledStatus.String()
+			cl.Tags = []string{"tag1", "tag2"}
+		}
+		cls = append(cls, cl)
+	}
+
+	cases := []struct {
+		desc         string
+		token        string
+		page         sdk.PageMetadata
+		response     []sdk.User
+		searchreturn mgclients.ClientsPage
+		identifyRes  *magistrala.IdentityRes
+		err          errors.SDKError
+		identifyErr  error
+	}{
+		{
+			desc:        "search for users",
+			token:       validToken,
+			err:         nil,
+			identifyRes: &magistrala.IdentityRes{UserId: validID},
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  limit,
+				Name:   "client_10",
+			},
+			response: []sdk.User{cls[10]},
+			searchreturn: mgclients.ClientsPage{
+				Clients: []mgclients.Client{convertClient(cls[10])},
+				Page: mgclients.Page{
+					Total:  1,
+					Offset: offset,
+					Limit:  limit,
+				},
+			},
+		},
+		{
+			desc:  "search for users with invalid token",
+			token: invalidToken,
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  limit,
+				Name:   "client_10",
+			},
+			err:         errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
+			response:    nil,
+			identifyErr: svcerr.ErrAuthentication,
+		},
+		{
+			desc:  "search for users with empty token",
+			token: "",
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  limit,
+				Name:   "client_10",
+			},
+			err:         errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, apiutil.ErrBearerToken), http.StatusUnauthorized),
+			response:    nil,
+			identifyErr: svcerr.ErrAuthentication,
+		},
+		{
+			desc:  "search for users with empty query",
+			token: validToken,
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  limit,
+				Name:   "",
+			},
+			err: errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, apiutil.ErrEmptySearchQuery), http.StatusBadRequest),
+		},
+		{
+			desc:  "search for users with invalid length of query",
+			token: validToken,
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  limit,
+				Name:   "a",
+			},
+			err: errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrLenSearchQuery, apiutil.ErrValidation), http.StatusBadRequest),
+		},
+		{
+			desc:  "search for users with invalid limit",
+			token: validToken,
+			page: sdk.PageMetadata{
+				Offset: offset,
+				Limit:  0,
+				Name:   "client_10",
+			},
+			err: errors.NewSDKErrorWithStatus(errors.Wrap(apiutil.ErrValidation, apiutil.ErrLimitSize), http.StatusBadRequest),
+		},
+	}
+
+	for _, tc := range cases {
+		repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: tc.token}).Return(tc.identifyRes, tc.identifyErr)
+		repoCall1 := crepo.On("SearchBasicInfo", mock.Anything, mock.Anything).Return(tc.searchreturn, tc.err)
+		page, err := mgsdk.SearchUsers(tc.page, tc.token)
+		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
+		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
+		repoCall.Unset()
+		repoCall1.Unset()
+	}
+}
+
 func TestViewUser(t *testing.T) {
 	ts, svc := setupUsers()
 	defer ts.Close()

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -543,7 +543,7 @@ func TestListUsers(t *testing.T) {
 }
 
 func TestSearchClients(t *testing.T) {
-	ts, crepo, _, auth := setupUsers()
+	ts, svc := setupUsers()
 	defer ts.Close()
 
 	var cls []sdk.User
@@ -576,7 +576,6 @@ func TestSearchClients(t *testing.T) {
 		page         sdk.PageMetadata
 		response     []sdk.User
 		searchreturn mgclients.ClientsPage
-		identifyRes  *magistrala.IdentityRes
 		err          errors.SDKError
 		identifyErr  error
 	}{
@@ -584,7 +583,6 @@ func TestSearchClients(t *testing.T) {
 			desc:        "search for users",
 			token:       validToken,
 			err:         nil,
-			identifyRes: &magistrala.IdentityRes{UserId: validID},
 			page: sdk.PageMetadata{
 				Offset: offset,
 				Limit:  limit,
@@ -657,13 +655,11 @@ func TestSearchClients(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		repoCall := auth.On("Identify", mock.Anything, &magistrala.IdentityReq{Token: tc.token}).Return(tc.identifyRes, tc.identifyErr)
-		repoCall1 := crepo.On("SearchBasicInfo", mock.Anything, mock.Anything).Return(tc.searchreturn, tc.err)
+		repoCall := svc.On("SearchUsers", mock.Anything, mock.Anything, mock.Anything).Return(tc.searchreturn, tc.err)
 		page, err := mgsdk.SearchUsers(tc.page, tc.token)
 		assert.Equal(t, tc.err, err, fmt.Sprintf("%s: expected error %s, got %s", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page.Users, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))
 		repoCall.Unset()
-		repoCall1.Unset()
 	}
 }
 

--- a/pkg/sdk/go/users_test.go
+++ b/pkg/sdk/go/users_test.go
@@ -580,9 +580,9 @@ func TestSearchClients(t *testing.T) {
 		identifyErr  error
 	}{
 		{
-			desc:        "search for users",
-			token:       validToken,
-			err:         nil,
+			desc:  "search for users",
+			token: validToken,
+			err:   nil,
 			page: sdk.PageMetadata{
 				Offset: offset,
 				Limit:  limit,

--- a/pkg/sdk/mocks/sdk.go
+++ b/pkg/sdk/mocks/sdk.go
@@ -2050,6 +2050,36 @@ func (_m *SDK) RevokeCert(thingID string, token string) (time.Time, errors.SDKEr
 	return r0, r1
 }
 
+// SearchUsers provides a mock function with given fields: pm, token
+func (_m *SDK) SearchUsers(pm sdk.PageMetadata, token string) (sdk.UsersPage, errors.SDKError) {
+	ret := _m.Called(pm, token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SearchUsers")
+	}
+
+	var r0 sdk.UsersPage
+	var r1 errors.SDKError
+	if rf, ok := ret.Get(0).(func(sdk.PageMetadata, string) (sdk.UsersPage, errors.SDKError)); ok {
+		return rf(pm, token)
+	}
+	if rf, ok := ret.Get(0).(func(sdk.PageMetadata, string) sdk.UsersPage); ok {
+		r0 = rf(pm, token)
+	} else {
+		r0 = ret.Get(0).(sdk.UsersPage)
+	}
+
+	if rf, ok := ret.Get(1).(func(sdk.PageMetadata, string) errors.SDKError); ok {
+		r1 = rf(pm, token)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.SDKError)
+		}
+	}
+
+	return r0, r1
+}
+
 // SendInvitation provides a mock function with given fields: invitation, token
 func (_m *SDK) SendInvitation(invitation sdk.Invitation, token string) error {
 	ret := _m.Called(invitation, token)

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -309,6 +309,16 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 		return nil, errors.Wrap(apiutil.ErrValidation, err)
 	}
 
+	for _, field := range []string{req.Name, req.Identity, req.Id} {
+		if field != "" && len(field) < 3 {
+			req = searchClientsReq{
+				token: apiutil.ExtractBearerToken(r),
+				Page:  mgclients.Page{},
+			}
+			return req, errors.Wrap(apiutil.ErrLenSearchQuery, apiutil.ErrValidation)
+		}
+	}
+
 	req := searchClientsReq{
 		token: apiutil.ExtractBearerToken(r),
 		Offset:     o,

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -309,25 +309,15 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 		return nil, errors.Wrap(apiutil.ErrValidation, err)
 	}
 
-	for _, field := range []string{req.Name, req.Identity, req.Id} {
-		if field != "" && len(field) < 3 {
-			req = searchClientsReq{
-				token: apiutil.ExtractBearerToken(r),
-				Page:  mgclients.Page{},
-			}
-			return req, errors.Wrap(apiutil.ErrLenSearchQuery, apiutil.ErrValidation)
-		}
-	}
-
 	req := searchClientsReq{
-		token: apiutil.ExtractBearerToken(r),
-		Offset:     o,
-		Limit:      l,
-		Identity:   i,
-		Name:       n,
-		Id:			id,
-		Order:		order,
-		Dir:		dir,
+		token:    apiutil.ExtractBearerToken(r),
+		Offset:   o,
+		Limit:    l,
+		Identity: i,
+		Name:     n,
+		Id:       id,
+		Order:    order,
+		Dir:      dir,
 	}
 
 	return req, nil

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -311,10 +311,8 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 
 	req := searchClientsReq{
 		token: apiutil.ExtractBearerToken(r),
-		Status:     st,
 		Offset:     o,
 		Limit:      l,
-		Metadata:   m,
 		Identity:   i,
 		Name:       n,
 		Id:			id,

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -306,13 +306,13 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 	}
 
 	req := searchClientsReq{
-		token:    apiutil.ExtractBearerToken(r),
-		Offset:   o,
-		Limit:    l,
-		Name:     n,
-		Id:       id,
-		Order:    order,
-		Dir:      dir,
+		token:  apiutil.ExtractBearerToken(r),
+		Offset: o,
+		Limit:  l,
+		Name:   n,
+		Id:     id,
+		Order:  order,
+		Dir:    dir,
 	}
 
 	for _, field := range []string{req.Name, req.Id} {

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -292,10 +292,6 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 	if err != nil {
 		return nil, errors.Wrap(apiutil.ErrValidation, err)
 	}
-	i, err := apiutil.ReadStringQuery(r, api.IdentityKey, "")
-	if err != nil {
-		return nil, errors.Wrap(apiutil.ErrValidation, err)
-	}
 	id, err := apiutil.ReadStringQuery(r, api.IDOrder, "")
 	if err != nil {
 		return nil, errors.Wrap(apiutil.ErrValidation, err)
@@ -313,14 +309,13 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 		token:    apiutil.ExtractBearerToken(r),
 		Offset:   o,
 		Limit:    l,
-		Identity: i,
 		Name:     n,
 		Id:       id,
 		Order:    order,
 		Dir:      dir,
 	}
 
-	for _, field := range []string{req.Name, req.Identity, req.Id} {
+	for _, field := range []string{req.Name, req.Id} {
 		if field != "" && len(field) < 3 {
 			req = searchClientsReq{
 				token: apiutil.ExtractBearerToken(r),

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -320,6 +320,15 @@ func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error
 		Dir:      dir,
 	}
 
+	for _, field := range []string{req.Name, req.Identity, req.Id} {
+		if field != "" && len(field) < 3 {
+			req = searchClientsReq{
+				token: apiutil.ExtractBearerToken(r),
+			}
+			return req, errors.Wrap(apiutil.ErrLenSearchQuery, apiutil.ErrValidation)
+		}
+	}
+
 	return req, nil
 }
 

--- a/users/api/clients.go
+++ b/users/api/clients.go
@@ -62,6 +62,13 @@ func clientsHandler(svc users.Service, r *chi.Mux, logger *slog.Logger, pr *rege
 			opts...,
 		), "list_clients").ServeHTTP)
 
+		r.Get("/search", otelhttp.NewHandler(kithttp.NewServer(
+			searchClientsEndpoint(svc),
+			decodeSearchClients,
+			api.EncodeResponse,
+			opts...,
+		), "search_clients").ServeHTTP)
+
 		r.Patch("/secret", otelhttp.NewHandler(kithttp.NewServer(
 			updateClientSecretEndpoint(svc),
 			decodeUpdateClientSecret,
@@ -267,6 +274,52 @@ func decodeListClients(_ context.Context, r *http.Request) (interface{}, error) 
 		order:    order,
 		dir:      dir,
 		id:       id,
+	}
+
+	return req, nil
+}
+
+func decodeSearchClients(_ context.Context, r *http.Request) (interface{}, error) {
+	o, err := apiutil.ReadNumQuery[uint64](r, api.OffsetKey, api.DefOffset)
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	l, err := apiutil.ReadNumQuery[uint64](r, api.LimitKey, api.DefLimit)
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	n, err := apiutil.ReadStringQuery(r, api.NameKey, "")
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	i, err := apiutil.ReadStringQuery(r, api.IdentityKey, "")
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	id, err := apiutil.ReadStringQuery(r, api.IDOrder, "")
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	order, err := apiutil.ReadStringQuery(r, api.OrderKey, api.DefOrder)
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+	dir, err := apiutil.ReadStringQuery(r, api.DirKey, api.DefDir)
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
+	}
+
+	req := searchClientsReq{
+		token: apiutil.ExtractBearerToken(r),
+		Status:     st,
+		Offset:     o,
+		Limit:      l,
+		Metadata:   m,
+		Identity:   i,
+		Name:       n,
+		Id:			id,
+		Order:		order,
+		Dir:		dir,
 	}
 
 	return req, nil

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -112,12 +112,12 @@ func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
 		}
 
 		pm := mgclients.Page{
-			Offset:   req.Offset,
-			Limit:    req.Limit,
-			Name:     req.Name,
-			Id:       req.Id,
-			Order:    req.Order,
-			Dir:      req.Dir,
+			Offset: req.Offset,
+			Limit:  req.Limit,
+			Name:   req.Name,
+			Id:     req.Id,
+			Order:  req.Order,
+			Dir:    req.Dir,
 		}
 		page, err := svc.SearchUsers(ctx, req.token, pm)
 		if err != nil {

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -121,7 +121,7 @@ func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
 			Order:    req.Order,
 			Dir:      req.Dir,
 		}
-		page, err := svc.SearchClients(ctx, req.token, pm)
+		page, err := svc.SearchUsers(ctx, req.token, pm)
 		if err != nil {
 			return nil, err
 		}

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -116,7 +116,7 @@ func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
 			Offset:   req.Offset,
 			Limit:    req.Limit,
 			Name:     req.Name,
-			Id:		  req.Id,
+			Id:       req.Id,
 			Identity: req.Identity,
 			Order:    req.Order,
 			Dir:      req.Dir,

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -104,6 +104,44 @@ func listClientsEndpoint(svc users.Service) endpoint.Endpoint {
 	}
 }
 
+func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(searchClientsReq)
+		if err := req.validate(); err != nil {
+			return nil, errors.Wrap(apiutil.ErrValidation, err)
+		}
+
+		pm := mgclients.Page{
+			Status:   req.Status,
+			Offset:   req.Offset,
+			Limit:    req.Limit,
+			Name:     req.Name,
+			Id:		  req.Id,
+			Identity: req.Identity,
+			Order:    req.Order,
+			Dir:      req.Dir,
+		}
+		page, err := svc.SearchClients(ctx, req.token, pm)
+		if err != nil {
+			return nil, err
+		}
+
+		res := clientsPageRes{
+			pageRes: pageRes{
+				Total:  page.Total,
+				Offset: page.Offset,
+				Limit:  page.Limit,
+			},
+			Clients: []viewClientRes{},
+		}
+		for _, client := range page.Clients {
+			res.Clients = append(res.Clients, viewClientRes{Client: client})
+		}
+
+		return res, nil
+	}
+}
+
 func listMembersByGroupEndpoint(svc users.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listMembersByObjectReq)

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -116,7 +116,6 @@ func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
 			Limit:    req.Limit,
 			Name:     req.Name,
 			Id:       req.Id,
-			Identity: req.Identity,
 			Order:    req.Order,
 			Dir:      req.Dir,
 		}

--- a/users/api/endpoints.go
+++ b/users/api/endpoints.go
@@ -112,7 +112,6 @@ func searchClientsEndpoint(svc users.Service) endpoint.Endpoint {
 		}
 
 		pm := mgclients.Page{
-			Status:   req.Status,
 			Offset:   req.Offset,
 			Limit:    req.Limit,
 			Name:     req.Name,

--- a/users/api/metrics.go
+++ b/users/api/metrics.go
@@ -84,6 +84,15 @@ func (ms *metricsMiddleware) ListClients(ctx context.Context, token string, pm m
 	return ms.svc.ListClients(ctx, token, pm)
 }
 
+// SearchUsers instruments SearchClients method with metrics.
+func (ms *metricsMiddleware) SearchUsers(ctx context.Context, token string, pm mgclients.Page) (mp mgclients.ClientsPage, err error) {
+	defer func(begin time.Time) {
+		ms.counter.With("method", "search_users").Add(1)
+		ms.latency.With("method", "search_users").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return ms.svc.SearchUsers(ctx, token, pm)
+}
+
 // UpdateClient instruments UpdateClient method with metrics.
 func (ms *metricsMiddleware) UpdateClient(ctx context.Context, token string, client mgclients.Client) (mgclients.Client, error) {
 	defer func(begin time.Time) {

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -99,6 +99,10 @@ func (req searchClientsReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
+	if req.Name == "" && req.Identity == "" && req.Id == "" {
+		return apiutil.ErrEmptySearchQuery
+	}
+
 	return nil
 }
 

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -90,7 +90,6 @@ func (req listClientsReq) validate() error {
 }
 
 type searchClientsReq struct {
-	mgclients.Page
 	token    string
 	Offset   uint64
 	Limit    uint64

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -93,7 +93,6 @@ type searchClientsReq struct {
 	token    string
 	Offset   uint64
 	Limit    uint64
-	Identity string
 	Name     string
 	Id       string
 	Order    string
@@ -105,7 +104,7 @@ func (req searchClientsReq) validate() error {
 		return apiutil.ErrBearerToken
 	}
 
-	if req.Name == "" && req.Identity == "" && req.Id == "" {
+	if req.Name == "" && req.Id == "" {
 		return apiutil.ErrEmptySearchQuery
 	}
 

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -91,7 +91,14 @@ func (req listClientsReq) validate() error {
 
 type searchClientsReq struct {
 	mgclients.Page
-	token string
+	token    string
+	Offset   uint64
+	Limit    uint64
+	Identity string
+	Name     string
+	Id       string
+	Order    string
+	Dir      string
 }
 
 func (req searchClientsReq) validate() error {

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -90,13 +90,13 @@ func (req listClientsReq) validate() error {
 }
 
 type searchClientsReq struct {
-	token    string
-	Offset   uint64
-	Limit    uint64
-	Name     string
-	Id       string
-	Order    string
-	Dir      string
+	token  string
+	Offset uint64
+	Limit  uint64
+	Name   string
+	Id     string
+	Order  string
+	Dir    string
 }
 
 func (req searchClientsReq) validate() error {

--- a/users/api/requests.go
+++ b/users/api/requests.go
@@ -89,6 +89,19 @@ func (req listClientsReq) validate() error {
 	return nil
 }
 
+type searchClientsReq struct {
+	mgclients.Page
+	token string
+}
+
+func (req searchClientsReq) validate() error {
+	if req.token == "" {
+		return apiutil.ErrBearerToken
+	}
+
+	return nil
+}
+
 type listMembersByObjectReq struct {
 	mgclients.Page
 	token      string

--- a/users/api/requests_test.go
+++ b/users/api/requests_test.go
@@ -237,6 +237,46 @@ func TestListClientsReqValidate(t *testing.T) {
 	}
 }
 
+func TestSearchClientsReqValidate(t *testing.T) {
+	cases := []struct {
+		desc string
+		req  searchClientsReq
+		err  error
+	}{
+		{
+			desc: "valid request",
+			req: searchClientsReq{
+				token: valid,
+				Page: mgclients.Page{
+					Name: name,
+				},
+			},
+			err: nil,
+		},
+		{
+			desc: "empty token",
+			req: searchClientsReq{
+				token: "",
+				Page: mgclients.Page{
+					Name: name,
+				},
+			},
+			err: apiutil.ErrBearerToken,
+		},
+		{
+			desc: "empty query",
+			req: searchClientsReq{
+				token: valid,
+			},
+			err: apiutil.ErrEmptySearchQuery,
+		},
+	}
+	for _, c := range cases {
+		err := c.req.validate()
+		assert.Equal(t, c.err, err)
+	}
+}
+
 func TestListMembersByObjectReqValidate(t *testing.T) {
 	cases := []struct {
 		desc string

--- a/users/api/requests_test.go
+++ b/users/api/requests_test.go
@@ -247,7 +247,7 @@ func TestSearchClientsReqValidate(t *testing.T) {
 			desc: "valid request",
 			req: searchClientsReq{
 				token: valid,
-				Name: name,
+				Name:  name,
 			},
 			err: nil,
 		},
@@ -255,7 +255,7 @@ func TestSearchClientsReqValidate(t *testing.T) {
 			desc: "empty token",
 			req: searchClientsReq{
 				token: "",
-				Name: name,
+				Name:  name,
 			},
 			err: apiutil.ErrBearerToken,
 		},

--- a/users/api/requests_test.go
+++ b/users/api/requests_test.go
@@ -247,9 +247,7 @@ func TestSearchClientsReqValidate(t *testing.T) {
 			desc: "valid request",
 			req: searchClientsReq{
 				token: valid,
-				Page: mgclients.Page{
-					Name: name,
-				},
+				Name: name,
 			},
 			err: nil,
 		},
@@ -257,9 +255,7 @@ func TestSearchClientsReqValidate(t *testing.T) {
 			desc: "empty token",
 			req: searchClientsReq{
 				token: "",
-				Page: mgclients.Page{
-					Name: name,
-				},
+				Name: name,
 			},
 			err: apiutil.ErrBearerToken,
 		},

--- a/users/clients.go
+++ b/users/clients.go
@@ -31,6 +31,9 @@ type Service interface {
 	// ListMembers retrieves everything that is assigned to a group/thing identified by objectID.
 	ListMembers(ctx context.Context, token, objectKind, objectID string, pm clients.Page) (clients.MembersPage, error)
 
+	// SearchClients searches for users with provided filters for a valid auth token.
+	SearchUsers(ctx context.Context, token string, pm clients.Page) (clients.ClientsPage, error)
+
 	// UpdateClient updates the client's name and metadata.
 	UpdateClient(ctx context.Context, token string, client clients.Client) (clients.Client, error)
 

--- a/users/events/events.go
+++ b/users/events/events.go
@@ -326,6 +326,9 @@ func (sce searchClientEvent) Encode() (map[string]interface{}, error) {
 	if sce.Identity != "" {
 		val["identity"] = sce.Identity
 	}
+	if sce.Id != "" {
+		val["id"] = sce.Id
+	}
 
 	return val, nil
 }

--- a/users/events/events.go
+++ b/users/events/events.go
@@ -18,6 +18,7 @@ const (
 	clientView         = clientPrefix + "view"
 	profileView        = clientPrefix + "view_profile"
 	clientList         = clientPrefix + "list"
+	clientSearch       = clientPrefix + "search"
 	clientListByGroup  = clientPrefix + "list_by_group"
 	clientIdentify     = clientPrefix + "identify"
 	generateResetToken = clientPrefix + "generate_reset_token"
@@ -37,6 +38,7 @@ var (
 	_ events.Event = (*viewProfileEvent)(nil)
 	_ events.Event = (*listClientEvent)(nil)
 	_ events.Event = (*listClientByGroupEvent)(nil)
+	_ events.Event = (*searchClientEvent)(nil)
 	_ events.Event = (*identifyClientEvent)(nil)
 	_ events.Event = (*generateResetTokenEvent)(nil)
 	_ events.Event = (*issueTokenEvent)(nil)
@@ -302,6 +304,27 @@ func (lcge listClientByGroupEvent) Encode() (map[string]interface{}, error) {
 	}
 	if lcge.Identity != "" {
 		val["identity"] = lcge.Identity
+	}
+
+	return val, nil
+}
+
+type searchClientEvent struct {
+	mgclients.Page
+}
+
+func (sce searchClientEvent) Encode() (map[string]interface{}, error) {
+	val := map[string]interface{}{
+		"operation": clientSearch,
+		"total":     sce.Total,
+		"offset":    sce.Offset,
+		"limit":     sce.Limit,
+	}
+	if sce.Name != "" {
+		val["name"] = sce.Name
+	}
+	if sce.Identity != "" {
+		val["identity"] = sce.Identity
 	}
 
 	return val, nil

--- a/users/events/streams.go
+++ b/users/events/streams.go
@@ -160,6 +160,22 @@ func (es *eventStore) ListClients(ctx context.Context, token string, pm mgclient
 	return cp, nil
 }
 
+func (es *eventStore) SearchUsers(ctx context.Context, token string, pm mgclients.Page) (mgclients.ClientsPage, error) {
+	cp, err := es.svc.SearchUsers(ctx, token, pm)
+	if err != nil {
+		return cp, err
+	}
+	event := searchClientEvent{
+		pm,
+	}
+
+	if err := es.Publish(ctx, event); err != nil {
+		return cp, err
+	}
+
+	return cp, nil
+}
+
 func (es *eventStore) ListMembers(ctx context.Context, token, objectKind, objectID string, pm mgclients.Page) (mgclients.MembersPage, error) {
 	mp, err := es.svc.ListMembers(ctx, token, objectKind, objectID, pm)
 	if err != nil {

--- a/users/mocks/service.go
+++ b/users/mocks/service.go
@@ -331,6 +331,34 @@ func (_m *Service) ResetSecret(ctx context.Context, resetToken string, secret st
 	return r0
 }
 
+// SearchUsers provides a mock function with given fields: ctx, token, pm
+func (_m *Service) SearchUsers(ctx context.Context, token string, pm clients.Page) (clients.ClientsPage, error) {
+	ret := _m.Called(ctx, token, pm)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SearchUsers")
+	}
+
+	var r0 clients.ClientsPage
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, clients.Page) (clients.ClientsPage, error)); ok {
+		return rf(ctx, token, pm)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, clients.Page) clients.ClientsPage); ok {
+		r0 = rf(ctx, token, pm)
+	} else {
+		r0 = ret.Get(0).(clients.ClientsPage)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, clients.Page) error); ok {
+		r1 = rf(ctx, token, pm)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SendPasswordReset provides a mock function with given fields: ctx, host, email, user, token
 func (_m *Service) SendPasswordReset(ctx context.Context, host string, email string, user string, token string) error {
 	ret := _m.Called(ctx, host, email, user, token)

--- a/users/service.go
+++ b/users/service.go
@@ -214,7 +214,7 @@ func (svc service) SearchUsers(ctx context.Context, token string, pm mgclients.P
 		return mgclients.ClientsPage{}, err
 	}
 
-	cp, err := svc.clients.SearchBasicInfo(ctx, pm)
+	cp, err := svc.clients.SearchClients(ctx, pm)
 	if err != nil {
 		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrSearch, err)
 	}

--- a/users/service.go
+++ b/users/service.go
@@ -189,6 +189,8 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return pg, err
 	}
 
+	// Return empty page if user is not super admin
+	// And search criteria by identity
 	if pm.Identity != "" {
 		return mgclients.ClientsPage{}, nil
 	}

--- a/users/service.go
+++ b/users/service.go
@@ -181,7 +181,7 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return mgclients.ClientsPage{}, err
 	}
 	if err := svc.checkSuperAdmin(ctx, userID); err != nil {
-		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrViewEntity, err)
+		return mgclients.ClientsPage{},  err
 	}
 
 	pm.Role = mgclients.AllRole

--- a/users/service.go
+++ b/users/service.go
@@ -197,7 +197,7 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		Role:   mgclients.UserRole,
 	}
 
-	pg, err := svc.clients.RetrieveAll(ctx, page)
+	pg, err := svc.clients.SearchClients(ctx, page)
 	if err != nil {
 		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}

--- a/users/service.go
+++ b/users/service.go
@@ -189,7 +189,15 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return pg, err
 	}
 
-	pg, err := svc.clients.SearchClients(ctx, pm)
+	page := mgclients.Page{
+		Offset: pm.Offset,
+		Limit:  pm.Limit,
+		Name:   pm.Name,
+		Id:     pm.Id,
+		Role:   mgclients.UserRole,
+	}
+
+	pg, err := svc.clients.SearchClients(ctx, page)
 	if err != nil {
 		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}

--- a/users/service.go
+++ b/users/service.go
@@ -189,12 +189,6 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return pg, err
 	}
 
-	// Return empty page if user is not super admin
-	// And search criteria by identity
-	if pm.Identity != "" {
-		return mgclients.ClientsPage{}, nil
-	}
-
 	page := mgclients.Page{
 		Offset: pm.Offset,
 		Limit:  pm.Limit,
@@ -203,7 +197,7 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		Role:   mgclients.UserRole,
 	}
 
-	pg, err := svc.clients.SearchClients(ctx, page)
+	pg, err := svc.clients.RetrieveAll(ctx, page)
 	if err != nil {
 		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}
@@ -212,6 +206,20 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 	}
 
 	return pg, nil
+}
+
+func (svc service) SearchUsers(ctx context.Context, token string, pm mgclients.Page) (mgclients.ClientsPage, error) {
+	_, err := svc.identify(ctx, token)
+	if err != nil {
+		return mgclients.ClientsPage{}, err
+	}
+
+	cp, err := svc.clients.SearchBasicInfo(ctx, pm)
+	if err != nil {
+		return mgclients.ClientsPage{}, errors.Wrap(svcerr.ErrSearch, err)
+	}
+
+	return cp, nil
 }
 
 func (svc service) UpdateClient(ctx context.Context, token string, cli mgclients.Client) (mgclients.Client, error) {

--- a/users/service.go
+++ b/users/service.go
@@ -181,7 +181,7 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return mgclients.ClientsPage{}, err
 	}
 	if err := svc.checkSuperAdmin(ctx, userID); err != nil {
-		return mgclients.ClientsPage{},  err
+		return mgclients.ClientsPage{}, err
 	}
 
 	pm.Role = mgclients.AllRole

--- a/users/service.go
+++ b/users/service.go
@@ -189,6 +189,10 @@ func (svc service) ListClients(ctx context.Context, token string, pm mgclients.P
 		return pg, err
 	}
 
+	if pm.Identity != "" {
+		return mgclients.ClientsPage{}, nil
+	}
+
 	page := mgclients.Page{
 		Offset: pm.Offset,
 		Limit:  pm.Limit,

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -534,7 +534,7 @@ func TestListClients(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: false},
 			token:             validToken,
 			authorizeErr:      svcerr.ErrAuthorization,
-			err:               nil,
+			err:               svcerr.ErrViewEntity,
 		},
 		{
 			desc: "list clients as admin with failed to retrieve clients",
@@ -557,29 +557,7 @@ func TestListClients(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: false},
 			token:             validToken,
 			superAdminErr:     svcerr.ErrAuthorization,
-			err:               nil,
-		},
-		{
-			desc: "list clients as normal user successfully",
-			page: mgclients.Page{
-				Total: 1,
-			},
-			identifyResponse:  &magistrala.IdentityRes{UserId: client.ID},
-			authorizeResponse: &magistrala.AuthorizeRes{Authorized: false},
-			retrieveAllResponse: mgclients.ClientsPage{
-				Page: mgclients.Page{
-					Total: 1,
-				},
-				Clients: []mgclients.Client{basicClient},
-			},
-			response: mgclients.ClientsPage{
-				Page: mgclients.Page{
-					Total: 1,
-				},
-				Clients: []mgclients.Client{basicClient},
-			},
-			token: validToken,
-			err:   nil,
+			err:               svcerr.ErrViewEntity,
 		},
 		{
 			desc: "list clients as normal user with failed to retrieve clients",

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -534,7 +534,7 @@ func TestListClients(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: false},
 			token:             validToken,
 			authorizeErr:      svcerr.ErrAuthorization,
-			err:               svcerr.ErrViewEntity,
+			err:               svcerr.ErrAuthorization,
 		},
 		{
 			desc: "list clients as admin with failed to retrieve clients",
@@ -557,7 +557,7 @@ func TestListClients(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: false},
 			token:             validToken,
 			superAdminErr:     svcerr.ErrAuthorization,
-			err:               svcerr.ErrViewEntity,
+			err:               svcerr.ErrAuthorization,
 		},
 		{
 			desc: "list clients as normal user with failed to retrieve clients",
@@ -569,7 +569,7 @@ func TestListClients(t *testing.T) {
 			retrieveAllResponse: mgclients.ClientsPage{},
 			token:               validToken,
 			retrieveAllErr:      repoerr.ErrNotFound,
-			err:                 svcerr.ErrViewEntity,
+			err:                 svcerr.ErrAuthorization,
 		},
 	}
 

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -660,17 +660,6 @@ func TestSearchUsers(t *testing.T) {
 			authorizeResponse: &magistrala.AuthorizeRes{Authorized: true},
 		},
 		{
-			desc:  "search clients with username",
-			token: validToken,
-			page:  mgclients.Page{Offset: 0, Identity: "clientidentity", Limit: 100},
-			response: mgclients.ClientsPage{
-				Page:    mgclients.Page{Total: 1, Offset: 0, Limit: 100},
-				Clients: []mgclients.Client{client},
-			},
-			identifyResp:      &magistrala.IdentityRes{UserId: client.ID},
-			authorizeResponse: &magistrala.AuthorizeRes{Authorized: true},
-		},
-		{
 			desc:  "search clients with random name",
 			token: validToken,
 			page:  mgclients.Page{Offset: 0, Name: "randomname", Limit: 100},

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/absmach/magistrala"
 	authsvc "github.com/absmach/magistrala/auth"
@@ -39,8 +38,6 @@ var (
 		Credentials: mgclients.Credentials{Identity: "clientidentity", Secret: secret},
 		Metadata:    validCMetadata,
 		Status:      mgclients.EnabledStatus,
-		CreatedAt:   time.Now(),
-		UpdatedAt:   time.Now(),
 	}
 	basicClient = mgclients.Client{
 		Name: "clientname",

--- a/users/service_test.go
+++ b/users/service_test.go
@@ -680,7 +680,7 @@ func TestSearchUsers(t *testing.T) {
 
 	for _, tc := range cases {
 		authCall := auth.On("Identify", context.Background(), &magistrala.IdentityReq{Token: tc.token}).Return(tc.identifyResp, tc.identifyErr)
-		repoCall := cRepo.On("SearchBasicInfo", context.Background(), tc.page).Return(tc.response, tc.responseErr)
+		repoCall := cRepo.On("SearchClients", context.Background(), tc.page).Return(tc.response, tc.responseErr)
 		page, err := svc.SearchUsers(context.Background(), tc.token, tc.page)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
 		assert.Equal(t, tc.response, page, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, tc.response, page))

--- a/users/tracing/tracing.go
+++ b/users/tracing/tracing.go
@@ -71,6 +71,14 @@ func (tm *tracingMiddleware) ListClients(ctx context.Context, token string, pm m
 	return tm.svc.ListClients(ctx, token, pm)
 }
 
+// SearchUsers traces the "SearchUsers" operation of the wrapped clients.Service.
+func (tm *tracingMiddleware) SearchUsers(ctx context.Context, token string, pm mgclients.Page) (mgclients.ClientsPage, error) {
+	ctx, span := tm.tracer.Start(ctx, "svc_search_clients", trace.WithAttributes(attribute.String("token", token)))
+	defer span.End()
+
+	return tm.svc.SearchUsers(ctx, token, pm)
+}
+
 // UpdateClient traces the "UpdateClient" operation of the wrapped clients.Service.
 func (tm *tracingMiddleware) UpdateClient(ctx context.Context, token string, cli mgclients.Client) (mgclients.Client, error) {
 	ctx, span := tm.tracer.Start(ctx, "svc_update_client_name_and_metadata", trace.WithAttributes(


### PR DESCRIPTION
# What type of PR is this?
This is a bug fix because it fixes the following issue: #2330 

## What does this do?
It restricts normal users from searching with `identity`.

## Which issue(s) does this PR fix/relate to?
- Related Issue #2330
- Resolves #2330

## Have you included tests for your changes?
No.

## Did you document any new/modified feature?
No


### Notes

<!--Please provide any additional information you feel is important.-->
