### PR TITLE
MG-2241 - Fix list domains with permission as query parameter

### DIFF
--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -194,7 +194,6 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	if pm.SubjectID == "" {
 		q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status
 		FROM domains as d `
-		//JOIN policies pc ON pc.object_id = d.id`
 	}
 
 	q = fmt.Sprintf("%s %s LIMIT %d OFFSET %d", q, query, pm.Limit, pm.Offset)
@@ -576,7 +575,7 @@ func buildPageQuery(pm auth.Page) (string, error) {
 		query = append(query, "pc.subject_id = :subject_id")
 	}
 
-	if pm.Permission != "" {
+	if pm.Permission != "" && pm.SubjectID != ""{
 		query = append(query, "pc.relation = :permission")
 	}
 

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -183,9 +183,9 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	}
 
 	q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status, pc.relation as relation
-	FROM domains as d`
-	// JOIN policies pc
-	// ON pc.object_id = d.id`
+	FROM domains as d
+	JOIN policies pc
+	ON pc.object_id = d.id`
 
 	// The service sends the user ID in the pagemeta subject field, which filters domains by joining with the policies table.
 	// For SuperAdmins, access to domains is granted without the policies filter.
@@ -193,7 +193,8 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	// In the repository, when the pagemeta subject is empty, the query should be constructed without applying the policies filter.
 	if pm.SubjectID == "" {
 		q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status
-		FROM domains as d JOIN policies pc ON pc.object_id = d.id`
+		FROM domains as d `
+		//JOIN policies pc ON pc.object_id = d.id`
 	}
 
 	q = fmt.Sprintf("%s %s LIMIT %d OFFSET %d", q, query, pm.Limit, pm.Offset)

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -183,9 +183,9 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	}
 
 	q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status, pc.relation as relation
-	FROM domains as d
-	JOIN policies pc
-	ON pc.object_id = d.id`
+	FROM domains as d`
+	// JOIN policies pc
+	// ON pc.object_id = d.id`
 
 	// The service sends the user ID in the pagemeta subject field, which filters domains by joining with the policies table.
 	// For SuperAdmins, access to domains is granted without the policies filter.
@@ -193,7 +193,7 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	// In the repository, when the pagemeta subject is empty, the query should be constructed without applying the policies filter.
 	if pm.SubjectID == "" {
 		q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status
-		FROM domains as d`
+		FROM domains as d JOIN policies pc ON pc.object_id = d.id`
 	}
 
 	q = fmt.Sprintf("%s %s LIMIT %d OFFSET %d", q, query, pm.Limit, pm.Offset)

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -575,7 +575,7 @@ func buildPageQuery(pm auth.Page) (string, error) {
 		query = append(query, "pc.subject_id = :subject_id")
 	}
 
-	if pm.Permission != "" && pm.SubjectID != ""{
+	if pm.Permission != "" && pm.SubjectID != "" {
 		query = append(query, "pc.relation = :permission")
 	}
 

--- a/auth/postgres/domains.go
+++ b/auth/postgres/domains.go
@@ -193,7 +193,7 @@ func (repo domainRepo) ListDomains(ctx context.Context, pm auth.Page) (auth.Doma
 	// In the repository, when the pagemeta subject is empty, the query should be constructed without applying the policies filter.
 	if pm.SubjectID == "" {
 		q = `SELECT d.id as id, d.name as name, d.tags as tags, d.alias as alias, d.metadata as metadata, d.created_at as created_at, d.updated_at as updated_at, d.updated_by as updated_by, d.created_by as created_by, d.status as status
-		FROM domains as d `
+		FROM domains as d`
 	}
 
 	q = fmt.Sprintf("%s %s LIMIT %d OFFSET %d", q, query, pm.Limit, pm.Offset)

--- a/auth/service.go
+++ b/auth/service.go
@@ -727,12 +727,6 @@ func (svc service) ListDomains(ctx context.Context, token string, p Page) (Domai
 		return DomainsPage{}, errors.Wrap(svcerr.ErrAuthentication, err)
 	}
 	p.SubjectID = key.User
-	// var permission string
-	// 	permission = AdminPermission
-	// if p.Permission != "" {
-	// 	permission = p.Permission
-	// }
-
 	if err := svc.Authorize(ctx, PolicyReq{
 		Subject:     key.User,
 		SubjectType: UserType,
@@ -753,20 +747,6 @@ func (svc service) ListDomains(ctx context.Context, token string, p Page) (Domai
 	}
 	return dp, nil
 }
-
-// func (svc service) listDomainsIDs(ctx context.Context, userID, permission string) ([]string, error) {
-// 	tids, err := svc.auth.ListAllObjects(ctx, &magistrala.ListObjectsReq{
-// 		SubjectType: UserType,
-// 		Subject:     userID,
-// 		Permission:  permission,
-// 		ObjectType:  DomainType,
-// 	})
-// 	if err != nil {
-// 		return nil, errors.Wrap(svcerr.ErrNotFound, err)
-// 	}
-// 	return tids.Policies, nil
-// }
-
 
 func (svc service) AssignUsers(ctx context.Context, token, id string, userIds []string, relation string) error {
 	if err := svc.Authorize(ctx, PolicyReq{

--- a/auth/service.go
+++ b/auth/service.go
@@ -727,6 +727,12 @@ func (svc service) ListDomains(ctx context.Context, token string, p Page) (Domai
 		return DomainsPage{}, errors.Wrap(svcerr.ErrAuthentication, err)
 	}
 	p.SubjectID = key.User
+	// var permission string
+	// 	permission = AdminPermission
+	// if p.Permission != "" {
+	// 	permission = p.Permission
+	// }
+
 	if err := svc.Authorize(ctx, PolicyReq{
 		Subject:     key.User,
 		SubjectType: UserType,
@@ -747,6 +753,20 @@ func (svc service) ListDomains(ctx context.Context, token string, p Page) (Domai
 	}
 	return dp, nil
 }
+
+// func (svc service) listDomainsIDs(ctx context.Context, userID, permission string) ([]string, error) {
+// 	tids, err := svc.auth.ListAllObjects(ctx, &magistrala.ListObjectsReq{
+// 		SubjectType: UserType,
+// 		Subject:     userID,
+// 		Permission:  permission,
+// 		ObjectType:  DomainType,
+// 	})
+// 	if err != nil {
+// 		return nil, errors.Wrap(svcerr.ErrNotFound, err)
+// 	}
+// 	return tids.Policies, nil
+// }
+
 
 func (svc service) AssignUsers(ctx context.Context, token, id string, userIds []string, relation string) error {
 	if err := svc.Authorize(ctx, PolicyReq{


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

# What type of PR is this?
This is a bug fix because it fixes the following issue: #2241 


## What does this do?
It changes how the `buildPageQuery` method is implemented when one is a super admin vs a normal user.

## Which issue(s) does this PR fix/relate to?

- Related Issue #2241 
- Resolves #2241 

## Have you included tests for your changes?
No.

## Did you document any new/modified feature?
N/A.


### Notes

<!--Please provide any additional information you feel is important.-->
