### PR TITLE
Fix Atom policy client defects

### DIFF
--- a/pkg/atom/bootstrap.go
+++ b/pkg/atom/bootstrap.go
@@ -35,6 +35,11 @@ var magistralaActionApplicability = []CapabilityApplicabilitySpec{
 	{ActionName: atomActionAlarmAcknowledge, ObjectKind: atomObjectKindTenant},
 	{ActionName: atomActionAlarmResolve, ObjectKind: atomObjectKindTenant},
 
+	{ActionName: atomActionRead, ObjectKind: atomObjectKindEntity, ObjectType: atomObjectTypeEntityDevice},
+	{ActionName: atomActionWrite, ObjectKind: atomObjectKindEntity, ObjectType: atomObjectTypeEntityDevice},
+	{ActionName: atomActionDelete, ObjectKind: atomObjectKindEntity, ObjectType: atomObjectTypeEntityDevice},
+	{ActionName: atomActionManage, ObjectKind: atomObjectKindEntity, ObjectType: atomObjectTypeEntityDevice},
+
 	{ActionName: atomActionRead, ObjectKind: atomObjectKindGroup},
 	{ActionName: atomActionWrite, ObjectKind: atomObjectKindGroup},
 	{ActionName: atomActionDelete, ObjectKind: atomObjectKindGroup},

--- a/pkg/atom/bootstrap_test.go
+++ b/pkg/atom/bootstrap_test.go
@@ -112,6 +112,10 @@ func TestBootstrapMagistralaActionsCreatesMissingActionsAndApplicability(t *test
 		t.Fatalf("unexpected applicability count: got %d want %d", len(applicability), len(magistralaActionApplicability))
 	}
 	assertApplicability(t, applicability, "write-id", atomObjectKindTenant, "")
+	assertApplicability(t, applicability, "read-id", atomObjectKindEntity, atomObjectTypeEntityDevice)
+	assertApplicability(t, applicability, "write-id", atomObjectKindEntity, atomObjectTypeEntityDevice)
+	assertApplicability(t, applicability, "delete-id", atomObjectKindEntity, atomObjectTypeEntityDevice)
+	assertApplicability(t, applicability, "manage-id", atomObjectKindEntity, atomObjectTypeEntityDevice)
 	assertApplicability(t, applicability, "alarm_read-id", atomObjectKindTenant, "")
 	assertApplicability(t, applicability, "alarm_update-id", atomObjectKindTenant, "")
 	assertApplicability(t, applicability, "alarm_delete-id", atomObjectKindTenant, "")
@@ -165,4 +169,121 @@ func assertAssignmentRule(t *testing.T, entries []map[string]any, entityKind, ac
 		}
 	}
 	t.Fatalf("missing assignment guardrail entity=%s action=%s object=%s:%s decision=%s", entityKind, actionName, objectKind, objectType, decision)
+}
+
+func TestBootstrapMagistralaActionsIsIdempotent(t *testing.T) {
+	actions := map[string]Capability{
+		atomActionRead:   {ID: "read-id", Name: atomActionRead},
+		atomActionWrite:  {ID: "write-id", Name: atomActionWrite},
+		atomActionDelete: {ID: "delete-id", Name: atomActionDelete},
+		atomActionManage: {ID: "manage-id", Name: atomActionManage},
+	}
+	applicabilityCalls := 0
+	// seen simulates Atom's ON CONFLICT DO NOTHING dedup on action_applicability.
+	seen := map[string]bool{}
+	assignmentRuleCalls := 0
+	existingAssignmentRules := map[string]map[string]any{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		switch {
+		case strings.Contains(payload.Query, "query Actions"):
+			items := make([]Capability, 0, len(actions))
+			for _, action := range actions {
+				items = append(items, action)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"actions": map[string]any{"items": items, "total": len(items)},
+				},
+			})
+		case strings.Contains(payload.Query, "query ActionAssignmentRules"):
+			items := make([]map[string]any, 0, len(existingAssignmentRules))
+			for _, rule := range existingAssignmentRules {
+				items = append(items, rule)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"actionAssignmentRules": map[string]any{"items": items, "total": len(items)},
+				},
+			})
+		case strings.Contains(payload.Query, "createActionAssignmentRule"):
+			assignmentRuleCalls++
+			input := payload.Variables["input"].(map[string]any)
+			rule := map[string]any{
+				"id":          input["actionName"].(string) + "-rule-id",
+				"tenant_id":   "",
+				"entity_kind": input["entityKind"],
+				"action_name": input["actionName"],
+				"object_kind": input["objectKind"],
+				"object_type": input["objectType"],
+				"decision":    input["decision"],
+				"is_absolute": input["isAbsolute"],
+				"created_at":  "2026-06-18T00:00:00Z",
+			}
+			existingAssignmentRules[input["actionName"].(string)] = rule
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"createActionAssignmentRule": rule},
+			})
+		case strings.Contains(payload.Query, "createAction"):
+			input := payload.Variables["input"].(map[string]any)
+			name := input["name"].(string)
+			action := Capability{ID: name + "-id", Name: name}
+			actions[name] = action
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"createAction": action},
+			})
+		case strings.Contains(payload.Query, "addActionApplicability"):
+			applicabilityCalls++
+			input := payload.Variables["input"].(map[string]any)
+			objectType, _ := input["objectType"].(string)
+			key := input["actionId"].(string) + "|" + input["objectKind"].(string) + "|" + objectType
+			seen[key] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"addActionApplicability": map[string]any{
+						"action_id":   input["actionId"],
+						"action_name": "action",
+						"object_kind": input["objectKind"],
+						"object_type": objectType,
+						"description": "",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	if err := BootstrapMagistralaActions(context.Background(), client); err != nil {
+		t.Fatalf("first bootstrap run failed: %v", err)
+	}
+	if err := BootstrapMagistralaActions(context.Background(), client); err != nil {
+		t.Fatalf("second bootstrap run failed: %v", err)
+	}
+
+	if applicabilityCalls != 2*len(magistralaActionApplicability) {
+		t.Fatalf("unexpected applicability call count: got %d want %d", applicabilityCalls, 2*len(magistralaActionApplicability))
+	}
+	if len(seen) != len(magistralaActionApplicability) {
+		t.Fatalf("bootstrap created duplicate applicability entries: got %d unique want %d", len(seen), len(magistralaActionApplicability))
+	}
+	for _, actionID := range []string{"read-id", "write-id", "delete-id", "manage-id"} {
+		key := actionID + "|" + atomObjectKindEntity + "|" + atomObjectTypeEntityDevice
+		if !seen[key] {
+			t.Fatalf("missing entity applicability for %s", key)
+		}
+	}
+	if assignmentRuleCalls != len(magistralaActionAssignmentRules) {
+		t.Fatalf("expected assignment guardrails to be created once, got %d calls", assignmentRuleCalls)
+	}
 }

--- a/pkg/atom/client.go
+++ b/pkg/atom/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 type Client struct {
@@ -20,6 +21,9 @@ type Client struct {
 	adminSecret   string
 	userAgent     string
 	httpClient    *http.Client
+
+	capMu    sync.RWMutex
+	capCache map[string]string
 }
 
 func NewClient(cfg Config) *Client {
@@ -263,27 +267,61 @@ func (c *Client) CheckAuthzWithToken(ctx context.Context, token string, req Auth
 	return out.AuthzCheck, err
 }
 
+const capabilityPageLimit = 100
+
 func (c *Client) ListCapabilities(ctx context.Context) (CapabilityList, error) {
+	return c.listCapabilitiesPage(ctx, capabilityPageLimit, 0)
+}
+
+func (c *Client) listCapabilitiesPage(ctx context.Context, limit, offset int) (CapabilityList, error) {
 	var out struct {
 		Actions CapabilityList `json:"actions"`
 	}
-	err := c.graphQL(ctx, `query Actions($limit: Int!) {
-		actions(limit: $limit) { total items { id name description } }
-	}`, map[string]any{"limit": 100}, &out)
+	err := c.graphQL(ctx, `query Actions($limit: Int!, $offset: Int!) {
+		actions(limit: $limit, offset: $offset) { total items { id name description } }
+	}`, map[string]any{"limit": limit, "offset": offset}, &out)
 	return out.Actions, err
 }
 
+// CapabilityID resolves a capability name to its ID, paginating past the
+// first page if needed. Results are cached since a capability's ID never
+// changes once created.
 func (c *Client) CapabilityID(ctx context.Context, name string) (string, error) {
-	list, err := c.ListCapabilities(ctx)
-	if err != nil {
-		return "", err
+	if id, ok := c.cachedCapabilityID(name); ok {
+		return id, nil
 	}
-	for _, capability := range list.Items {
-		if capability.Name == name {
-			return capability.ID, nil
+	for offset := 0; ; offset += capabilityPageLimit {
+		page, err := c.listCapabilitiesPage(ctx, capabilityPageLimit, offset)
+		if err != nil {
+			return "", err
+		}
+		for _, capability := range page.Items {
+			c.cacheCapability(capability)
+		}
+		if id, ok := c.cachedCapabilityID(name); ok {
+			return id, nil
+		}
+		if len(page.Items) < capabilityPageLimit || int64(offset+len(page.Items)) >= page.Total {
+			break
 		}
 	}
 	return "", Error{StatusCode: http.StatusNotFound, Message: "capability " + name + " not found"}
+}
+
+func (c *Client) cachedCapabilityID(name string) (string, bool) {
+	c.capMu.RLock()
+	defer c.capMu.RUnlock()
+	id, ok := c.capCache[name]
+	return id, ok
+}
+
+func (c *Client) cacheCapability(capability Capability) {
+	c.capMu.Lock()
+	defer c.capMu.Unlock()
+	if c.capCache == nil {
+		c.capCache = map[string]string{}
+	}
+	c.capCache[capability.Name] = capability.ID
 }
 
 func (c *Client) CreateCapability(ctx context.Context, name, description string) (Capability, error) {

--- a/pkg/atom/client_test.go
+++ b/pkg/atom/client_test.go
@@ -6,6 +6,7 @@ package atom
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -526,6 +527,70 @@ func TestListCredentials(t *testing.T) {
 	}
 	if item.CreatedAt.Format(time.RFC3339) != createdAt {
 		t.Fatalf("unexpected created_at: %s", item.CreatedAt.Format(time.RFC3339))
+	}
+}
+
+func TestCapabilityIDPaginatesBeyondFirstPageAndCaches(t *testing.T) {
+	const total = 150
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		limit := int(payload.Variables["limit"].(float64))
+		offset := int(payload.Variables["offset"].(float64))
+		items := make([]Capability, 0, limit)
+		for i := offset; i < offset+limit && i < total; i++ {
+			items = append(items, Capability{ID: fmt.Sprintf("cap-%d", i), Name: fmt.Sprintf("action-%d", i)})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"actions": map[string]any{"items": items, "total": total},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+
+	id, err := client.CapabilityID(context.Background(), "action-120")
+	if err != nil {
+		t.Fatalf("capability id lookup failed: %v", err)
+	}
+	if id != "cap-120" {
+		t.Fatalf("unexpected capability id: %s", id)
+	}
+	if requests < 2 {
+		t.Fatalf("expected the scan to paginate past the first page, got %d requests", requests)
+	}
+
+	requestsBeforeCachedLookup := requests
+	if _, err := client.CapabilityID(context.Background(), "action-120"); err != nil {
+		t.Fatalf("second capability id lookup failed: %v", err)
+	}
+	if requests != requestsBeforeCachedLookup {
+		t.Fatalf("expected cached lookup to avoid further requests, got %d new requests", requests-requestsBeforeCachedLookup)
+	}
+}
+
+func TestCapabilityIDNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"actions": map[string]any{"items": []Capability{}, "total": 0},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	if _, err := client.CapabilityID(context.Background(), "missing"); !IsNotFound(err) {
+		t.Fatalf("expected not found error, got %v", err)
 	}
 }
 

--- a/pkg/atom/constants.go
+++ b/pkg/atom/constants.go
@@ -50,6 +50,7 @@ const (
 	atomObjectTypeResourceChannel = "resource:channel"
 	atomObjectTypeResourceRule    = "resource:rule"
 	atomObjectTypeResourceReport  = "resource:report"
+	atomObjectTypeEntityDevice    = atomObjectKindEntity + ":" + atomKindDevice
 )
 
 const atomDecisionAllow = "allow"

--- a/pkg/atom/mapping.go
+++ b/pkg/atom/mapping.go
@@ -88,6 +88,12 @@ func entityKind(kind string) string {
 	}
 }
 
+// atomObjectType returns the namespaced object type Atom requires,
+// e.g. "entity:device", "resource:channel".
+func atomObjectType(objectKind, kind string) string {
+	return objectKind + ":" + kind
+}
+
 func GroupFromFields(f ObjectFields) Group {
 	return Group{
 		ID:          f.ID,

--- a/pkg/atom/policy_service.go
+++ b/pkg/atom/policy_service.go
@@ -84,20 +84,33 @@ func (ps PolicyService) DeletePolicyFilter(ctx context.Context, pr policies.Poli
 	if err != nil {
 		return err
 	}
-	page, err := writer.ListDirectPolicies(ctx, DirectPolicyQuery{
-		TenantID:    pr.Domain,
-		SubjectKind: policyGrantSubjectKind(pr),
-		SubjectID:   policySubjectID(pr),
-		Limit:       policyPageLimit,
-	})
-	if err != nil {
-		return err
-	}
-	for _, policy := range page.Items {
-		if !directPolicyMatches(policy, capID, pr) {
-			continue
+
+	// Collect matching IDs across all pages before deleting: deleting while
+	// paginating would shift later pages under us and skip matches.
+	var ids []string
+	for offset := uint64(0); ; offset += policyPageLimit {
+		page, err := writer.ListDirectPolicies(ctx, DirectPolicyQuery{
+			TenantID:    pr.Domain,
+			SubjectKind: policyGrantSubjectKind(pr),
+			SubjectID:   policySubjectID(pr),
+			Limit:       policyPageLimit,
+			Offset:      offset,
+		})
+		if err != nil {
+			return err
 		}
-		if err := writer.DeleteDirectPolicy(ctx, policy.ID); err != nil {
+		for _, policy := range page.Items {
+			if directPolicyMatches(policy, capID, pr) {
+				ids = append(ids, policy.ID)
+			}
+		}
+		if uint64(len(page.Items)) < policyPageLimit || offset+uint64(len(page.Items)) >= page.Total {
+			break
+		}
+	}
+
+	for _, id := range ids {
+		if err := writer.DeleteDirectPolicy(ctx, id); err != nil {
 			return err
 		}
 	}
@@ -136,7 +149,7 @@ func (ps PolicyService) ListAllObjects(ctx context.Context, pr policies.Policy) 
 			SubjectID:  policySubjectID(pr),
 			Action:     CapabilityName(pr.Permission),
 			ObjectKind: policyObjectKind(pr),
-			ObjectType: entityKind(KindClient),
+			ObjectType: atomPolicyObjectType(pr.ObjectType),
 			TenantID:   pr.Domain,
 			Limit:      policyPageLimit,
 			Offset:     offset,
@@ -180,10 +193,10 @@ func (ps PolicyService) ListPermissions(context.Context, policies.Policy, []stri
 }
 
 func isSupportedObjectList(pr policies.Policy) bool {
-	return pr.SubjectType == policies.UserType &&
-		pr.Subject != "" &&
-		pr.ObjectType == policies.ClientType &&
-		pr.Permission == policies.ViewPermission
+	if pr.SubjectType != policies.UserType || pr.Subject == "" || pr.ObjectType != policies.ClientType {
+		return false
+	}
+	return pr.Permission == policies.ViewPermission || pr.Permission == atomActionRead
 }
 
 func policyGrantSubjectKind(pr policies.Policy) string {
@@ -221,20 +234,22 @@ func policyGrantObjectType(pr policies.Policy) string {
 	if policyGrantScopeMode(pr) != atomScopeModeObject {
 		return ""
 	}
-	if pr.ObjectType == policies.ClientType {
-		return atomObjectKindEntity + ":" + entityKind(KindClient)
-	}
-	switch pr.ObjectType {
+	return atomPolicyObjectType(pr.ObjectType)
+}
+
+// atomPolicyObjectType is shared by the write and read paths so their object types cannot drift apart.
+func atomPolicyObjectType(objectType string) string {
+	switch objectType {
+	case policies.ClientType:
+		return atomObjectType(atomObjectKindEntity, entityKind(KindClient))
 	case policies.ChannelType:
-		return "resource:" + KindChannel
+		return atomObjectType(atomObjectKindResource, KindChannel)
 	case policies.RulesType:
-		return "resource:" + KindRule
+		return atomObjectType(atomObjectKindResource, KindRule)
 	case policies.ReportsType:
-		return "resource:" + KindReport
+		return atomObjectType(atomObjectKindResource, KindReport)
 	case policies.AlarmsType:
-		return "resource:" + KindAlarm
-	case policies.GroupType:
-		return ""
+		return atomObjectType(atomObjectKindResource, KindAlarm)
 	default:
 		return ""
 	}

--- a/pkg/atom/policy_service_test.go
+++ b/pkg/atom/policy_service_test.go
@@ -5,6 +5,7 @@ package atom
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/absmach/magistrala/pkg/policies"
@@ -63,11 +64,26 @@ func (f *fakePolicyClient) CreateDirectPolicy(_ context.Context, policy CreateDi
 
 func (f *fakePolicyClient) ListDirectPolicies(_ context.Context, q DirectPolicyQuery) (DirectPolicyList, error) {
 	f.directPolicyQueries = append(f.directPolicyQueries, q)
-	return DirectPolicyList{Items: f.policies, Total: uint64(len(f.policies))}, nil
+	total := uint64(len(f.policies))
+	start := q.Offset
+	if start > total {
+		start = total
+	}
+	end := total
+	if q.Limit > 0 && start+q.Limit < total {
+		end = start + q.Limit
+	}
+	return DirectPolicyList{Items: f.policies[start:end], Total: total}, nil
 }
 
 func (f *fakePolicyClient) DeleteDirectPolicy(_ context.Context, id string) error {
 	f.deleted = append(f.deleted, id)
+	for i, p := range f.policies {
+		if p.ID == id {
+			f.policies = append(f.policies[:i], f.policies[i+1:]...)
+			break
+		}
+	}
 	return nil
 }
 
@@ -97,7 +113,7 @@ func TestPolicyServiceListAllObjectsUsesAtomAuthorizedObjectIds(t *testing.T) {
 	if query.SubjectID != "user-1" ||
 		query.Action != atomActionRead ||
 		query.ObjectKind != atomObjectKindEntity ||
-		query.ObjectType != entityKind(KindClient) ||
+		query.ObjectType != atomObjectTypeEntityDevice ||
 		query.TenantID != testDomainID {
 		t.Fatalf("unexpected authorized object query: %+v", query)
 	}
@@ -236,5 +252,194 @@ func TestPolicyServiceUnsupportedOperation(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected unsupported operation error")
+	}
+}
+
+func TestPolicyServiceObjectTypeMatchesOnWriteAndReadPaths(t *testing.T) {
+	client := &fakePolicyClient{capID: "cap-read"}
+	svc := NewPolicyService(client)
+
+	writePolicy := policies.Policy{
+		Domain:      testDomainID,
+		Subject:     testDomainID + "_user-1",
+		SubjectType: policies.UserType,
+		Object:      "device-1",
+		ObjectType:  policies.ClientType,
+		Permission:  policies.ViewPermission,
+	}
+	if err := svc.AddPolicy(context.Background(), writePolicy); err != nil {
+		t.Fatalf("add policy failed: %v", err)
+	}
+	if len(client.blocks) != 1 {
+		t.Fatalf("expected one permission block, got %d", len(client.blocks))
+	}
+	writtenObjectType := client.blocks[0].ObjectType
+
+	readPolicy := policies.Policy{
+		Domain:      testDomainID,
+		Subject:     testDomainID + "_user-1",
+		SubjectType: policies.UserType,
+		ObjectType:  policies.ClientType,
+		Permission:  policies.ViewPermission,
+	}
+	if _, err := svc.ListAllObjects(context.Background(), readPolicy); err != nil {
+		t.Fatalf("list objects failed: %v", err)
+	}
+	if len(client.queries) != 1 {
+		t.Fatalf("expected one authorized object query, got %d", len(client.queries))
+	}
+	readObjectType := client.queries[0].ObjectType
+
+	if writtenObjectType != readObjectType {
+		t.Fatalf("write and read object types diverged: write=%q read=%q", writtenObjectType, readObjectType)
+	}
+	if writtenObjectType != "entity:device" {
+		t.Fatalf("expected namespaced object type, got %q", writtenObjectType)
+	}
+}
+
+// namespacedObjectStore simulates Atom storing policy grants keyed by the
+// namespaced object type, only returning matches on an exact match. This
+// exposes the pre-fix bug where the write and read paths disagreed.
+type namespacedObjectStore struct {
+	grantedObjectType string
+	grantedObjectID   string
+}
+
+func (n *namespacedObjectStore) CheckAuthz(context.Context, AuthzRequest) (AuthzResponse, error) {
+	return AuthzResponse{}, nil
+}
+
+func (n *namespacedObjectStore) AuthorizedObjectIDs(_ context.Context, q AuthorizedObjectIDsQuery) (AuthorizedObjectIDs, error) {
+	if q.ObjectType != n.grantedObjectType {
+		return AuthorizedObjectIDs{}, nil
+	}
+	return AuthorizedObjectIDs{IDs: []string{n.grantedObjectID}, Total: 1}, nil
+}
+
+func TestPolicyServiceListAllObjectsFindsObjectScopedDeviceGrant(t *testing.T) {
+	store := &namespacedObjectStore{grantedObjectType: "entity:device", grantedObjectID: "device-1"}
+	svc := NewPolicyService(store)
+
+	page, err := svc.ListAllObjects(context.Background(), policies.Policy{
+		SubjectType: policies.UserType,
+		Subject:     testDomainID + "_user-1",
+		Domain:      testDomainID,
+		ObjectType:  policies.ClientType,
+		Permission:  policies.ViewPermission,
+	})
+	if err != nil {
+		t.Fatalf("list objects failed: %v", err)
+	}
+	if len(page.Policies) != 1 || page.Policies[0] != "device-1" {
+		t.Fatalf("expected object-scoped device grant to be returned, got %+v", page.Policies)
+	}
+}
+
+func TestPolicyServiceDeletePolicyFilterPaginatesAcrossAllMatches(t *testing.T) {
+	const total = 250
+	allPolicies := make([]DirectPolicy, 0, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("policy-%d", i)
+		allPolicies = append(allPolicies, DirectPolicy{
+			ID: id,
+			PermissionBlock: PermissionBlock{
+				ID:         "block-" + id,
+				ScopeMode:  atomScopeModeObject,
+				ObjectKind: atomObjectKindResource,
+				ObjectType: "resource:channel",
+				ObjectID:   "channel-1",
+				Actions:    []Capability{{ID: "cap-subscribe"}},
+			},
+		})
+	}
+	client := &fakePolicyClient{capID: "cap-subscribe", policies: allPolicies}
+	svc := NewPolicyService(client)
+
+	pr := policies.Policy{
+		Domain:      testDomainID,
+		Subject:     testDomainID + "_client-1",
+		SubjectType: policies.ClientType,
+		Object:      "channel-1",
+		ObjectType:  policies.ChannelType,
+		Permission:  policies.SubscribePermission,
+	}
+	if err := svc.DeletePolicyFilter(context.Background(), pr); err != nil {
+		t.Fatalf("delete policy failed: %v", err)
+	}
+
+	if len(client.deleted) != total {
+		t.Fatalf("expected %d deletions, got %d", total, len(client.deleted))
+	}
+	deleted := make(map[string]bool, total)
+	for _, id := range client.deleted {
+		deleted[id] = true
+	}
+	for _, p := range allPolicies {
+		if !deleted[p.ID] {
+			t.Fatalf("policy %s was not deleted", p.ID)
+		}
+	}
+	if len(client.directPolicyQueries) < 3 {
+		t.Fatalf("expected pagination across at least 3 pages, got %d queries", len(client.directPolicyQueries))
+	}
+
+	remaining, err := client.ListDirectPolicies(context.Background(), DirectPolicyQuery{
+		TenantID:    pr.Domain,
+		SubjectKind: policyGrantSubjectKind(pr),
+		SubjectID:   policySubjectID(pr),
+		Limit:       policyPageLimit,
+	})
+	if err != nil {
+		t.Fatalf("re-query after deletion failed: %v", err)
+	}
+	if remaining.Total != 0 || len(remaining.Items) != 0 {
+		t.Fatalf("expected no policies left after deletion, got %+v", remaining)
+	}
+}
+
+func TestIsSupportedObjectList(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   policies.Policy
+		want bool
+	}{
+		{
+			name: "user view on client is supported",
+			pr:   policies.Policy{SubjectType: policies.UserType, Subject: "user-1", ObjectType: policies.ClientType, Permission: policies.ViewPermission},
+			want: true,
+		},
+		{
+			name: "user read on client (entity:device) is supported",
+			pr:   policies.Policy{SubjectType: policies.UserType, Subject: "user-1", ObjectType: policies.ClientType, Permission: atomActionRead},
+			want: true,
+		},
+		{
+			name: "non-user subject is unsupported",
+			pr:   policies.Policy{SubjectType: policies.ClientType, Subject: "client-1", ObjectType: policies.ClientType, Permission: policies.ViewPermission},
+			want: false,
+		},
+		{
+			name: "empty subject is unsupported",
+			pr:   policies.Policy{SubjectType: policies.UserType, Subject: "", ObjectType: policies.ClientType, Permission: policies.ViewPermission},
+			want: false,
+		},
+		{
+			name: "non-client object type is unsupported",
+			pr:   policies.Policy{SubjectType: policies.UserType, Subject: "user-1", ObjectType: policies.ChannelType, Permission: policies.ViewPermission},
+			want: false,
+		},
+		{
+			name: "unsupported permission on client is rejected",
+			pr:   policies.Policy{SubjectType: policies.UserType, Subject: "user-1", ObjectType: policies.ClientType, Permission: policies.EditPermission},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSupportedObjectList(tc.pr); got != tc.want {
+				t.Fatalf("isSupportedObjectList(%+v) = %v, want %v", tc.pr, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`pkg/atom` is the Go client for the `absmach/atom` GraphQL identity/authz service. `PolicyService` isn't wired into any running binary yet, so these are all latent bugs today — but they become live once other work wires reader authorization through this client (device-level read grants in particular). This fixes four defects found in review, plus a small related widening:

- **Object type namespacing mismatch**: the write path (`AddPolicy`) stored grants with Atom's namespaced object type (`entity:device`), but the read path (`ListAllObjects`) queried with the unnamespaced form (`device`). Object-scoped device grants never matched, so `AuthorizedObjectIDs` silently returned nothing. Both paths now route through one `atomPolicyObjectType` mapping so they can't drift apart again. This is an intentional breaking change for any policy block written with the old unnamespaced form — there's no compatibility shim, per the project's no-backcompat stance for this work.
- **`DeletePolicyFilter` silently truncated at 100 policies**: it only inspected the first page of a subject's direct policies, so revoking access for a subject with more than 100 matching policies left the rest in place — a silent security defect. It now collects matching IDs across all pages before deleting.
- **`CapabilityID` couldn't see past the first 100 actions**: it linear-scanned a single page of `actions`. An action registered at position 101+ resolved to a confusing "not found" error. It now paginates the scan and caches resolved name→ID mappings, since capability IDs are immutable once created.
- **No Atom applicability registered for `objectKind: entity`**: `BootstrapMagistralaActions` registered applicability for tenant/group/resource but never entity, even though `fluxmq` already checks `read` on an entity when validating a publisher client. Added read/write/delete/manage applicability for `entity:device`, following the existing registration pattern (Atom dedupes on `action_applicability` server-side via `ON CONFLICT DO NOTHING`, so bootstrap stays idempotent across repeated runs, same as every other entry in that table).
- **`isSupportedObjectList` widened**: it previously admitted only `user + client + view`. Widened to also admit `read` on `entity:device`, needed by upcoming reader-authorization work. Kept as narrow as possible — still rejects other subject/object/permission combinations.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — no unformatted files
- [x] `golangci-lint run ./pkg/atom/... ./fluxmq/...` — 0 issues
- [x] `go test ./pkg/atom/...` — all green, including new tests:
  - write/read object-type parity (byte-for-byte comparison)
  - regression test that fails pre-fix and passes post-fix: an object-scoped read grant on a device is now found by `ListAllObjects`
  - `DeletePolicyFilter` against a fake client with 250 policies across 3 pages — asserts every matching policy is deleted, verified by re-querying afterward
  - `CapabilityID` resolving an action registered beyond the first 100, plus a cache-hit assertion (no further requests on second lookup)
  - `BootstrapMagistralaActions` run twice — no error, no duplicate applicability entries, entity applicability present
  - `isSupportedObjectList` truth table covering the new `read`/`entity:device` case and rejected combinations
- [x] `go test ./...` — full repo green

Out of scope (left untouched, called out explicitly since they're adjacent): wiring `PolicyService` into a running service/binary, group-scoped permission blocks, and `AddPolicy`'s block-per-call shape.