### PR TITLE
NOISSUE - Limit pdf-generator memory

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1029,7 +1029,7 @@ services:
       - ./templates/${MG_REPORTS_EMAIL_TEMPLATE}:/email.tmpl
 
   pdf-generator:
-    image: gotenberg/gotenberg:8.25.1
+    image: gotenberg/gotenberg:8.34.0
     container_name: magistrala-pdf
     restart: on-failure
     # Gotenberg leaks memory over time (upstream issues #987, #1169); the cap

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1031,6 +1031,10 @@ services:
   pdf-generator:
     image: gotenberg/gotenberg:8.25.1
     container_name: magistrala-pdf
+    restart: on-failure
+    # Gotenberg leaks memory over time (upstream issues #987, #1169); the cap
+    # keeps the OOM kill inside this container instead of stalling the host.
+    mem_limit: 512m
     ports:
       - "4000:3000"
     networks:


### PR DESCRIPTION
Gotenberg's dns-filter leaks memory (upstream #987, #1169) and grows until the host OOMs, stalling co-located services; on FluxMQ cluster deployments the stall expires etcd leases and breaks cross-node routing. The cap keeps the OOM kill inside the container so Docker restarts Gotenberg instead.

<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `MG-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/magistrala/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a bugfix.
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
It limits PDF generator memory footprint to prevent it crashing the entire composition.
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

There is no such issue.
## Have you included tests for your changes?

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->
Yes.
## Did you document any new/modified feature?
No.

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
N/A