### PR TITLE
MG-887 - Create certs, messages, health, consumers CLI tests

### DIFF
--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/errors"
+	svcerr "github.com/absmach/magistrala/pkg/errors/service"
+	mgsdk "github.com/absmach/magistrala/pkg/sdk/go"
+	sdkmocks "github.com/absmach/magistrala/pkg/sdk/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	revokeCommand = "revoke"
+	issueCommand = "issue"
+)
+
+var cert = mgsdk.Cert{
+	ThingID: thing.ID,
+}
+
+func TestGetCertCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	var ct mgsdk.Cert
+	var cts mgsdk.CertSerials
+
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		errLogMessage string
+		logType       outputLog
+		serials       mgsdk.CertSerials
+		cert          mgsdk.Cert
+	}{
+		{
+			desc: "get cert successfully",
+			args: []string{
+				get,
+				"thing",
+				thing.ID,
+				validToken,
+			},
+			logType: entityLog,
+			serials: mgsdk.CertSerials{
+				PageRes: mgsdk.PageRes{
+					Total:  1,
+					Offset: 0,
+					Limit:  10,
+				},
+				Certs: []mgsdk.Cert{cert},
+			},
+		},
+		{
+			desc: "get cert successfully by id",
+			args: []string{
+				get,
+				thing.ID,
+				validToken,
+			},
+			logType: entityLog,
+			cert:    cert,
+		},
+		{
+			desc: "get cert with invalid token",
+			args: []string{
+				get,
+				"thing",
+				thing.ID,
+				invalidToken,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized)),
+			logType:       errLog,
+		},
+		{
+			desc: "get cert successfully by id with invalid token",
+			args: []string{
+				get,
+				thing.ID,
+				validToken,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized)),
+			logType:       errLog,
+		},
+		{
+			desc: "get cert with invalid args",
+			args: []string{
+				get,
+				thing.ID,
+			},
+			logType: usageLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("ViewCertByThing", mock.Anything, mock.Anything).Return(tc.serials, tc.sdkErr)
+			sdkCall1 := sdkMock.On("ViewCert", mock.Anything, mock.Anything).Return(tc.cert, tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+			switch tc.logType {
+			case entityLog:
+				if tc.args[1] == "thing" {
+					err := json.Unmarshal([]byte(out), &cts)
+					assert.Nil(t, err)
+					assert.Equal(t, tc.serials, cts, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.serials, cts))
+				} else {
+					err := json.Unmarshal([]byte(out), &ct)
+					assert.Nil(t, err)
+					assert.Equal(t, tc.cert, ct, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.cert, ct))
+				}
+
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+			sdkCall1.Unset()
+		})
+	}
+}
+
+func TestRevokeCertCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	revokeTime := time.Now()
+
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		logType       outputLog
+		errLogMessage string
+		time time.Time
+		response string
+	}{
+		{
+			desc: "revoke cert successfully",
+			args: []string{
+				revokeCommand,
+				thing.ID,
+				token,
+			},
+			logType: revokeLog,
+			response: fmt.Sprintf("\nrevoked: %s\n\n", revokeTime),
+			time: revokeTime,
+		},
+		{
+			desc: "revoke cert with invalid args",
+			args: []string{
+				revokeCommand,
+				thing.ID,
+				token,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "revoke cert with invalid token",
+			args: []string{
+				revokeCommand,
+				thing.ID,
+				invalidToken,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("RevokeCert", tc.args[1], tc.args[2]).Return(tc.time,tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case revokeLog:
+				assert.Equal(t, tc.response, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.response, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestIssueCertCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	var ct mgsdk.Cert
+	cases := []struct {
+		desc          string
+		args          []string
+		logType       outputLog
+		errLogMessage string
+		sdkErr        errors.SDKError
+		cert mgsdk.Cert
+	}{
+		{
+			desc: "issue cert successfully",
+			args: []string{
+				issueCommand,
+				thing.ID,
+				validToken,
+			},
+			cert: cert,
+			logType:  entityLog,
+		},
+		{
+			desc: "issue cert with invalid args",
+			args: []string{
+				issueCommand,
+				thing.ID,
+				validToken,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "issue cert with invalid token",
+			args: []string{
+				issueCommand,
+				thing.ID,
+				invalidToken,
+			},
+			logType:       errLog,
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("IssueCert", mock.Anything, mock.Anything, tc.args[2]).Return(tc.cert, tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case entityLog:
+				err := json.Unmarshal([]byte(out), &ct)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.cert, ct, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.cert, ct))
+			}
+			sdkCall.Unset()
+		})
+	}
+}

--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	revokeCommand = "revoke"
-	issueCommand = "issue"
+	issueCommand  = "issue"
 )
 
 var cert = mgsdk.Cert{
@@ -150,8 +150,8 @@ func TestRevokeCertCmd(t *testing.T) {
 		sdkErr        errors.SDKError
 		logType       outputLog
 		errLogMessage string
-		time time.Time
-		response string
+		time          time.Time
+		response      string
 	}{
 		{
 			desc: "revoke cert successfully",
@@ -160,9 +160,9 @@ func TestRevokeCertCmd(t *testing.T) {
 				thing.ID,
 				token,
 			},
-			logType: revokeLog,
+			logType:  revokeLog,
 			response: fmt.Sprintf("\nrevoked: %s\n\n", revokeTime),
-			time: revokeTime,
+			time:     revokeTime,
 		},
 		{
 			desc: "revoke cert with invalid args",
@@ -189,7 +189,7 @@ func TestRevokeCertCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("RevokeCert", tc.args[1], tc.args[2]).Return(tc.time,tc.sdkErr)
+			sdkCall := sdkMock.On("RevokeCert", tc.args[1], tc.args[2]).Return(tc.time, tc.sdkErr)
 			out := executeCommand(t, rootCmd, tc.args...)
 
 			switch tc.logType {
@@ -218,7 +218,7 @@ func TestIssueCertCmd(t *testing.T) {
 		logType       outputLog
 		errLogMessage string
 		sdkErr        errors.SDKError
-		cert mgsdk.Cert
+		cert          mgsdk.Cert
 	}{
 		{
 			desc: "issue cert successfully",
@@ -227,8 +227,8 @@ func TestIssueCertCmd(t *testing.T) {
 				thing.ID,
 				validToken,
 			},
-			cert: cert,
-			logType:  entityLog,
+			cert:    cert,
+			logType: entityLog,
 		},
 		{
 			desc: "issue cert with invalid args",

--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -20,11 +20,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const (
-	revokeCommand = "revoke"
-	issueCommand  = "issue"
-)
-
 var cert = mgsdk.Cert{
 	ThingID: thing.ID,
 }
@@ -182,7 +177,7 @@ func TestRevokeCertCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("RevokeCert", tc.args[0], tc.args[1]).Return(tc.time, tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{revokeCommand}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{revokeCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case revokeLog:
@@ -245,7 +240,7 @@ func TestIssueCertCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("IssueCert", mock.Anything, mock.Anything, tc.args[1]).Return(tc.cert, tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{issueCommand}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{issueCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case usageLog:

--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -88,11 +88,11 @@ func TestGetCertCmd(t *testing.T) {
 			logType:       errLog,
 		},
 		{
-			desc: "get cert successfully by id with invalid token",
+			desc: "get cert by id with invalid token",
 			args: []string{
 				get,
 				thing.ID,
-				validToken,
+				invalidToken,
 			},
 			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized),
 			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized)),

--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -50,7 +50,6 @@ func TestGetCertCmd(t *testing.T) {
 		{
 			desc: "get cert successfully",
 			args: []string{
-				get,
 				"thing",
 				thing.ID,
 				validToken,
@@ -68,7 +67,6 @@ func TestGetCertCmd(t *testing.T) {
 		{
 			desc: "get cert successfully by id",
 			args: []string{
-				get,
 				thing.ID,
 				validToken,
 			},
@@ -78,7 +76,6 @@ func TestGetCertCmd(t *testing.T) {
 		{
 			desc: "get cert with invalid token",
 			args: []string{
-				get,
 				"thing",
 				thing.ID,
 				invalidToken,
@@ -90,7 +87,6 @@ func TestGetCertCmd(t *testing.T) {
 		{
 			desc: "get cert by id with invalid token",
 			args: []string{
-				get,
 				thing.ID,
 				invalidToken,
 			},
@@ -101,7 +97,6 @@ func TestGetCertCmd(t *testing.T) {
 		{
 			desc: "get cert with invalid args",
 			args: []string{
-				get,
 				thing.ID,
 			},
 			logType: usageLog,
@@ -112,7 +107,7 @@ func TestGetCertCmd(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("ViewCertByThing", mock.Anything, mock.Anything).Return(tc.serials, tc.sdkErr)
 			sdkCall1 := sdkMock.On("ViewCert", mock.Anything, mock.Anything).Return(tc.cert, tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			out := executeCommand(t, rootCmd, append([]string{getCmd}, tc.args...)...)
 			switch tc.logType {
 			case entityLog:
 				if tc.args[1] == "thing" {
@@ -156,7 +151,6 @@ func TestRevokeCertCmd(t *testing.T) {
 		{
 			desc: "revoke cert successfully",
 			args: []string{
-				revokeCommand,
 				thing.ID,
 				token,
 			},
@@ -167,7 +161,6 @@ func TestRevokeCertCmd(t *testing.T) {
 		{
 			desc: "revoke cert with invalid args",
 			args: []string{
-				revokeCommand,
 				thing.ID,
 				token,
 				extraArg,
@@ -177,7 +170,6 @@ func TestRevokeCertCmd(t *testing.T) {
 		{
 			desc: "revoke cert with invalid token",
 			args: []string{
-				revokeCommand,
 				thing.ID,
 				invalidToken,
 			},
@@ -189,8 +181,8 @@ func TestRevokeCertCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("RevokeCert", tc.args[1], tc.args[2]).Return(tc.time, tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("RevokeCert", tc.args[0], tc.args[1]).Return(tc.time, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{revokeCommand}, tc.args...)...)
 
 			switch tc.logType {
 			case revokeLog:
@@ -223,7 +215,6 @@ func TestIssueCertCmd(t *testing.T) {
 		{
 			desc: "issue cert successfully",
 			args: []string{
-				issueCommand,
 				thing.ID,
 				validToken,
 			},
@@ -233,7 +224,6 @@ func TestIssueCertCmd(t *testing.T) {
 		{
 			desc: "issue cert with invalid args",
 			args: []string{
-				issueCommand,
 				thing.ID,
 				validToken,
 				extraArg,
@@ -243,7 +233,6 @@ func TestIssueCertCmd(t *testing.T) {
 		{
 			desc: "issue cert with invalid token",
 			args: []string{
-				issueCommand,
 				thing.ID,
 				invalidToken,
 			},
@@ -255,8 +244,8 @@ func TestIssueCertCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("IssueCert", mock.Anything, mock.Anything, tc.args[2]).Return(tc.cert, tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("IssueCert", mock.Anything, mock.Anything, tc.args[1]).Return(tc.cert, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{issueCommand}, tc.args...)...)
 
 			switch tc.logType {
 			case usageLog:

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -3,31 +3,58 @@
 
 package cli_test
 
+// CRUD and common commands
 const (
-	createCmd     = "create"
-	getCmd        = "get"
+	createCmd  = "create"
+	updateCmd  = "update"
+	getCmd     = "get"
+	enableCmd  = "enable"
+	disableCmd = "disable"
+	updCmd     = "update"
+	delCmd     = "delete"
+	rmCmd      = "remove"
+)
+
+// Users commands
+const (
 	tokCmd        = "token"
 	refTokCmd     = "refreshtoken"
-	updCmd        = "update"
 	profCmd       = "profile"
 	resPassReqCmd = "resetpasswordrequest"
 	resPassCmd    = "resetpassword"
 	passCmd       = "password"
-	enableCmd     = "enable"
-	disableCmd    = "disable"
-	delCmd        = "delete"
-	chansCmd      = "channels"
-	thsCmd        = "things"
 	domsCmd       = "domains"
-	grpCmd        = "groups"
-	connsCmd      = "connections"
-	connCmd       = "connect"
-	disconnCmd    = "disconnect"
-	shrCmd        = "share"
-	unshrCmd      = "unshare"
-	childCmd      = "children"
-	parentCmd     = "parents"
-	usrCmd        = "users"
-	assignCmd     = "assign"
-	unassignCmd   = "unassign"
+)
+
+// Things commands
+const (
+	thsCmd     = "things"
+	connsCmd   = "connections"
+	connCmd    = "connect"
+	disconnCmd = "disconnect"
+	shrCmd     = "share"
+	unshrCmd   = "unshare"
+)
+
+// Groups and channels commands
+const (
+	chansCmd    = "channels"
+	grpCmd      = "groups"
+	childCmd    = "children"
+	parentCmd   = "parents"
+	usrCmd      = "users"
+	assignCmd   = "assign"
+	unassignCmd = "unassign"
+)
+
+// Certs commands
+const (
+	revokeCmd = "revoke"
+	issueCmd  = "issue"
+)
+
+// Messages commands
+const (
+	sendCmd = "send"
+	readCmd = "read"
 )

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -3,7 +3,7 @@
 
 package cli_test
 
-// CRUD and common commands.
+// CRUD and common commands
 const (
 	createCmd  = "create"
 	updateCmd  = "update"
@@ -15,7 +15,7 @@ const (
 	rmCmd      = "remove"
 )
 
-// Users commands.
+// Users commands
 const (
 	tokCmd        = "token"
 	refTokCmd     = "refreshtoken"
@@ -26,7 +26,7 @@ const (
 	domsCmd       = "domains"
 )
 
-// Things commands.
+// Things commands
 const (
 	thsCmd     = "things"
 	connsCmd   = "connections"
@@ -36,7 +36,7 @@ const (
 	unshrCmd   = "unshare"
 )
 
-// Groups and channels commands.
+// Groups and channels commands
 const (
 	chansCmd    = "channels"
 	grpCmd      = "groups"
@@ -47,13 +47,13 @@ const (
 	unassignCmd = "unassign"
 )
 
-// Certs commands.
+// Certs commands
 const (
 	revokeCmd = "revoke"
 	issueCmd  = "issue"
 )
 
-// Messages commands.
+// Messages commands
 const (
 	sendCmd = "send"
 	readCmd = "read"

--- a/cli/commands_test.go
+++ b/cli/commands_test.go
@@ -3,7 +3,7 @@
 
 package cli_test
 
-// CRUD and common commands
+// CRUD and common commands.
 const (
 	createCmd  = "create"
 	updateCmd  = "update"
@@ -15,7 +15,7 @@ const (
 	rmCmd      = "remove"
 )
 
-// Users commands
+// Users commands.
 const (
 	tokCmd        = "token"
 	refTokCmd     = "refreshtoken"
@@ -26,7 +26,7 @@ const (
 	domsCmd       = "domains"
 )
 
-// Things commands
+// Things commands.
 const (
 	thsCmd     = "things"
 	connsCmd   = "connections"
@@ -36,7 +36,7 @@ const (
 	unshrCmd   = "unshare"
 )
 
-// Groups and channels commands
+// Groups and channels commands.
 const (
 	chansCmd    = "channels"
 	grpCmd      = "groups"
@@ -47,13 +47,13 @@ const (
 	unassignCmd = "unassign"
 )
 
-// Certs commands
+// Certs commands.
 const (
 	revokeCmd = "revoke"
 	issueCmd  = "issue"
 )
 
-// Messages commands
+// Messages commands.
 const (
 	sendCmd = "send"
 	readCmd = "read"

--- a/cli/consumers_test.go
+++ b/cli/consumers_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/internal/testsutil"
+	"github.com/absmach/magistrala/pkg/errors"
+	svcerr "github.com/absmach/magistrala/pkg/errors/service"
+	mgsdk "github.com/absmach/magistrala/pkg/sdk/go"
+	sdkmocks "github.com/absmach/magistrala/pkg/sdk/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	createCommand = "create"
+	getCommand    = "get"
+	removeCommand = "remove"
+)
+
+var subscription = mgsdk.Subscription{
+	ID:      testsutil.GenerateUUID(&testing.T{}),
+	OwnerID: user.ID,
+	Topic:   "topic",
+	Contact: "identity@example.com",
+}
+
+func TestCreateSubscriptionCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	subCmd := cli.NewSubscriptionCmd()
+	rootCmd := setFlags(subCmd)
+
+	cases := []struct {
+		desc          string
+		args          []string
+		logType       outputLog
+		errLogMessage string
+		sdkErr        errors.SDKError
+		response      string
+		id            string
+	}{
+		{
+			desc: "create subscription successfully",
+			args: []string{
+				createCommand,
+				subscription.Topic,
+				subscription.Contact,
+				validToken,
+			},
+			id:       user.ID,
+			response: fmt.Sprintf("\ncreated: %s\n\n", user.ID),
+			logType:  createLog,
+		},
+		{
+			desc: "create subscription with invalid args",
+			args: []string{
+				createCommand,
+				subscription.Topic,
+				subscription.Contact,
+				validToken,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "create subscription with invalid token",
+			args: []string{
+				createCommand,
+				subscription.Topic,
+				subscription.Contact,
+				invalidToken,
+			},
+			logType:       errLog,
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("CreateSubscription", tc.args[1], tc.args[2], tc.args[3]).Return(tc.id, tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case createLog:
+				assert.Equal(t, tc.response, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.response, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestGetSubscriptionsCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	subCmd := cli.NewSubscriptionCmd()
+	rootCmd := setFlags(subCmd)
+
+	var sub mgsdk.Subscription
+	var page mgsdk.SubscriptionPage
+
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		page          mgsdk.SubscriptionPage
+		subscription  mgsdk.Subscription
+		logType       outputLog
+		errLogMessage string
+	}{
+		{
+			desc: "get all subscriptions successfully",
+			args: []string{
+				getCommand,
+				all,
+				token,
+			},
+			page: mgsdk.SubscriptionPage{
+				Subscriptions: []mgsdk.Subscription{subscription},
+			},
+			logType: entityLog,
+		},
+		{
+			desc: "get subscription with id",
+			args: []string{
+				getCommand,
+				subscription.ID,
+				token,
+			},
+			logType:      entityLog,
+			subscription: subscription,
+		},
+		{
+			desc: "get subscriptions with invalid args",
+			args: []string{
+				getCommand,
+				all,
+				token,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "get all subscriptions with invalid token",
+			args: []string{
+				getCommand,
+				all,
+				invalidToken,
+			},
+			logType:       errLog,
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+		},
+		{
+			desc: "get subscription without domain token",
+			args: []string{
+				getCommand,
+				subscription.ID,
+				tokenWithoutDomain,
+			},
+			logType:       errLog,
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrDomainAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrDomainAuthorization, http.StatusForbidden)),
+		},
+		{
+			desc: "get subscription with invalid id",
+			args: []string{
+				getCommand,
+				invalidID,
+				token,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("ViewSubscription", tc.args[1], tc.args[2]).Return(tc.subscription, tc.sdkErr)
+			sdkCall1 := sdkMock.On("ListSubscriptions", mock.Anything, tc.args[2]).Return(tc.page, tc.sdkErr)
+
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case entityLog:
+				if tc.args[1] == all {
+					err := json.Unmarshal([]byte(out), &page)
+					assert.Nil(t, err)
+					assert.Equal(t, tc.page, page, fmt.Sprintf("%v unexpected response, expected: %v, got: %v", tc.desc, tc.page, page))
+				} else {
+					err := json.Unmarshal([]byte(out), &sub)
+					assert.Nil(t, err)
+					assert.Equal(t, tc.subscription, sub, fmt.Sprintf("%v unexpected response, expected: %v, got: %v", tc.desc, tc.subscription, sub))
+				}
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+			sdkCall1.Unset()
+		})
+	}
+}
+
+func TestRemoveSubscriptionCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	subCmd := cli.NewSubscriptionCmd()
+	rootCmd := setFlags(subCmd)
+
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		logType       outputLog
+		errLogMessage string
+	}{
+		{
+			desc: "remove subscription successfully",
+			args: []string{
+				removeCommand,
+				subscription.ID,
+				token,
+			},
+			logType: okLog,
+		},
+		{
+			desc: "remove subscription with invalid args",
+			args: []string{
+				removeCommand,
+				subscription.ID,
+				token,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "remove subscription with invalid subscription id",
+			args: []string{
+				removeCommand,
+				invalidID,
+				token,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+			logType:       errLog,
+		},
+		{
+			desc: "remove subscription with invalid token",
+			args: []string{
+				removeCommand,
+				subscription.ID,
+				invalidToken,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusForbidden)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("DeleteSubscription", tc.args[1], tc.args[2]).Return(tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case okLog:
+				assert.True(t, strings.Contains(out, "ok"), fmt.Sprintf("%s unexpected response: expected success message, got: %v", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}

--- a/cli/consumers_test.go
+++ b/cli/consumers_test.go
@@ -51,7 +51,6 @@ func TestCreateSubscriptionCmd(t *testing.T) {
 		{
 			desc: "create subscription successfully",
 			args: []string{
-				createCommand,
 				subscription.Topic,
 				subscription.Contact,
 				validToken,
@@ -63,7 +62,6 @@ func TestCreateSubscriptionCmd(t *testing.T) {
 		{
 			desc: "create subscription with invalid args",
 			args: []string{
-				createCommand,
 				subscription.Topic,
 				subscription.Contact,
 				validToken,
@@ -74,7 +72,6 @@ func TestCreateSubscriptionCmd(t *testing.T) {
 		{
 			desc: "create subscription with invalid token",
 			args: []string{
-				createCommand,
 				subscription.Topic,
 				subscription.Contact,
 				invalidToken,
@@ -87,8 +84,8 @@ func TestCreateSubscriptionCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("CreateSubscription", tc.args[1], tc.args[2], tc.args[3]).Return(tc.id, tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("CreateSubscription", tc.args[0], tc.args[1], tc.args[2]).Return(tc.id, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{createCommand}, tc.args...)...)
 
 			switch tc.logType {
 			case usageLog:
@@ -124,7 +121,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get all subscriptions successfully",
 			args: []string{
-				getCommand,
 				all,
 				token,
 			},
@@ -136,7 +132,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get subscription with id",
 			args: []string{
-				getCommand,
 				subscription.ID,
 				token,
 			},
@@ -146,7 +141,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get subscriptions with invalid args",
 			args: []string{
-				getCommand,
 				all,
 				token,
 				extraArg,
@@ -156,7 +150,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get all subscriptions with invalid token",
 			args: []string{
-				getCommand,
 				all,
 				invalidToken,
 			},
@@ -167,7 +160,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get subscription without domain token",
 			args: []string{
-				getCommand,
 				subscription.ID,
 				tokenWithoutDomain,
 			},
@@ -178,7 +170,6 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 		{
 			desc: "get subscription with invalid id",
 			args: []string{
-				getCommand,
 				invalidID,
 				token,
 			},
@@ -190,10 +181,10 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("ViewSubscription", tc.args[1], tc.args[2]).Return(tc.subscription, tc.sdkErr)
-			sdkCall1 := sdkMock.On("ListSubscriptions", mock.Anything, tc.args[2]).Return(tc.page, tc.sdkErr)
+			sdkCall := sdkMock.On("ViewSubscription", tc.args[0], tc.args[1]).Return(tc.subscription, tc.sdkErr)
+			sdkCall1 := sdkMock.On("ListSubscriptions", mock.Anything, tc.args[1]).Return(tc.page, tc.sdkErr)
 
-			out := executeCommand(t, rootCmd, tc.args...)
+			out := executeCommand(t, rootCmd, append([]string{getCommand}, tc.args...)...)
 
 			switch tc.logType {
 			case entityLog:
@@ -233,7 +224,6 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 		{
 			desc: "remove subscription successfully",
 			args: []string{
-				removeCommand,
 				subscription.ID,
 				token,
 			},
@@ -242,7 +232,6 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 		{
 			desc: "remove subscription with invalid args",
 			args: []string{
-				removeCommand,
 				subscription.ID,
 				token,
 				extraArg,
@@ -252,7 +241,6 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 		{
 			desc: "remove subscription with invalid subscription id",
 			args: []string{
-				removeCommand,
 				invalidID,
 				token,
 			},
@@ -263,7 +251,6 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 		{
 			desc: "remove subscription with invalid token",
 			args: []string{
-				removeCommand,
 				subscription.ID,
 				invalidToken,
 			},
@@ -275,8 +262,8 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("DeleteSubscription", tc.args[1], tc.args[2]).Return(tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("DeleteSubscription", tc.args[0], tc.args[1]).Return(tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{removeCommand}, tc.args...)...)
 
 			switch tc.logType {
 			case okLog:

--- a/cli/consumers_test.go
+++ b/cli/consumers_test.go
@@ -20,12 +20,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const (
-	createCommand = "create"
-	getCommand    = "get"
-	removeCommand = "remove"
-)
-
 var subscription = mgsdk.Subscription{
 	ID:      testsutil.GenerateUUID(&testing.T{}),
 	OwnerID: user.ID,
@@ -85,7 +79,7 @@ func TestCreateSubscriptionCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("CreateSubscription", tc.args[0], tc.args[1], tc.args[2]).Return(tc.id, tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{createCommand}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{createCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case usageLog:
@@ -184,7 +178,7 @@ func TestGetSubscriptionsCmd(t *testing.T) {
 			sdkCall := sdkMock.On("ViewSubscription", tc.args[0], tc.args[1]).Return(tc.subscription, tc.sdkErr)
 			sdkCall1 := sdkMock.On("ListSubscriptions", mock.Anything, tc.args[1]).Return(tc.page, tc.sdkErr)
 
-			out := executeCommand(t, rootCmd, append([]string{getCommand}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{getCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case entityLog:
@@ -263,7 +257,7 @@ func TestRemoveSubscriptionCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("DeleteSubscription", tc.args[0], tc.args[1]).Return(tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{removeCommand}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{rmCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case okLog:

--- a/cli/health_test.go
+++ b/cli/health_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/errors"
+	mgsdk "github.com/absmach/magistrala/pkg/sdk/go"
+	sdkmocks "github.com/absmach/magistrala/pkg/sdk/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHealthCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	healthCmd := cli.NewHealthCmd()
+	rootCmd := setFlags(healthCmd)
+	service := "users"
+
+	var hl mgsdk.HealthInfo
+	cases := []struct {
+		desc          string
+		args          []string
+		logType       outputLog
+		errLogMessage string
+		health        mgsdk.HealthInfo
+		sdkErr        errors.SDKError
+	}{
+		{
+			desc: "Check health successfully",
+			args: []string{
+				service,
+			},
+			logType: entityLog,
+			health: mgsdk.HealthInfo{
+				Status:      "pass",
+				Description: "users service",
+			},
+		},
+		{
+			desc: "Check health with invalid args",
+			args: []string{
+				service,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "Check health with invalid service",
+			args: []string{
+				"invalid",
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(errors.New("unsupported protocol scheme"), 306),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(errors.New("unsupported protocol scheme"), 306)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("Health", mock.Anything).Return(tc.health, tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case entityLog:
+				err := json.Unmarshal([]byte(out), &hl)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.health, hl, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.health, hl))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.True(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}

--- a/cli/health_test.go
+++ b/cli/health_test.go
@@ -1,4 +1,4 @@
- // Copyright (c) Abstract Machines
+// Copyright (c) Abstract Machines
 // SPDX-License-Identifier: Apache-2.0
 
 package cli_test

--- a/cli/health_test.go
+++ b/cli/health_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Abstract Machines
+ // Copyright (c) Abstract Machines
 // SPDX-License-Identifier: Apache-2.0
 
 package cli_test
@@ -24,7 +24,7 @@ func TestHealthCmd(t *testing.T) {
 	rootCmd := setFlags(healthCmd)
 	service := "users"
 
-	var hl mgsdk.HealthInfo
+	var health mgsdk.HealthInfo
 	cases := []struct {
 		desc          string
 		args          []string
@@ -70,9 +70,9 @@ func TestHealthCmd(t *testing.T) {
 
 			switch tc.logType {
 			case entityLog:
-				err := json.Unmarshal([]byte(out), &hl)
+				err := json.Unmarshal([]byte(out), &health)
 				assert.Nil(t, err)
-				assert.Equal(t, tc.health, hl, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.health, hl))
+				assert.Equal(t, tc.health, health, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.health, health))
 			case errLog:
 				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
 			case usageLog:

--- a/cli/message.go
+++ b/cli/message.go
@@ -10,7 +10,7 @@ import (
 
 var cmdMessages = []cobra.Command{
 	{
-		Use:   "send <channel_id.subtopic> <JSON_string> <thing_key>",
+		Use:   "send <channel_id.subtopic> <JSON_string> <thing_secret>",
 		Short: "Send messages",
 		Long:  `Sends message on the channel`,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cli/message_test.go
+++ b/cli/message_test.go
@@ -20,11 +20,6 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const (
-	send = "send"
-	read = "read"
-)
-
 func TestSendMesageCmd(t *testing.T) {
 	sdkMock := new(sdkmocks.SDK)
 	cli.SetSDK(sdkMock)
@@ -75,7 +70,7 @@ func TestSendMesageCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("SendMessage", tc.args[0], tc.args[1], tc.args[2]).Return(tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{send}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{sendCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case okLog:
@@ -149,7 +144,7 @@ func TestReadMesageCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("ReadMessages", mock.Anything, tc.args[0], tc.args[1]).Return(tc.page, tc.sdkErr)
-			out := executeCommand(t, rootCmd, append([]string{read}, tc.args...)...)
+			out := executeCommand(t, rootCmd, append([]string{readCmd}, tc.args...)...)
 
 			switch tc.logType {
 			case entityLog:

--- a/cli/message_test.go
+++ b/cli/message_test.go
@@ -62,7 +62,7 @@ func TestSendMesageCmd(t *testing.T) {
 			logType: usageLog,
 		},
 		{
-			desc: "send message with invalid secret",
+			desc: "send message with invalid thing secret",
 			args: []string{
 				send,
 				channel.ID,

--- a/cli/message_test.go
+++ b/cli/message_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/errors"
+	svcerr "github.com/absmach/magistrala/pkg/errors/service"
+	mgsdk "github.com/absmach/magistrala/pkg/sdk/go"
+	sdkmocks "github.com/absmach/magistrala/pkg/sdk/mocks"
+	"github.com/absmach/magistrala/pkg/transformers/senml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	send = "send"
+	read = "read"
+)
+
+func TestSendMesageCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	messageCmd := cli.NewMessagesCmd()
+	rootCmd := setFlags(messageCmd)
+
+	message := "[{\"bn\":\"Dev1\",\"n\":\"temp\",\"v\":20}, {\"n\":\"hum\",\"v\":40}, {\"bn\":\"Dev2\", \"n\":\"temp\",\"v\":20}, {\"n\":\"hum\",\"v\":40}]"
+
+	cases := []struct {
+		desc          string
+		args          []string
+		logType       outputLog
+		errLogMessage string
+		sdkErr        errors.SDKError
+	}{
+		{
+			desc: "send message successfully",
+			args: []string{
+				send,
+				channel.ID,
+				message,
+				thing.Credentials.Secret,
+			},
+			logType: okLog,
+		},
+		{
+			desc: "send message with invalid args",
+			args: []string{
+				send,
+				channel.ID,
+				message,
+				thing.Credentials.Secret,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "send message with invalid secret",
+			args: []string{
+				send,
+				channel.ID,
+				message,
+				"invalid_secret",
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrNotFound)), http.StatusBadRequest),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(errors.Wrap(svcerr.ErrAuthentication, errors.Wrap(svcerr.ErrAuthorization, svcerr.ErrNotFound)), http.StatusBadRequest)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("SendMessage", tc.args[1], tc.args[2], tc.args[3]).Return(tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case okLog:
+				assert.True(t, strings.Contains(out, "ok"), fmt.Sprintf("%s unexpected response: expected success message, got: %v", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestReadMesageCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.SDK)
+	cli.SetSDK(sdkMock)
+	messageCmd := cli.NewMessagesCmd()
+	rootCmd := setFlags(messageCmd)
+
+	var mp mgsdk.MessagesPage
+	cases := []struct {
+		desc          string
+		args          []string
+		logType       outputLog
+		errLogMessage string
+		sdkErr        errors.SDKError
+		page          mgsdk.MessagesPage
+	}{
+		{
+			desc: "read message successfully",
+			args: []string{
+				read,
+				channel.ID,
+				validToken,
+			},
+			page: mgsdk.MessagesPage{
+				PageRes: mgsdk.PageRes{
+					Total:  1,
+					Offset: 0,
+					Limit:  10,
+				},
+				Messages: []senml.Message{
+					{
+						Channel: channel.ID,
+					},
+				},
+			},
+			logType: entityLog,
+		},
+		{
+			desc: "read message with invalid args",
+			args: []string{
+				read,
+				channel.ID,
+				validToken,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "read message with invalid token",
+			args: []string{
+				read,
+				channel.ID,
+				invalidToken,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(svcerr.ErrAuthorization, http.StatusUnauthorized)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("ReadMessages", mock.Anything, tc.args[1], tc.args[2]).Return(tc.page, tc.sdkErr)
+			out := executeCommand(t, rootCmd, tc.args...)
+
+			switch tc.logType {
+			case entityLog:
+				err := json.Unmarshal([]byte(out), &mp)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.page, mp, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.page, mp))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}

--- a/cli/message_test.go
+++ b/cli/message_test.go
@@ -43,7 +43,6 @@ func TestSendMesageCmd(t *testing.T) {
 		{
 			desc: "send message successfully",
 			args: []string{
-				send,
 				channel.ID,
 				message,
 				thing.Credentials.Secret,
@@ -53,7 +52,6 @@ func TestSendMesageCmd(t *testing.T) {
 		{
 			desc: "send message with invalid args",
 			args: []string{
-				send,
 				channel.ID,
 				message,
 				thing.Credentials.Secret,
@@ -64,7 +62,6 @@ func TestSendMesageCmd(t *testing.T) {
 		{
 			desc: "send message with invalid thing secret",
 			args: []string{
-				send,
 				channel.ID,
 				message,
 				"invalid_secret",
@@ -77,8 +74,8 @@ func TestSendMesageCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("SendMessage", tc.args[1], tc.args[2], tc.args[3]).Return(tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("SendMessage", tc.args[0], tc.args[1], tc.args[2]).Return(tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{send}, tc.args...)...)
 
 			switch tc.logType {
 			case okLog:
@@ -111,7 +108,6 @@ func TestReadMesageCmd(t *testing.T) {
 		{
 			desc: "read message successfully",
 			args: []string{
-				read,
 				channel.ID,
 				validToken,
 			},
@@ -132,7 +128,6 @@ func TestReadMesageCmd(t *testing.T) {
 		{
 			desc: "read message with invalid args",
 			args: []string{
-				read,
 				channel.ID,
 				validToken,
 				extraArg,
@@ -142,7 +137,6 @@ func TestReadMesageCmd(t *testing.T) {
 		{
 			desc: "read message with invalid token",
 			args: []string{
-				read,
 				channel.ID,
 				invalidToken,
 			},
@@ -154,8 +148,8 @@ func TestReadMesageCmd(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			sdkCall := sdkMock.On("ReadMessages", mock.Anything, tc.args[1], tc.args[2]).Return(tc.page, tc.sdkErr)
-			out := executeCommand(t, rootCmd, tc.args...)
+			sdkCall := sdkMock.On("ReadMessages", mock.Anything, tc.args[0], tc.args[1]).Return(tc.page, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{read}, tc.args...)...)
 
 			switch tc.logType {
 			case entityLog:

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -19,6 +19,8 @@ const (
 	errLog
 	entityLog
 	okLog
+	createLog
+	revokeLog
 )
 
 func executeCommand(t *testing.T, root *cobra.Command, args ...string) string {

--- a/cli/things_test.go
+++ b/cli/things_test.go
@@ -28,12 +28,12 @@ var (
 	tokenWithoutDomain = "valid"
 	relation           = "administrator"
 	all                = "all"
-	get = "get"
+	get                = "get"
 )
 
 var thing = mgsdk.Thing{
-	ID:       testsutil.GenerateUUID(&testing.T{}),
-	Name:     "testthing",
+	ID:   testsutil.GenerateUUID(&testing.T{}),
+	Name: "testthing",
 	Credentials: mgsdk.Credentials{
 		Secret: "secret",
 	},

--- a/cli/things_test.go
+++ b/cli/things_test.go
@@ -28,7 +28,7 @@ var (
 	tokenWithoutDomain = "valid"
 	relation           = "administrator"
 	all                = "all"
-	get                = "get"
+	getCmd               = "get"
 )
 
 var thing = mgsdk.Thing{

--- a/cli/things_test.go
+++ b/cli/things_test.go
@@ -28,7 +28,6 @@ var (
 	tokenWithoutDomain = "valid"
 	relation           = "administrator"
 	all                = "all"
-	getCmd               = "get"
 )
 
 var thing = mgsdk.Thing{

--- a/cli/things_test.go
+++ b/cli/things_test.go
@@ -28,11 +28,15 @@ var (
 	tokenWithoutDomain = "valid"
 	relation           = "administrator"
 	all                = "all"
+	get = "get"
 )
 
 var thing = mgsdk.Thing{
 	ID:       testsutil.GenerateUUID(&testing.T{}),
 	Name:     "testthing",
+	Credentials: mgsdk.Credentials{
+		Secret: "secret",
+	},
 	DomainID: testsutil.GenerateUUID(&testing.T{}),
 	Status:   mgclients.EnabledStatus.String(),
 }

--- a/tools/config/.golangci.yml
+++ b/tools/config/.golangci.yml
@@ -12,6 +12,10 @@ issues:
   exclude:
     - "string `Usage:\n` has (\\d+) occurrences, make it a constant"
     - "string `For example:\n` has (\\d+) occurrences, make it a constant"
+  exclude-rules:
+    - path: github.com/absmach/magistrala/cli/commands_test.go
+      linters:
+        - godot
 
 linters-settings:
   importas:

--- a/tools/config/.golangci.yml
+++ b/tools/config/.golangci.yml
@@ -13,7 +13,7 @@ issues:
     - "string `Usage:\n` has (\\d+) occurrences, make it a constant"
     - "string `For example:\n` has (\\d+) occurrences, make it a constant"
   exclude-rules:
-    - path: ./cli/commands_test.go
+    - path: cli/commands_test.go
       linters:
         - godot
 

--- a/tools/config/.golangci.yml
+++ b/tools/config/.golangci.yml
@@ -12,8 +12,10 @@ issues:
   exclude:
     - "string `Usage:\n` has (\\d+) occurrences, make it a constant"
     - "string `For example:\n` has (\\d+) occurrences, make it a constant"
-  exclude-files:
-    - github.com/absmach/magistrala/cli/commands_test.go
+  exclude-rules:
+    - path: ./cli/commands_test.go
+      linters:
+        - godot
 
 linters-settings:
   importas:

--- a/tools/config/.golangci.yml
+++ b/tools/config/.golangci.yml
@@ -12,10 +12,8 @@ issues:
   exclude:
     - "string `Usage:\n` has (\\d+) occurrences, make it a constant"
     - "string `For example:\n` has (\\d+) occurrences, make it a constant"
-  exclude-rules:
-    - path: github.com/absmach/magistrala/cli/commands_test.go
-      linters:
-        - godot
+  exclude-files:
+    - github.com/absmach/magistrala/cli/commands_test.go
 
 linters-settings:
   importas:


### PR DESCRIPTION
# What type of PR is this?
This is an enhancement because it adds cli tests for certs, messages, health, consumers.


## What does this do?
It adds cli tests for certs, messages, health, consumers.

## Which issue(s) does this PR fix/relate to?
- Related Issue #887 

## Have you included tests for your changes?
Yes, I have included tests for my changes.

## Did you document any new/modified feature?
No. 

### Notes

