### PR TITLE
SMQ-3224 - Add consistent error for assigning channel and client with parent group to parent group

### DIFF
--- a/channels/service.go
+++ b/channels/service.go
@@ -26,6 +26,7 @@ var (
 	errAddConnectionsClients    = errors.New("failed to add connections in clients service")
 	errRemoveConnectionsClients = errors.New("failed to remove connections from clients service")
 	errSetParentGroup           = errors.New("channel already have parent")
+	errSetSameParentGroup       = errors.New("channel already assigned to the parent group")
 )
 
 type service struct {
@@ -421,7 +422,12 @@ func (svc service) SetParentGroup(ctx context.Context, session authn.Session, pa
 	}
 
 	var pols []policies.Policy
-	if ch.ParentGroup != "" {
+	switch ch.ParentGroup {
+	case parentGroupID:
+		return errors.Wrap(svcerr.ErrConflict, errSetSameParentGroup)
+	case "":
+		// No action needed, proceed to next code after switch
+	default:
 		return errors.Wrap(svcerr.ErrConflict, errSetParentGroup)
 	}
 	pols = append(pols, policies.Policy{

--- a/clients/service.go
+++ b/clients/service.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	errRollbackRepo   = errors.New("failed to rollback repo")
-	errSetParentGroup = errors.New("client already have parent")
+	errRollbackRepo       = errors.New("failed to rollback repo")
+	errSetParentGroup     = errors.New("client already have parent")
+	errSetSameParentGroup = errors.New("client already assigned to the parent group")
 )
 var _ Service = (*service)(nil)
 
@@ -247,7 +248,7 @@ func (svc service) SetParentGroup(ctx context.Context, session authn.Session, pa
 	}
 	switch cli.ParentGroup {
 	case parentGroupID:
-		return nil
+		return errors.Wrap(svcerr.ErrConflict, errSetSameParentGroup)
 	case "":
 		// No action needed, proceed to next code after switch
 	default:

--- a/clients/service_test.go
+++ b/clients/service_test.go
@@ -1029,7 +1029,7 @@ func TestSetParentGroup(t *testing.T) {
 			parentGroupID:    validID,
 			session:          smqauthn.Session{UserID: validID, DomainID: validID, DomainUserID: validID + "_" + validID},
 			retrieveByIDResp: parentedClient,
-			err:              nil,
+			err:              svcerr.ErrConflict,
 		},
 		{
 			desc:             "set parent group of client with existing parent group",


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a bug fix because it fixes the following issue: #3224
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
This pr add consistent error handling for assigning an already assigned channel and client to a parent group
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #3224
- Resolves #3224

## Have you included tests for your changes?
Yes, tests have been updated.
<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
In code documentation is included
<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
