### PR TITLE
SMQ-2832: Fix make sed -i compatible with both macOS and Linux

### DIFF
--- a/docker/addons/vault/scripts/vault_copy_env.sh
+++ b/docker/addons/vault/scripts/vault_copy_env.sh
@@ -33,7 +33,7 @@ done
 
 write_env() {
     if [ -e "$scriptdir/data/secrets" ]; then
-        if [[ "$(uname)" == "Darwin" ]]; then # macOS
+        if [[ "$(uname)" == "Darwin" ]]; then
             SED_OPT=(-i '')
         else
             SED_OPT=(-i)

--- a/docker/addons/vault/scripts/vault_copy_env.sh
+++ b/docker/addons/vault/scripts/vault_copy_env.sh
@@ -33,10 +33,16 @@ done
 
 write_env() {
     if [ -e "$scriptdir/data/secrets" ]; then
-        sed -i "s,SMQ_VAULT_UNSEAL_KEY_1=.*,SMQ_VAULT_UNSEAL_KEY_1=$(awk -F ": " '$1 == "Unseal Key 1" {print $2}' $scriptdir/data/secrets)," "$env_file"
-        sed -i "s,SMQ_VAULT_UNSEAL_KEY_2=.*,SMQ_VAULT_UNSEAL_KEY_2=$(awk -F ": " '$1 == "Unseal Key 2" {print $2}' $scriptdir/data/secrets)," "$env_file"
-        sed -i "s,SMQ_VAULT_UNSEAL_KEY_3=.*,SMQ_VAULT_UNSEAL_KEY_3=$(awk -F ": " '$1 == "Unseal Key 3" {print $2}' $scriptdir/data/secrets)," "$env_file"
-        sed -i "s,SMQ_VAULT_TOKEN=.*,SMQ_VAULT_TOKEN=$(awk -F ": " '$1 == "Initial Root Token" {print $2}' $scriptdir/data/secrets)," "$env_file"
+        if [[ "$(uname)" == "Darwin" ]]; then # macOS
+            SED_OPT=(-i '')
+        else
+            SED_OPT=(-i)
+        fi
+    
+        sed "${SED_OPT[@]}" "s,SMQ_VAULT_UNSEAL_KEY_1=.*,SMQ_VAULT_UNSEAL_KEY_1=$(awk -F ': ' '$1 == "Unseal Key 1" {print $2}' "$scriptdir/data/secrets")," "$env_file"
+        sed "${SED_OPT[@]}" "s,SMQ_VAULT_UNSEAL_KEY_2=.*,SMQ_VAULT_UNSEAL_KEY_2=$(awk -F ': ' '$1 == "Unseal Key 2" {print $2}' "$scriptdir/data/secrets")," "$env_file"
+        sed "${SED_OPT[@]}" "s,SMQ_VAULT_UNSEAL_KEY_3=.*,SMQ_VAULT_UNSEAL_KEY_3=$(awk -F ': ' '$1 == "Unseal Key 3" {print $2}' "$scriptdir/data/secrets")," "$env_file"
+        sed "${SED_OPT[@]}" "s,SMQ_VAULT_TOKEN=.*,SMQ_VAULT_TOKEN=$(awk -F ': ' '$1 == "Initial Root Token" {print $2}' "$scriptdir/data/secrets")," "$env_file"
         echo "Vault environment variables are set successfully in $env_file"
     else
         echo "Error: Source file '$scriptdir/data/secrets' not found."


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a bug fix because it fixes the following issue: sed -i syntax incompatibility between macOS and Linux in vault environment variable setup script.
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
This PR fixes a cross-platform compatibility issue in the `vault_copy_env.sh` script where `sed -i` fails on macOS due to BSD sed syntax. The script now detects the OS and applies the correct `-i` option:
- `sed -i ''` for macOS (BSD sed)
- `sed -i` for Linux (GNU sed)

No functionality is broken or changed — the behavior is preserved but made portable across systems.

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #2832
- Resolves #

## Have you included tests for your changes?
No, I have not included tests because this is a shell script fix targeting developer tooling, which is hard to unit test. However, I manually tested on both macOS and Linux to ensure compatibility.

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
No new features. Behavior remains the same. The logic is now more robust across environments.

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes
- This fix is important for contributors and CI/CD systems that use macOS or Linux interchangeably.
- A follow-up update in `README.md` or `CONTRIBUTING.md` to remind contributors about `sed` portability could help avoid this in future.

<!--Please provide any additional information you feel is important.-->
