### PR TITLE
MG-1969 - Check parent group domain while creating/assigning groups

### DIFF
--- a/internal/groups/service.go
+++ b/internal/groups/service.go
@@ -56,6 +56,17 @@ func (svc service) CreateGroup(ctx context.Context, token, kind string, g groups
 		return groups.Group{}, svcerr.ErrInvalidStatus
 	}
 
+	if g.Parent != "" {
+		x,y := svc.auth.Authorize(ctx, &magistrala.AuthorizeReq{
+			SubjectType: auth.GroupType,
+			SubjectKind: auth.GroupsKind,
+			Subject:     g.Parent,
+			Permission:  auth.MembershipPermission,
+			Object:      res.GetDomainId(),
+			ObjectType:  auth.DomainType,	
+		})
+		fmt.Printf("Response is %+v and error is %+v\n", x, y)
+	}
 	g.ID = groupID
 	g.CreatedAt = time.Now()
 	g.Domain = res.GetDomainId()

--- a/internal/groups/service.go
+++ b/internal/groups/service.go
@@ -75,7 +75,7 @@ func (svc service) CreateGroup(ctx context.Context, token, kind string, g groups
 			return groups.Group{}, err
 		}
 		if !contains(allowedGrps.Policies, g.Parent) {
-			return groups.Group{}, errors.Wrap(errParentUnAuthz, errParentChildDom)
+			return groups.Group{}, errors.Wrap(svcerr.ErrAuthorization, errParentChildDom)
 		}
 	}
 
@@ -444,7 +444,6 @@ func (svc service) Assign(ctx context.Context, token, groupID, relation, memberK
 }
 
 func (svc service) assignParentGroup(ctx context.Context, domain, parentGroupID string, groupIDs []string) (err error) {
-
 	allowedGrps, err := svc.auth.ListAllObjects(ctx, &magistrala.ListObjectsReq{
 		SubjectType: auth.DomainType,
 		Subject:     domain,
@@ -455,7 +454,7 @@ func (svc service) assignParentGroup(ctx context.Context, domain, parentGroupID 
 		return err
 	}
 	if !contains(allowedGrps.Policies, parentGroupID) {
-		return errors.Wrap(errParentUnAuthz, errParentChildDom)
+		return errors.Wrap(svcerr.ErrAuthorization, errParentChildDom)
 	}
 
 	groupsPage, err := svc.groups.RetrieveByIDs(ctx, groups.Page{PageMeta: groups.PageMeta{Limit: 1<<63 - 1}}, groupIDs...)


### PR DESCRIPTION
# What type of PR is this?
This is a feature because it adds the following functionality: it check if parent and child groups are in the same domain before creating or assigning the child. 

## What does this do?
It implements a grpc call to check if parent is in the same domain as the child.

## Which issue(s) does this PR fix/relate to?
- Related Issue #1969 
- Resolves #1969 

## Have you included tests for your changes?
Yes

## Did you document any new/modified feature?
N/A

### Notes

<!--Please provide any additional information you feel is important.-->
