### PR TITLE
NOISSUE - Enable empty Transformers

### DIFF
--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -152,7 +152,7 @@ func makeTransformer(cfg transformerConfig, logger *slog.Logger) transformers.Tr
 		logger.Info("Using JSON transformer")
 		return json.New(cfg.TimeFields)
 	default:
-		logger.Error(fmt.Sprintf("Can't create transformer: unknown transformer type %s", cfg.Format))
+		logger.Warn(fmt.Sprintf("No transformer created: unknown transformer type %s", cfg.Format))
 		return nil
 	}
 }

--- a/consumers/messages.go
+++ b/consumers/messages.go
@@ -153,7 +153,6 @@ func makeTransformer(cfg transformerConfig, logger *slog.Logger) transformers.Tr
 		return json.New(cfg.TimeFields)
 	default:
 		logger.Error(fmt.Sprintf("Can't create transformer: unknown transformer type %s", cfg.Format))
-		os.Exit(1)
 		return nil
 	}
 }


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a minor update.
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
It enables an empty transformer in the consumer loop in case we don't want to use any transformers.
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?
There is no such issue.
<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->


## Have you included tests for your changes?

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->
No, except for manual tests.
## Did you document any new/modified feature?
N/A
<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes
N/A
<!--Please provide any additional information you feel is important.-->
