### PR TITLE
SMQ-2905 - Add repo dispatch to trigger stage deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
           make latest -j $(nproc) # This should build and push docker.io/absmach/supermq:latest
 
       - name: Notify amdm Helm Chart Repository of New Image
-        if: success()
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_PAT_TO_AMDM }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,7 @@ jobs:
           event-type: supermq-image-updated
           client-payload: |
             {
+              "image_repository": "docker.io/absmach/supermq",
               "image_tag": "latest",
               "source_commit_sha": "${{ github.sha }}"
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ jobs:
   build-and-push:
     name: Build and Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -57,6 +59,20 @@ jobs:
         run: |
           SMQ_ES_TYPE=es_redis make mqtt
 
-      - name: Build and push Dockers
+      - name: Build and push Docker images
         run: |
-          make latest -j $(nproc)
+          make latest -j $(nproc) # This should build and push docker.io/absmach/supermq:latest
+
+      - name: Notify amdm Helm Chart Repository of New Image
+        if: success()
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_DISPATCH_PAT_TO_AMDM }}
+          repository: absmach/amdm
+          event-type: supermq-image-updated
+          client-payload: |
+            {
+              "image_repository": "docker.io/absmach/supermq",
+              "image_tag": "latest",
+              "source_commit_sha": "${{ github.sha }}"
+            }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,4 +69,4 @@ jobs:
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: absmach/amdm
-          event-type: deploy-latest-images
+          event-type: deploy-latest-smq-images

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,18 +61,17 @@ jobs:
 
       - name: Build and push Docker images
         run: |
-          make latest -j $(nproc) # This should build and push docker.io/absmach/supermq:latest
+          make latest -j $(nproc)
 
-      - name: Notify amdm Helm Chart Repository of New Image
+      - name: Notify AMDM Helm Chart Repository of New Image
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.REPO_DISPATCH_PAT_TO_AMDM }}
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: absmach/amdm
           event-type: supermq-image-updated
           client-payload: |
             {
-              "image_repository": "docker.io/absmach/supermq",
               "image_tag": "latest",
               "source_commit_sha": "${{ github.sha }}"
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
           make latest -j $(nproc)
 
       - name: Trigger Helm Chart Deployment
-        if: success()
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,16 +63,10 @@ jobs:
         run: |
           make latest -j $(nproc)
 
-      - name: Notify AMDM Helm Chart Repository of New Image
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Trigger Helm Chart Deployment
+        if: success()
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: absmach/amdm
-          event-type: supermq-image-updated
-          client-payload: |
-            {
-              "image_repository": "docker.io/absmach/supermq",
-              "image_tag": "latest",
-              "source_commit_sha": "${{ github.sha }}"
-            }
+          event-type: deploy-latest-images


### PR DESCRIPTION
# What type of PR is this?

Feature

## What does this do?

Adds a `repository_dispatch` step to notify the `amdm` chart repository (`absmach/amdm`) whenever new Docker images are built and pushed.

## Which issue(s) does this PR fix/relate to?

- Resolves #2905
- Related Issue https://github.com/absmach/amdm/pull/202
- Related Issue https://github.com/absmach/magistrala/issues/178

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No

### Notes
