### PR TITLE
NOISSUE - Mark Rules Engine, Alarms, and Audit Logs as Enterprise Edition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ Magistrala provides a complete set of building blocks for IoT systems — from d
 
 ### ⚙️ Processing & Automation
 
-- Rules engine for message processing and routing
-- Alarms and triggers for reacting to events
+- Rules engine for message processing and routing (Enterprise Edition)
+- Alarms and triggers for reacting to events (Enterprise Edition)
 - Scheduled actions for time-based workflows
 - Event-driven architecture as the foundation
 
 ### 📊 Observability
 
-- Audit logs for tracking system activity
+- Audit logs for tracking system activity (Enterprise Edition)
 - Metrics and tracing via Prometheus and OpenTelemetry
 - Built-in visibility into system behavior and data flows
 


### PR DESCRIPTION

# What type of PR is this?

This is a documentation update because it updates the following documentation: the root README's Features section.

## What does this do?

Marks Rules Engine, Alarms, and Audit Logs as "(Enterprise Edition)" in the Features section. These services moved to Magistrala EE in #3552, but the README still listed them as plain, unqualified community capabilities, which is misleading for anyone evaluating what ships in the open-source repo.

## Which issue(s) does this PR fix/relate to?

- Related Issue #3552

## Have you included tests for your changes?

No, I have not included tests because this is a documentation-only change to README.md.

## Did you document any new/modified feature?

Yes, this PR is itself the documentation update — no separate docs needed.

### Notes

Found while auditing the docs site (absmach/magistrala-website) for staleness after the EE move. A matching fix (Enterprise Edition callouts across the affected pages) is being applied there as a separate PR.
