### PR TITLE
NOISSUE - Add PAT entity type support for reports, alarms and rules

### DIFF
--- a/auth/pat.go
+++ b/auth/pat.go
@@ -70,6 +70,9 @@ const (
 	MessagesType
 	DomainsType
 	UsersType
+	ReportsType
+	AlarmsType
+	RulesType
 )
 
 const (
@@ -80,6 +83,9 @@ const (
 	MessagesStr      = "messages"
 	DomainsStr       = "domains"
 	UsersStr         = "users"
+	ReportsStr       = "report"
+	AlarmsStr        = "alarm"
+	RulesStr         = "rule"
 )
 
 func (et EntityType) String() string {
@@ -98,6 +104,12 @@ func (et EntityType) String() string {
 		return DomainsStr
 	case UsersType:
 		return UsersStr
+	case ReportsType:
+		return ReportsStr
+	case AlarmsType:
+		return AlarmsStr
+	case RulesType:
+		return RulesStr
 	default:
 		return fmt.Sprintf("unknown domain entity type %d", et)
 	}
@@ -119,6 +131,12 @@ func ParseEntityType(et string) (EntityType, error) {
 		return DomainsType, nil
 	case UsersStr:
 		return UsersType, nil
+	case ReportsStr:
+		return ReportsType, nil
+	case AlarmsStr:
+		return AlarmsType, nil
+	case RulesStr:
+		return RulesType, nil
 	default:
 		return 0, fmt.Errorf("unknown domain entity type %s", et)
 	}
@@ -147,7 +165,7 @@ func (et *EntityType) UnmarshalText(data []byte) (err error) {
 
 func IsValidOperationForEntity(entityType EntityType, operation string) bool {
 	switch entityType {
-	case ClientsType, ChannelsType, GroupsType, DomainsType:
+	case ClientsType, ChannelsType, GroupsType, DomainsType, ReportsType, AlarmsType, RulesType:
 		return true
 	case DashboardType:
 		return operation == OpDashboardShare || operation == OpDashboardUnshare


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

# What type of PR is this?

Bug fix — missing PAT entity types for reports, alarms, and rules.

## What does this do?

Adds `ReportsType`, `AlarmsType`, `RulesType` to the `EntityType` iota in `auth/pat.go`, with string constants (`"report"`, `"alarm"`, `"rule"`), `String()`, `ParseEntityType()`, and `IsValidOperationForEntity()` support.

Without this, `ParseEntityType` returned "unknown domain entity type report/alarm/rule" when the auth gRPC server handled PAT authorize requests for these services, causing the reports service to fail with "Unexpected end of JSON input". Also, `IsValidOperationForEntity` rejected any attempt to create PAT scopes for these entity types.

Note: the fix for refresh-derived access tokens being falsely classified as PAT sessions is handled separately in #3472.

## Which issue(s) does this PR fix/relate to?

- Related Issue #
- Resolves #

## Have you included tests for your changes?

No — `ParseEntityType` and `IsValidOperationForEntity` are covered by existing scope validation tests. The entity type strings are defined by the service operation packages (`reports/operations`, `alarms/operations`, `re/operations`) which already test their own entity types.

## Did you document any new/modified feature?

No documentation needed — internal auth entity type registration.

### Notes

The string values (`"report"`, `"alarm"`, `"rule"`) are singular to match the `EntityType` constants in each service's `operations/operations.go` package, which is what the authorization middleware passes when building PAT requests.