### PR TITLE
MG-3512 - Add `rendered context` field to update endpoint

### DIFF
--- a/bootstrap/api/endpoint.go
+++ b/bootstrap/api/endpoint.go
@@ -133,9 +133,10 @@ func updateEndpoint(svc bootstrap.Service) endpoint.Endpoint {
 		}
 
 		config := bootstrap.Config{
-			ID:      req.id,
-			Name:    req.Name,
-			Content: req.Content,
+			ID:            req.id,
+			Name:          req.Name,
+			Content:       req.Content,
+			RenderContext: req.RenderContext,
 		}
 
 		if err := svc.Update(ctx, session, config); err != nil {

--- a/bootstrap/api/endpoint_test.go
+++ b/bootstrap/api/endpoint_test.go
@@ -65,15 +65,17 @@ var (
 	}
 
 	updateReq = struct {
-		Content    string           `json:"content,omitempty"`
-		Status     bootstrap.Status `json:"status,omitempty"`
-		ClientCert string           `json:"client_cert,omitempty"`
-		CACert     string           `json:"ca_cert,omitempty"`
+		Content       string           `json:"content,omitempty"`
+		Status        bootstrap.Status `json:"status,omitempty"`
+		ClientCert    string           `json:"client_cert,omitempty"`
+		CACert        string           `json:"ca_cert,omitempty"`
+		RenderContext map[string]any   `json:"render_context,omitempty"`
 	}{
-		Content:    "config update",
-		Status:     bootstrap.EnabledStatus,
-		ClientCert: "newcert",
-		CACert:     "newca",
+		Content:       "config update",
+		Status:        bootstrap.EnabledStatus,
+		ClientCert:    "newcert",
+		CACert:        "newca",
+		RenderContext: map[string]any{"site": "warehouse-2", "region": "mombasa"},
 	}
 
 	missingIDRes              = toJSON(apiutil.ErrMissingID)
@@ -477,6 +479,17 @@ func TestUpdate(t *testing.T) {
 			contentType: contentType,
 			status:      http.StatusBadRequest,
 			err:         svcerr.ErrMalformedEntity,
+		},
+		{
+			desc: "update a config render_context",
+			req: toJSON(struct {
+				RenderContext map[string]any `json:"render_context"`
+			}{RenderContext: map[string]any{"site": "warehouse-2", "region": "mombasa"}}),
+			id:          c.ID,
+			token:       validToken,
+			contentType: contentType,
+			status:      http.StatusOK,
+			err:         nil,
 		},
 	}
 

--- a/bootstrap/api/requests.go
+++ b/bootstrap/api/requests.go
@@ -52,9 +52,10 @@ func (req entityReq) validate() error {
 }
 
 type updateReq struct {
-	id      string
-	Name    string `json:"name"`
-	Content string `json:"content"`
+	id            string
+	Name          string         `json:"name"`
+	Content       string         `json:"content"`
+	RenderContext map[string]any `json:"render_context"`
 }
 
 func (req updateReq) validate() error {

--- a/bootstrap/postgres/configs.go
+++ b/bootstrap/postgres/configs.go
@@ -169,13 +169,19 @@ func (cr configRepository) RetrieveByExternalID(ctx context.Context, externalID 
 }
 
 func (cr configRepository) Update(ctx context.Context, cfg bootstrap.Config) error {
-	q := `UPDATE configs SET name = :name, content = :content WHERE id = :id AND domain_id = :domain_id `
+	q := `UPDATE configs SET name = :name, content = :content, render_context = :render_context WHERE id = :id AND domain_id = :domain_id `
+
+	renderContext, err := json.Marshal(cfg.RenderContext)
+	if err != nil {
+		return errors.Wrap(repoerr.ErrUpdateEntity, err)
+	}
 
 	dbcfg := dbConfig{
-		Name:     nullString(cfg.Name),
-		Content:  nullString(cfg.Content),
-		ID:       cfg.ID,
-		DomainID: cfg.DomainID,
+		Name:          nullString(cfg.Name),
+		Content:       nullString(cfg.Content),
+		RenderContext: renderContext,
+		ID:            cfg.ID,
+		DomainID:      cfg.DomainID,
 	}
 
 	res, err := cr.db.NamedExecContext(ctx, q, dbcfg)

--- a/bootstrap/postgres/configs_test.go
+++ b/bootstrap/postgres/configs_test.go
@@ -256,17 +256,23 @@ func TestUpdate(t *testing.T) {
 	c.Content = "new content"
 	c.Name = "new name"
 
+	withRenderContext := c
+	withRenderContext.RenderContext = map[string]any{
+		"site":   "warehouse-2",
+		"region": "mombasa",
+	}
+
 	wrongDomainID := c
 	wrongDomainID.DomainID = "3"
 
 	cases := []struct {
-		desc   string
-		id     string
-		config bootstrap.Config
-		err    error
+		desc          string
+		config        bootstrap.Config
+		renderContext map[string]any
+		err           error
 	}{
 		{
-			desc:   "update with wrong domainID ",
+			desc:   "update with wrong domainID",
 			config: wrongDomainID,
 			err:    repoerr.ErrNotFound,
 		},
@@ -275,10 +281,21 @@ func TestUpdate(t *testing.T) {
 			config: c,
 			err:    nil,
 		},
+		{
+			desc:          "update a config render_context",
+			config:        withRenderContext,
+			renderContext: map[string]any{"site": "warehouse-2", "region": "mombasa"},
+			err:           nil,
+		},
 	}
 	for _, tc := range cases {
 		err := repo.Update(context.Background(), tc.config)
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", tc.desc, tc.err, err))
+		if tc.err == nil && tc.renderContext != nil {
+			saved, err := repo.RetrieveByID(context.Background(), tc.config.DomainID, tc.config.ID)
+			require.Nil(t, err, fmt.Sprintf("%s: unexpected retrieve error: %s\n", tc.desc, err))
+			assert.Equal(t, tc.renderContext, saved.RenderContext, fmt.Sprintf("%s: expected render_context %v got %v\n", tc.desc, tc.renderContext, saved.RenderContext))
+		}
 	}
 }
 

--- a/bootstrap/service_test.go
+++ b/bootstrap/service_test.go
@@ -199,6 +199,12 @@ func TestUpdate(t *testing.T) {
 	modifiedCreated.Content = "new-config"
 	modifiedCreated.Name = "new name"
 
+	modifiedRenderContext := c
+	modifiedRenderContext.RenderContext = map[string]any{
+		"site":   "warehouse-2",
+		"region": "mombasa",
+	}
+
 	nonExisting := c
 	nonExisting.ID = unknown
 
@@ -215,6 +221,14 @@ func TestUpdate(t *testing.T) {
 		{
 			desc:     "update a config with status Created",
 			config:   modifiedCreated,
+			token:    validToken,
+			userID:   validID,
+			domainID: domainID,
+			err:      nil,
+		},
+		{
+			desc:     "update a config render_context",
+			config:   modifiedRenderContext,
 			token:    validToken,
 			userID:   validID,
 			domainID: domainID,


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

# What type of PR is this?

This is a bug fix because it fixes the Bootstrap config update API not supporting `render_context` updates (issue #3512).

## What does this do?

Adds `render_context` to the Bootstrap config update endpoint (`PATCH /{domain_id}/clients/configs/{config_id}`).

Previously, `render_context` could only be set at config creation time. After creation, there was no way to update per-device template variables such as site location or sample intervals. This PR:

- Adds `render_context` to the `updateReq` struct in the API layer.
- Passes `render_context` through the endpoint to the service.
- Adds `render_context` to the Postgres `UPDATE` query so the value is persisted.

## Which issue(s) does this PR fix/relate to?

Resolves #3512

## Have you included tests for your changes?

Yes. Tests have been added at three levels:

- **Service tests** (`bootstrap/service_test.go`) — new `"update a config render_context"` case in `TestUpdate`.
- **Repository tests** (`bootstrap/postgres/configs_test.go`) — new `"update a config render_context"` case in `TestUpdate` that verifies the value is correctly persisted and retrieved.
- **API endpoint tests** (`bootstrap/api/endpoint_test.go`) — new `"update a config render_context"` case in `TestUpdate` that verifies the HTTP layer accepts and forwards the field.

## Did you document any new/modified feature?

No documentation update required. The `render_context` field was already documented as part of the config model; this PR only fixes the update path to respect it.

### Notes

The `render_context` field is the primary way to store per-device template variables used during profile rendering via `.Vars`. Without the ability to update it post-creation, operators had no way to change device-specific values such as site, location, or intervals after a config was created.