### PR TITLE
SMQ-2739 - Prevent removing of all users from Built in admin role

### DIFF
--- a/api/http/common.go
+++ b/api/http/common.go
@@ -233,7 +233,8 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		errors.Contains(err, apiutil.ErrMissingRoleMembers),
 		errors.Contains(err, apiutil.ErrMissingDescription),
 		errors.Contains(err, apiutil.ErrMissingEntityID),
-		errors.Contains(err, apiutil.ErrInvalidRouteFormat):
+		errors.Contains(err, apiutil.ErrInvalidRouteFormat),
+		errors.Contains(err, svcerr.ErrRetainOneMember):
 		err = unwrap(err)
 		w.WriteHeader(http.StatusBadRequest)
 

--- a/domains/service.go
+++ b/domains/service.go
@@ -316,7 +316,7 @@ func (svc *service) RejectInvitation(ctx context.Context, session authn.Session,
 func (svc *service) DeleteInvitation(ctx context.Context, session authn.Session, inviteeUserID, domainID string) error {
 	if session.UserID == inviteeUserID {
 		if err := svc.repo.DeleteInvitation(ctx, inviteeUserID, domainID); err != nil {
-			return err
+			return errors.Wrap(svcerr.ErrRemoveEntity, err)
 		}
 		return nil
 	}
@@ -369,7 +369,7 @@ func (svc *service) RoleRemoveMembers(ctx context.Context, session authn.Session
 
 	for _, memberID := range members {
 		if err := svc.repo.DeleteInvitation(ctx, memberID, entityID); err != nil && err != repoerr.ErrNotFound {
-			return svcerr.ErrRetainOneMember
+			return err
 		}
 	}
 

--- a/domains/service.go
+++ b/domains/service.go
@@ -360,6 +360,6 @@ func (svc *service) RoleRemoveMembers(ctx context.Context, session authn.Session
 	return svc.ProvisionManageService.RoleRemoveMembers(ctx, session, entityID, roleID, members)
 }
 
-func (svc *service) RoleRemoveAllMembers(ctx context.Context, session authn.Session, entityID, roleID string) (err error) {
-	return svcerr.ErrNotFound
+func (svc *service) RoleRemoveAllMembers(ctx context.Context, session authn.Session, entityID, roleID string) error {
+	return svc.ProvisionManageService.RoleRemoveAllMembers(ctx, session, entityID, roleID)
 }

--- a/domains/service.go
+++ b/domains/service.go
@@ -5,7 +5,6 @@ package domains
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/absmach/supermq"
@@ -317,7 +316,7 @@ func (svc *service) RejectInvitation(ctx context.Context, session authn.Session,
 func (svc *service) DeleteInvitation(ctx context.Context, session authn.Session, inviteeUserID, domainID string) error {
 	if session.UserID == inviteeUserID {
 		if err := svc.repo.DeleteInvitation(ctx, inviteeUserID, domainID); err != nil {
-			return errors.Wrap(svcerr.ErrRemoveEntity, err)
+			return err
 		}
 		return nil
 	}
@@ -353,34 +352,24 @@ func (svc *service) RemoveEntityMembers(ctx context.Context, session authn.Sessi
 }
 
 func (svc *service) RoleRemoveMembers(ctx context.Context, session authn.Session, entityID, roleID string, members []string) error {
-	if len(members) == 0 {
-		return svcerr.ErrMalformedEntity
-	}
-
 	ro, err := svc.repo.RetrieveEntityRole(ctx, entityID, roleID)
 	if err != nil {
-		return errors.Wrap(svcerr.ErrViewEntity, fmt.Errorf("failed to retrieve role '%s' for entity '%s': %w", roleID, entityID, err))
+		return errors.Wrap(svcerr.ErrViewEntity, err)
 	}
 
-	isBuiltInRole := false
-	if _, ok := svc.ProvisionManageService.BuiltInRoles[roles.BuiltInRoleName(ro.Name)]; ok {
-		isBuiltInRole = true
-	}
-
-	if isBuiltInRole {
-		membersPage, listErr := svc.repo.RoleListMembers(ctx, ro.ID, 0, 0)
-		if listErr != nil {
-			return errors.Wrap(svcerr.ErrViewEntity, fmt.Errorf("failed to list members for built-in role '%s' to check count: %w", ro.Name, listErr))
+	if _, err := svc.ProvisionManageService.BuiltInRoleActions(roles.BuiltInRoleName(ro.Name)); err == nil {
+		membersPage, err := svc.repo.RoleListMembers(ctx, ro.ID, 0, 0)
+		if err != nil {
+			return errors.Wrap(svcerr.ErrViewEntity, err)
 		}
-
 		if membersPage.Total <= uint64(len(members)) {
-			return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("built-in role '%s' must retain at least one member. Attempting to remove %d member(s) from %d would leave too few.", ro.Name, len(members), membersPage.Total))
+			return svcerr.ErrRetainOneMember
 		}
 	}
 
 	for _, memberID := range members {
 		if err := svc.repo.DeleteInvitation(ctx, memberID, entityID); err != nil && err != repoerr.ErrNotFound {
-			return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("failed to delete invitation for member '%s' in domain '%s' from role '%s': %w", memberID, entityID, ro.Name, err))
+			return svcerr.ErrRetainOneMember
 		}
 	}
 
@@ -390,37 +379,12 @@ func (svc *service) RoleRemoveMembers(ctx context.Context, session authn.Session
 func (svc *service) RoleRemoveAllMembers(ctx context.Context, session authn.Session, entityID, roleID string) error {
 	ro, err := svc.repo.RetrieveEntityRole(ctx, entityID, roleID)
 	if err != nil {
-		return errors.Wrap(svcerr.ErrViewEntity, fmt.Errorf("failed to retrieve role '%s' for entity '%s': %w", roleID, entityID, err))
+		return errors.Wrap(svcerr.ErrViewEntity, err)
 	}
 
-	isBuiltInRole := false
-	if _, ok := svc.ProvisionManageService.BuiltInRoles[roles.BuiltInRoleName(ro.Name)]; ok {
-		isBuiltInRole = true
+	if _, err := svc.ProvisionManageService.BuiltInRoleActions(roles.BuiltInRoleName(ro.Name)); err == nil {
+		return svcerr.ErrRetainOneMember
 	}
 
-	if isBuiltInRole {
-		membersPage, listErr := svc.repo.RoleListMembers(ctx, ro.ID, 0, 0)
-		if listErr != nil {
-			return errors.Wrap(svcerr.ErrViewEntity, fmt.Errorf("failed to list members for built-in role '%s' to check count: %w", ro.Name, listErr))
-		}
-
-		if membersPage.Total > 0 {
-			return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("built-in role '%s' must retain at least one member and cannot have all members removed", ro.Name))
-		}
-	}
-
-	currentMembersPage, listErr := svc.repo.RoleListMembers(ctx, ro.ID, 0, 0)
-	if listErr != nil {
-		return errors.Wrap(svcerr.ErrViewEntity, fmt.Errorf("failed to list members of role '%s' for invitation cleanup: %w", ro.Name, listErr))
-	}
-
-	if len(currentMembersPage.Members) > 0 {
-		for _, member := range currentMembersPage.Members {
-			memberID := string(member)
-			if err := svc.repo.DeleteInvitation(ctx, memberID, entityID); err != nil && err != repoerr.ErrNotFound {
-				return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("failed to delete invitation for member '%s' in domain '%s' from role '%s': %w", memberID, entityID, ro.Name, err))
-			}
-		}
-	}
 	return svc.ProvisionManageService.RoleRemoveAllMembers(ctx, session, entityID, roleID)
 }

--- a/pkg/errors/service/types.go
+++ b/pkg/errors/service/types.go
@@ -87,4 +87,7 @@ var (
 
 	// ErrUnauthorizedPAT indicates failure occurred while authorizing PAT.
 	ErrUnauthorizedPAT = errors.New("failed to authorize PAT")
+
+	// ErrRetainOneMember indicates that at least one owner must be retained in the entity.
+	ErrRetainOneMember = errors.New("must retain at least one member")
 )

--- a/pkg/roles/provisionmanage.go
+++ b/pkg/roles/provisionmanage.go
@@ -34,7 +34,7 @@ type ProvisionManageService struct {
 	sidProvider  supermq.IDProvider
 	policy       policies.Service
 	actions      []Action
-	builtInRoles map[BuiltInRoleName][]Action
+	BuiltInRoles map[BuiltInRoleName][]Action
 }
 
 func NewProvisionManageService(entityType string, repo Repository, policy policies.Service, sidProvider supermq.IDProvider, actions []Action, builtInRoles map[BuiltInRoleName][]Action) (ProvisionManageService, error) {
@@ -44,7 +44,7 @@ func NewProvisionManageService(entityType string, repo Repository, policy polici
 		sidProvider:  sidProvider,
 		policy:       policy,
 		actions:      actions,
-		builtInRoles: builtInRoles,
+		BuiltInRoles: builtInRoles,
 	}
 	return rm, nil
 }
@@ -143,7 +143,7 @@ func (r ProvisionManageService) AddNewEntitiesRoles(ctx context.Context, domainI
 
 	for _, entityID := range entityIDs {
 		for defaultRole, defaultRoleMembers := range newBuiltInRoleMembers {
-			actions, ok := r.builtInRoles[defaultRole]
+			actions, ok := r.BuiltInRoles[defaultRole]
 			if !ok {
 				return []RoleProvision{}, fmt.Errorf("default role %s not found in in-built roles", defaultRole)
 			}
@@ -559,16 +559,6 @@ func (r ProvisionManageService) RoleRemoveMembers(ctx context.Context, session a
 		return errors.Wrap(svcerr.ErrRemoveEntity, err)
 	}
 
-	if _, ok := r.builtInRoles[BuiltInRoleName(ro.Name)]; ok {
-		page, err := r.repo.RoleListMembers(ctx, ro.ID, 0, 0)
-		if err != nil {
-			return errors.Wrap(svcerr.ErrViewEntity, err)
-		}
-		if page.Total <= uint64(len(members)) {
-			return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("built-in role '%s' must retain at least one member", ro.Name))
-		}
-	}
-
 	if len(members) == 0 {
 		return svcerr.ErrMalformedEntity
 	}
@@ -600,10 +590,6 @@ func (r ProvisionManageService) RoleRemoveAllMembers(ctx context.Context, sessio
 	ro, err := r.repo.RetrieveEntityRole(ctx, entityID, roleID)
 	if err != nil {
 		return errors.Wrap(svcerr.ErrRemoveEntity, err)
-	}
-
-	if _, ok := r.builtInRoles[BuiltInRoleName(ro.Name)]; ok {
-		return errors.Wrap(svcerr.ErrRemoveEntity, fmt.Errorf("removing all members from built-in role '%s' is not permitted", ro.Name))
 	}
 
 	prs := policies.Policy{


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

# What type of PR is this?

This is a feature
## What does this do?

This PR introduces a safeguard that prevents all members from being removed from the built-in `admin` role on any domain. When an attempt is made to remove the last user from the `admin` role, the system now rejects the request with:

```bash
{
    "error": "",
    "message": "failed to remove entity"
}
```

This ensures that at least one user always retains admin privileges, preventing domains from becoming orphaned. 

Example behavior:
- If a domain has 2 admin users, removing one is allowed.
- Attempting to remove both in the same request is rejected.
- If only one admin remains, any attempt to remove them is blocked.

## Which issue(s) does this PR fix/relate to?

- Resolves #2739
- Related # https://github.com/absmach/supermq-docs/pull/223

## Have you included tests for your changes?

Yes. Manual testing was performed by removing members via the `/domains/{domainID}/roles/{roleID}/members/delete` endpoint and verifying behavior with various admin user counts. Unit tests will follow up in a separate test refactor PR.

## Did you document any new/modified feature?

Yes. Documented at https://github.com/absmach/supermq-docs/pull/223

### Notes
