### PR TITLE
SMQ-2838 - Mark supermq-base-net as external in addons docker-compose

### DIFF
--- a/docker/addons/certs/docker-compose.yaml
+++ b/docker/addons/certs/docker-compose.yaml
@@ -8,6 +8,8 @@
 
 networks:
   supermq-base-net:
+    external: true
+    name: supermq-base-net
 
 volumes:
   supermq-certs-db-volume:
@@ -118,7 +120,7 @@ services:
       AM_JAEGER_URL: ${SMQ_JAEGER_URL}
       AM_JAEGER_TRACE_RATIO: ${SMQ_JAEGER_TRACE_RATIO}
     volumes:
-     - ./config.yaml:/config/config.yaml
+      - ./config.yaml:/config/config.yml
     ports:
       - 9010:9010
       - 7012:7012

--- a/docker/addons/certs/docker-compose.yaml
+++ b/docker/addons/certs/docker-compose.yaml
@@ -8,8 +8,7 @@
 
 networks:
   supermq-base-net:
-    external: true
-    name: supermq-base-net
+
 
 volumes:
   supermq-certs-db-volume:

--- a/docker/addons/journal/docker-compose.yaml
+++ b/docker/addons/journal/docker-compose.yaml
@@ -10,8 +10,7 @@
 
 networks:
   supermq-base-net:
-    external: true
-    name: supermq-base-net
+
 
 volumes:
   supermq-journal-volume:

--- a/docker/addons/journal/docker-compose.yaml
+++ b/docker/addons/journal/docker-compose.yaml
@@ -10,9 +10,12 @@
 
 networks:
   supermq-base-net:
+    external: true
+    name: supermq-base-net
 
 volumes:
   supermq-journal-volume:
+
 
 services:
   journal-db:

--- a/docker/addons/prometheus/docker-compose.yaml
+++ b/docker/addons/prometheus/docker-compose.yaml
@@ -9,8 +9,7 @@
 
 networks:
   supermq-base-net:
-    external: true
-    name: supermq-base-net
+
 
 volumes:
   supermq-prometheus-volume:

--- a/docker/addons/prometheus/docker-compose.yaml
+++ b/docker/addons/prometheus/docker-compose.yaml
@@ -9,9 +9,12 @@
 
 networks:
   supermq-base-net:
+    external: true
+    name: supermq-base-net
 
 volumes:
   supermq-prometheus-volume:
+
 
 services:
   promethues:

--- a/docker/addons/vault/docker-compose.yaml
+++ b/docker/addons/vault/docker-compose.yaml
@@ -10,9 +10,12 @@
 
 networks:
   supermq-base-net:
+    external: true
+    name: supermq-base-net
 
 volumes:
   supermq-vault-volume:
+
 
 services:
   vault:

--- a/docker/addons/vault/docker-compose.yaml
+++ b/docker/addons/vault/docker-compose.yaml
@@ -10,8 +10,7 @@
 
 networks:
   supermq-base-net:
-    external: true
-    name: supermq-base-net
+
 
 volumes:
   supermq-vault-volume:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,6 +6,7 @@ name: "supermq"
 networks:
   supermq-base-net:
     driver: bridge
+    name: supermq-base-net
 
 volumes:
   supermq-users-db-volume:
@@ -20,8 +21,8 @@ volumes:
   supermq-pat-db-volume:
   supermq-domains-db-volume:
   supermq-domains-redis-volume:
-  supermq-ui-db-volume:
   supermq-auth-redis-volume:
+
 
 services:
   spicedb:
@@ -68,7 +69,7 @@ services:
       POSTGRES_DB: ${SMQ_SPICEDB_DB_NAME}
     volumes:
       - supermq-spicedb-db-volume:/var/lib/postgresql/data
-    command: ["postgres", "-c", "track_commit_timestamp=on"]
+    command: [ "postgres", "-c", "track_commit_timestamp=on" ]
 
   auth-db:
     image: postgres:16.2-alpine


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a bug fix because it fixes the following issue: active endpoints error when running make run_addons vault after make run.
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?
This PR modifies the docker/addons/.../docker-compose.yaml file to mark the shared Docker network supermq-base-net as external: true.

By doing this, the addons will reuse the existing network instead of trying to recreate or remove it, thus avoiding Docker errors when the network has active endpoints.
<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #2838 
- Resolves #

## Have you included tests for your changes?
No, I have not included tests because this change only modifies the Docker Compose configuration for services orchestration, which is usually tested manually during deployment.
<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
No, I have not updated the documentation because the change is in the deployment layer only (docker-compose network configuration).
<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
