### PR TITLE
SMQ-2985 - Use coap mux.Handler instead of coap mux.HandlerFunc

### DIFF
--- a/pkg/server/coap/coap.go
+++ b/pkg/server/coap/coap.go
@@ -16,12 +16,12 @@ import (
 
 type coapServer struct {
 	server.BaseServer
-	handler mux.HandlerFunc
+	handler mux.Handler
 }
 
 var _ server.Server = (*coapServer)(nil)
 
-func NewServer(ctx context.Context, cancel context.CancelFunc, name string, config server.Config, handler mux.HandlerFunc, logger *slog.Logger) server.Server {
+func NewServer(ctx context.Context, cancel context.CancelFunc, name string, config server.Config, handler mux.Handler, logger *slog.Logger) server.Server {
 	baseServer := server.NewBaseServer(ctx, cancel, name, config, logger)
 
 	return &coapServer{


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is an optimization because it improves handler logic
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
This pr:
- changes MakeCoAPHandler to return a mux.Handler and rename its internal handler method to ServeCOAP.
- updates coapServer struct and NewServer constructor to accept and store a mux.Handler instead of mux.HandlerFunc.
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Resolves #2985

## Have you included tests for your changes?
No
<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
No
<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
