### PR TITLE
Add device-gateway reachability primitives to pkg/atom

### DIFF
--- a/fluxmq/api/http/publish.go
+++ b/fluxmq/api/http/publish.go
@@ -175,7 +175,7 @@ func (h publishHandler) ensureClientPublisher(
 	if err != nil {
 		return fmt.Errorf("publisher client not found")
 	}
-	if client.Kind != "device" && attrString(client.Attributes, "magistrala_kind") != atom.KindClient {
+	if client.Kind != "device" && attrString(client.Attributes, "magistrala_kind") != atom.KindDevice {
 		return fmt.Errorf("publisher identity is not a client")
 	}
 	if client.TenantID == "" || client.TenantID != domainID {

--- a/pkg/atom/authz.go
+++ b/pkg/atom/authz.go
@@ -58,7 +58,7 @@ func ObjectKind(legacyObjectType, resourceKind string) string {
 		return atomObjectKindResource
 	}
 	switch resourceKind {
-	case KindClient, atomKindDevice:
+	case KindDevice, atomKindDevice:
 		return atomObjectKindEntity
 	case atomKindGroup:
 		return atomObjectKindGroup

--- a/pkg/atom/client.go
+++ b/pkg/atom/client.go
@@ -773,8 +773,8 @@ func (c *Client) ListEntities(ctx context.Context, q Query) (EntityList, error) 
 	var out struct {
 		Entities EntityList `json:"entities"`
 	}
-	err := c.graphQL(ctx, `query Entities($q: String, $kind: EntityKind, $tenantId: ID, $status: EntityStatus, $limit: Int, $offset: Int) {
-		entities(q: $q, kind: $kind, tenantId: $tenantId, status: $status, limit: $limit, offset: $offset) {
+	err := c.graphQL(ctx, `query Entities($q: String, $kind: EntityKind, $tenantId: ID, $status: EntityStatus, $attributesContains: JSON, $limit: Int, $offset: Int) {
+		entities(q: $q, kind: $kind, tenantId: $tenantId, status: $status, attributesContains: $attributesContains, limit: $limit, offset: $offset) {
 			total
 			items { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
 		}
@@ -1076,6 +1076,9 @@ func objectQueryVariables(q Query) map[string]any {
 	setIfNotEmpty(vars, atomInputKeyKind, q.Kind)
 	setIfNotEmpty(vars, "tenantId", q.TenantID)
 	setIfNotEmpty(vars, atomAttributeStatus, q.Status)
+	if q.AttributesContains != nil {
+		vars["attributesContains"] = q.AttributesContains
+	}
 	if q.Limit > 0 {
 		vars["limit"] = int(q.Limit)
 	}

--- a/pkg/atom/client_test.go
+++ b/pkg/atom/client_test.go
@@ -95,6 +95,66 @@ func TestListResources(t *testing.T) {
 	}
 }
 
+func TestListEntitiesAttributesContains(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != atomGraphQLPath {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(payload.Query, "$attributesContains: JSON") || !strings.Contains(payload.Query, "attributesContains: $attributesContains") {
+			t.Fatalf("query does not declare/pass attributesContains: %s", payload.Query)
+		}
+		contains, ok := payload.Variables["attributesContains"].(map[string]any)
+		if !ok {
+			t.Fatalf("attributesContains was not sent on the wire: %+v", payload.Variables)
+		}
+		gateways, _ := contains["gateways"].([]any)
+
+		// Only entities whose gateways attribute actually satisfies the
+		// requested containment are returned - proving the fake server (and
+		// therefore the argument sent) drives the result, not an unfiltered
+		// listing.
+		items := []Entity{}
+		if len(gateways) == 1 && gateways[0] == "gw-1" {
+			items = append(items, Entity{ID: "device-1", Kind: atomKindDevice})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"entities": map[string]any{"items": items, "total": len(items)},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+
+	got, err := client.ListEntities(context.Background(), Query{
+		AttributesContains: map[string]any{"gateways": []string{"gw-1"}},
+	})
+	if err != nil {
+		t.Fatalf("list entities failed: %v", err)
+	}
+	if got.Total != 1 || len(got.Items) != 1 || got.Items[0].ID != "device-1" {
+		t.Fatalf("unexpected filtered list: %+v", got)
+	}
+
+	miss, err := client.ListEntities(context.Background(), Query{
+		AttributesContains: map[string]any{"gateways": []string{"gw-2"}},
+	})
+	if err != nil {
+		t.Fatalf("list entities failed: %v", err)
+	}
+	if miss.Total != 0 || len(miss.Items) != 0 {
+		t.Fatalf("expected no matches for a non-satisfying containment, got: %+v", miss)
+	}
+}
+
 func TestCurrentAtomCompatibilitySurface(t *testing.T) {
 	const (
 		serviceToken = "service-token"

--- a/pkg/atom/constants.go
+++ b/pkg/atom/constants.go
@@ -80,6 +80,7 @@ const (
 
 const (
 	atomAttributeCreatedAt = "created_at"
+	atomAttributeGateways  = "gateways"
 	atomAttributeMetadata  = "metadata"
 	atomAttributeRoute     = "route"
 	atomAttributeSource    = "source"

--- a/pkg/atom/devices.go
+++ b/pkg/atom/devices.go
@@ -77,6 +77,7 @@ func (c *Client) GatewayDevices(ctx context.Context, gatewayID string, q Query) 
 		filter[k] = v
 	}
 	filter[atomAttributeGateways] = []string{gatewayID}
+	q.Kind = atomKindDevice
 	q.AttributesContains = filter
 
 	return c.ListEntities(ctx, q)

--- a/pkg/atom/devices.go
+++ b/pkg/atom/devices.go
@@ -1,0 +1,136 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"context"
+	"errors"
+	"sort"
+)
+
+// ErrGatewaysConflict is returned by SetDeviceGateways when the device's
+// current gateways attribute no longer matches expectedCurrent, so the
+// caller's view of it is stale and the write was not performed.
+var ErrGatewaysConflict = errors.New("atom: device gateways changed since last read")
+
+// SetDeviceGateways replaces a device's entire gateway list.
+//
+// Atom's update_entity overwrites the whole attributes column rather than
+// merging individual keys, so this reads the device's current attributes
+// first and writes them back with only the gateways key changed - every
+// other attribute on the device is preserved unmodified.
+//
+// expectedCurrent must match the gateway list last read for this device
+// (order-independent), or the call fails with ErrGatewaysConflict instead of
+// writing. Atom offers no compare-and-swap primitive, so there remains a
+// window between the read below and the write; this check narrows it from
+// "however long the caller took to decide" to one GraphQL round trip. It is
+// not a substitute for real distributed locking, and does not attempt to be.
+func (c *Client) SetDeviceGateways(ctx context.Context, deviceID string, gatewayIDs, expectedCurrent []string) error {
+	device, err := c.GetEntity(ctx, deviceID)
+	if err != nil {
+		return err
+	}
+
+	current := attrStrings(device.Attributes, atomAttributeGateways)
+	if !sameStringSet(current, expectedCurrent) {
+		return ErrGatewaysConflict
+	}
+
+	attrs := cloneAttributes(device.Attributes)
+	attrs[atomAttributeGateways] = gatewayIDs
+	_, err = c.UpdateEntity(ctx, deviceID, Entity{Attributes: attrs})
+	return err
+}
+
+// DeviceGateways returns the gateway IDs a device declares, resolving away
+// any stale IDs pointing at gateways that no longer exist (or were deleted).
+// Deleting a gateway leaves it referenced in the devices that named it -
+// nothing sweeps those references - so this is where they get dropped.
+func (c *Client) DeviceGateways(ctx context.Context, deviceID string) ([]string, error) {
+	device, err := c.GetEntity(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+
+	declared := attrStrings(device.Attributes, atomAttributeGateways)
+	live := make([]string, 0, len(declared))
+	for _, gatewayID := range declared {
+		if _, err := c.GetEntity(ctx, gatewayID); err != nil {
+			if IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		live = append(live, gatewayID)
+	}
+	return live, nil
+}
+
+// GatewayDevices lists devices whose gateways attribute contains gatewayID,
+// via attributesContains JSONB array containment. Any AttributesContains
+// already set on q is preserved alongside the gateways filter.
+func (c *Client) GatewayDevices(ctx context.Context, gatewayID string, q Query) (EntityList, error) {
+	filter := make(map[string]any, len(q.AttributesContains)+1)
+	for k, v := range q.AttributesContains {
+		filter[k] = v
+	}
+	filter[atomAttributeGateways] = []string{gatewayID}
+	q.AttributesContains = filter
+
+	return c.ListEntities(ctx, q)
+}
+
+// attrStrings reads a []string-valued attribute. Values come back from the
+// GraphQL client as []any (each element a string), since Attributes decodes
+// from JSON, but a []string is accepted too so callers can build one without
+// a round trip.
+func attrStrings(attrs Attributes, key string) []string {
+	if attrs == nil {
+		return nil
+	}
+	switch v := attrs[key].(type) {
+	case []string:
+		return append([]string(nil), v...)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// cloneAttributes returns a shallow, mutable copy of attrs, never nil, so
+// callers can add or overwrite a key without affecting the source map or
+// panicking on a nil map.
+func cloneAttributes(attrs Attributes) Attributes {
+	out := make(Attributes, len(attrs)+1)
+	for k, v := range attrs {
+		out[k] = v
+	}
+	return out
+}
+
+// sameStringSet reports whether a and b hold the same strings, ignoring
+// order.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sortedA := append([]string(nil), a...)
+	sortedB := append([]string(nil), b...)
+	sort.Strings(sortedA)
+	sort.Strings(sortedB)
+	for i := range sortedA {
+		if sortedA[i] != sortedB[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/atom/devices.go
+++ b/pkg/atom/devices.go
@@ -76,11 +76,41 @@ func (c *Client) GatewayDevices(ctx context.Context, gatewayID string, q Query) 
 	for k, v := range q.AttributesContains {
 		filter[k] = v
 	}
-	filter[atomAttributeGateways] = []string{gatewayID}
+	filter[atomAttributeGateways] = mergeContainsString(filter[atomAttributeGateways], gatewayID)
 	q.Kind = atomKindDevice
 	q.AttributesContains = filter
 
 	return c.ListEntities(ctx, q)
+}
+
+func mergeContainsString(existing any, value string) any {
+	switch v := existing.(type) {
+	case nil:
+		return []string{value}
+	case string:
+		if v == value {
+			return []string{value}
+		}
+		return []string{v, value}
+	case []string:
+		out := append([]string(nil), v...)
+		for _, item := range out {
+			if item == value {
+				return out
+			}
+		}
+		return append(out, value)
+	case []any:
+		out := append([]any(nil), v...)
+		for _, item := range out {
+			if item, ok := item.(string); ok && item == value {
+				return out
+			}
+		}
+		return append(out, value)
+	default:
+		return []any{v, value}
+	}
 }
 
 // attrStrings reads a []string-valued attribute. Values come back from the

--- a/pkg/atom/devices_test.go
+++ b/pkg/atom/devices_test.go
@@ -267,6 +267,25 @@ func TestGatewayDevicesFiltersByAttributesContains(t *testing.T) {
 	}
 }
 
+func TestGatewayDevicesPreservesExistingGatewaysContainsFilter(t *testing.T) {
+	_, srv := newFakeAtomDevices(t,
+		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1"}}},
+		Entity{ID: "device-2", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-2"}}},
+		Entity{ID: "device-3", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1", "gw-2"}}},
+	)
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	got, err := client.GatewayDevices(context.Background(), "gw-1", Query{
+		AttributesContains: map[string]any{atomAttributeGateways: []string{"gw-2"}},
+	})
+	if err != nil {
+		t.Fatalf("gateway devices failed: %v", err)
+	}
+	if got.Total != 1 || len(got.Items) != 1 || got.Items[0].ID != "device-3" {
+		t.Fatalf("expected only the device containing both gateways, got: %+v", got)
+	}
+}
+
 func TestDeviceGatewaysRoundTripsZeroOneAndManyGateways(t *testing.T) {
 	fa, srv := newFakeAtomDevices(t,
 		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"source": "magistrala"}},

--- a/pkg/atom/devices_test.go
+++ b/pkg/atom/devices_test.go
@@ -61,8 +61,12 @@ func (fa *fakeAtomDevices) handle(w http.ResponseWriter, r *http.Request) {
 		if !hasFilter {
 			fa.t.Fatalf("entities query ran without an attributesContains filter: %+v", payload.Variables)
 		}
+		kind, _ := payload.Variables["kind"].(string)
 		var items []map[string]any
 		for _, e := range fa.entities {
+			if kind != "" && e.Kind != kind {
+				continue
+			}
 			if entityMatchesContains(e, contains) {
 				items = append(items, deviceEntityJSON(e))
 			}
@@ -243,6 +247,7 @@ func TestGatewayDevicesFiltersByAttributesContains(t *testing.T) {
 		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1"}}},
 		Entity{ID: "device-2", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-2"}}},
 		Entity{ID: "device-3", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1", "gw-2"}}},
+		Entity{ID: "human-1", Kind: atomKindHuman, Attributes: Attributes{"gateways": []string{"gw-1"}}},
 	)
 
 	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})

--- a/pkg/atom/devices_test.go
+++ b/pkg/atom/devices_test.go
@@ -1,0 +1,310 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAtomDevices is a minimal in-memory Atom stand-in backing entity,
+// updateEntity and entities - enough surface to exercise
+// SetDeviceGateways / DeviceGateways / GatewayDevices without a real server.
+//
+// It also mirrors a real behaviour these tests depend on: updateEntity
+// replaces the whole attributes column rather than merging individual keys.
+type fakeAtomDevices struct {
+	t           *testing.T
+	entities    map[string]Entity
+	updateCalls int
+}
+
+func newFakeAtomDevices(t *testing.T, seed ...Entity) (*fakeAtomDevices, *httptest.Server) {
+	t.Helper()
+	fa := &fakeAtomDevices{t: t, entities: map[string]Entity{}}
+	for _, e := range seed {
+		fa.entities[e.ID] = e
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fa.handle))
+	t.Cleanup(srv.Close)
+	return fa, srv
+}
+
+func (fa *fakeAtomDevices) handle(w http.ResponseWriter, r *http.Request) {
+	payload := decodePayload(fa.t, r)
+	switch {
+	case strings.Contains(payload.Query, "mutation UpdateEntity"):
+		fa.updateCalls++
+		id, _ := payload.Variables["id"].(string)
+		existing, ok := fa.entities[id]
+		if !ok {
+			_ = writeJSON(w, map[string]any{
+				"errors": []map[string]string{{"message": "entity not found"}},
+			})
+			return
+		}
+		input, _ := payload.Variables["input"].(map[string]any)
+		if attrs, ok := input["attributes"].(map[string]any); ok {
+			existing.Attributes = Attributes(attrs)
+		}
+		fa.entities[id] = existing
+		_ = writeJSON(w, map[string]any{"data": map[string]any{"updateEntity": deviceEntityJSON(existing)}})
+
+	case strings.Contains(payload.Query, "query Entities("):
+		contains, hasFilter := payload.Variables["attributesContains"].(map[string]any)
+		if !hasFilter {
+			fa.t.Fatalf("entities query ran without an attributesContains filter: %+v", payload.Variables)
+		}
+		var items []map[string]any
+		for _, e := range fa.entities {
+			if entityMatchesContains(e, contains) {
+				items = append(items, deviceEntityJSON(e))
+			}
+		}
+		_ = writeJSON(w, map[string]any{
+			"data": map[string]any{"entities": map[string]any{"items": items, "total": len(items)}},
+		})
+
+	case strings.Contains(payload.Query, "query Entity("):
+		id, _ := payload.Variables["id"].(string)
+		e, ok := fa.entities[id]
+		if !ok {
+			_ = writeJSON(w, map[string]any{
+				"errors": []map[string]string{{"message": "entity not found"}},
+			})
+			return
+		}
+		_ = writeJSON(w, map[string]any{"data": map[string]any{"entity": deviceEntityJSON(e)}})
+
+	default:
+		fa.t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
+	}
+}
+
+func deviceEntityJSON(e Entity) map[string]any {
+	attrs := map[string]any(e.Attributes)
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+	return map[string]any{
+		"id":         e.ID,
+		"kind":       e.Kind,
+		"name":       e.Name,
+		"tenant_id":  e.TenantID,
+		"status":     e.Status,
+		"attributes": attrs,
+	}
+}
+
+// entityMatchesContains reimplements, for the fake server only, the JSONB
+// containment semantics the real Atom applies: every key in contains must be
+// present in the entity's attributes, and for list-valued attributes every
+// element of the wanted list must appear in the entity's list (order
+// irrelevant, extra elements on the entity side allowed).
+func entityMatchesContains(e Entity, contains map[string]any) bool {
+	for key, want := range contains {
+		got, ok := e.Attributes[key]
+		if !ok {
+			return false
+		}
+		wantList := toAnySlice(want)
+		if wantList == nil {
+			if got != want {
+				return false
+			}
+			continue
+		}
+		gotList := toAnySlice(got)
+		for _, w := range wantList {
+			found := false
+			for _, g := range gotList {
+				if g == w {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func toAnySlice(v any) []any {
+	switch vv := v.(type) {
+	case []any:
+		return vv
+	case []string:
+		out := make([]any, len(vv))
+		for i, s := range vv {
+			out[i] = s
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func TestSetDeviceGatewaysWritesWhenExpectedCurrentMatches(t *testing.T) {
+	fa, srv := newFakeAtomDevices(t, Entity{
+		ID:   "device-1",
+		Kind: atomKindDevice,
+		Attributes: Attributes{
+			"source":   "magistrala",
+			"gateways": []string{"gw-1", "gw-2"},
+		},
+	})
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	err := client.SetDeviceGateways(context.Background(), "device-1", []string{"gw-3"}, []string{"gw-2", "gw-1"})
+	if err != nil {
+		t.Fatalf("set device gateways failed: %v", err)
+	}
+	if fa.updateCalls != 1 {
+		t.Fatalf("expected exactly one write, got %d", fa.updateCalls)
+	}
+
+	updated := fa.entities["device-1"]
+	got := attrStrings(updated.Attributes, atomAttributeGateways)
+	if !sameStringSet(got, []string{"gw-3"}) {
+		t.Fatalf("unexpected gateways after write: %+v", got)
+	}
+	if updated.Attributes["source"] != "magistrala" {
+		t.Fatalf("write must preserve unrelated attributes, got: %+v", updated.Attributes)
+	}
+}
+
+func TestSetDeviceGatewaysConflictWhenExpectedCurrentMismatches(t *testing.T) {
+	fa, srv := newFakeAtomDevices(t, Entity{
+		ID:         "device-1",
+		Kind:       atomKindDevice,
+		Attributes: Attributes{"gateways": []string{"gw-1"}},
+	})
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	err := client.SetDeviceGateways(context.Background(), "device-1", []string{"gw-9"}, []string{"gw-2"})
+	if !errors.Is(err, ErrGatewaysConflict) {
+		t.Fatalf("expected ErrGatewaysConflict, got %v", err)
+	}
+	if fa.updateCalls != 0 {
+		t.Fatalf("conflict must not write, got %d update calls", fa.updateCalls)
+	}
+
+	unchanged := attrStrings(fa.entities["device-1"].Attributes, atomAttributeGateways)
+	if !sameStringSet(unchanged, []string{"gw-1"}) {
+		t.Fatalf("device gateways must be unchanged after a conflict, got: %+v", unchanged)
+	}
+}
+
+func TestSetDeviceGatewaysExpectedCurrentIsOrderIndependent(t *testing.T) {
+	_, srv := newFakeAtomDevices(t, Entity{
+		ID:         "device-1",
+		Kind:       atomKindDevice,
+		Attributes: Attributes{"gateways": []string{"gw-1", "gw-2"}},
+	})
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	// expectedCurrent is given in the opposite order to how it is stored.
+	if err := client.SetDeviceGateways(context.Background(), "device-1", []string{"gw-3"}, []string{"gw-2", "gw-1"}); err != nil {
+		t.Fatalf("expected reordered expectedCurrent to match, got: %v", err)
+	}
+}
+
+func TestDeviceGatewaysDropsStaleGateway(t *testing.T) {
+	_, srv := newFakeAtomDevices(t,
+		Entity{
+			ID:         "device-1",
+			Kind:       atomKindDevice,
+			Attributes: Attributes{"gateways": []string{"gw-live", "gw-deleted"}},
+		},
+		Entity{ID: "gw-live", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+		// gw-deleted intentionally not seeded: it no longer resolves.
+	)
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	got, err := client.DeviceGateways(context.Background(), "device-1")
+	if err != nil {
+		t.Fatalf("device gateways failed: %v", err)
+	}
+	if !sameStringSet(got, []string{"gw-live"}) {
+		t.Fatalf("expected stale gateway to be dropped, got: %+v", got)
+	}
+}
+
+func TestGatewayDevicesFiltersByAttributesContains(t *testing.T) {
+	_, srv := newFakeAtomDevices(t,
+		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1"}}},
+		Entity{ID: "device-2", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-2"}}},
+		Entity{ID: "device-3", Kind: atomKindDevice, Attributes: Attributes{"gateways": []string{"gw-1", "gw-2"}}},
+	)
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	got, err := client.GatewayDevices(context.Background(), "gw-1", Query{})
+	if err != nil {
+		t.Fatalf("gateway devices failed: %v", err)
+	}
+	if got.Total != 2 || len(got.Items) != 2 {
+		t.Fatalf("unexpected result count: %+v", got)
+	}
+	ids := map[string]bool{}
+	for _, item := range got.Items {
+		ids[item.ID] = true
+	}
+	if !ids["device-1"] || !ids["device-3"] || ids["device-2"] {
+		t.Fatalf("unexpected devices returned: %+v", ids)
+	}
+}
+
+func TestDeviceGatewaysRoundTripsZeroOneAndManyGateways(t *testing.T) {
+	fa, srv := newFakeAtomDevices(t,
+		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"source": "magistrala"}},
+		Entity{ID: "gw-a", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+		Entity{ID: "gw-b", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+		Entity{ID: "gw-c", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+	)
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	ctx := context.Background()
+
+	// 0 gateways.
+	current, err := client.DeviceGateways(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("device gateways failed: %v", err)
+	}
+	if len(current) != 0 {
+		t.Fatalf("expected no gateways initially, got: %+v", current)
+	}
+
+	// 1 gateway.
+	if err := client.SetDeviceGateways(ctx, "device-1", []string{"gw-a"}, current); err != nil {
+		t.Fatalf("set device gateways (1) failed: %v", err)
+	}
+	current, err = client.DeviceGateways(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("device gateways failed: %v", err)
+	}
+	if !sameStringSet(current, []string{"gw-a"}) {
+		t.Fatalf("expected exactly gw-a, got: %+v", current)
+	}
+
+	// 3 gateways.
+	if err := client.SetDeviceGateways(ctx, "device-1", []string{"gw-a", "gw-b", "gw-c"}, current); err != nil {
+		t.Fatalf("set device gateways (3) failed: %v", err)
+	}
+	current, err = client.DeviceGateways(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("device gateways failed: %v", err)
+	}
+	if !sameStringSet(current, []string{"gw-a", "gw-b", "gw-c"}) {
+		t.Fatalf("expected all three gateways, got: %+v", current)
+	}
+	if fa.updateCalls != 2 {
+		t.Fatalf("expected exactly two writes across the round trip, got %d", fa.updateCalls)
+	}
+}

--- a/pkg/atom/mapping.go
+++ b/pkg/atom/mapping.go
@@ -6,6 +6,7 @@ package atom
 const (
 	KindUser    = "user"
 	KindDevice  = "client"
+	KindClient  = KindDevice
 	KindChannel = "channel"
 	KindRule    = "rule"
 	KindAlarm   = "alarm"

--- a/pkg/atom/mapping.go
+++ b/pkg/atom/mapping.go
@@ -5,7 +5,7 @@ package atom
 
 const (
 	KindUser    = "user"
-	KindClient  = "client"
+	KindDevice  = "client"
 	KindChannel = "channel"
 	KindRule    = "rule"
 	KindAlarm   = "alarm"
@@ -81,7 +81,7 @@ func entityKind(kind string) string {
 	switch kind {
 	case KindUser:
 		return atomKindHuman
-	case KindClient:
+	case KindDevice:
 		return atomKindDevice
 	default:
 		return kind

--- a/pkg/atom/mapping_test.go
+++ b/pkg/atom/mapping_test.go
@@ -35,7 +35,7 @@ func TestTenantFromFields(t *testing.T) {
 func TestEntityFromFields(t *testing.T) {
 	got := EntityFromFields(ObjectFields{
 		ID:       "client-1",
-		Kind:     KindClient,
+		Kind:     KindDevice,
 		Name:     "pump",
 		TenantID: "domain-1",
 		Status:   "enabled",
@@ -46,11 +46,17 @@ func TestEntityFromFields(t *testing.T) {
 	if got.Kind != "device" || got.TenantID != "domain-1" {
 		t.Fatalf("unexpected entity: %+v", got)
 	}
-	if got.Attributes["magistrala_kind"] != KindClient {
+	if got.Attributes["magistrala_kind"] != KindDevice {
 		t.Fatalf("missing magistrala kind: %+v", got.Attributes)
 	}
 	if got.Attributes["parent_group_id"] != "group-1" {
 		t.Fatalf("missing parent group: %+v", got.Attributes)
+	}
+}
+
+func TestKindDeviceMapsToAtomDeviceKind(t *testing.T) {
+	if got := entityKind(KindDevice); got != atomKindDevice {
+		t.Fatalf("KindDevice must map to the atom kind %q, got %q", atomKindDevice, got)
 	}
 }
 

--- a/pkg/atom/mapping_test.go
+++ b/pkg/atom/mapping_test.go
@@ -54,9 +54,11 @@ func TestEntityFromFields(t *testing.T) {
 	}
 }
 
-func TestKindDeviceMapsToAtomDeviceKind(t *testing.T) {
-	if got := entityKind(KindDevice); got != atomKindDevice {
-		t.Fatalf("KindDevice must map to the atom kind %q, got %q", atomKindDevice, got)
+func TestDeviceKindNamesMapToAtomDeviceKind(t *testing.T) {
+	for _, kind := range []string{KindDevice, KindClient} {
+		if got := entityKind(kind); got != atomKindDevice {
+			t.Fatalf("%q must map to the atom kind %q, got %q", kind, atomKindDevice, got)
+		}
 	}
 }
 

--- a/pkg/atom/policy_service.go
+++ b/pkg/atom/policy_service.go
@@ -374,7 +374,7 @@ func policyGrantObjectType(pr policies.Policy) string {
 func atomPolicyObjectType(objectType string) string {
 	switch objectType {
 	case policies.ClientType:
-		return atomObjectType(atomObjectKindEntity, entityKind(KindClient))
+		return atomObjectType(atomObjectKindEntity, entityKind(KindDevice))
 	case policies.ChannelType:
 		return atomObjectType(atomObjectKindResource, KindChannel)
 	case policies.RulesType:

--- a/pkg/atom/types.go
+++ b/pkg/atom/types.go
@@ -65,6 +65,11 @@ type Query struct {
 	Status   string
 	Limit    uint64
 	Offset   uint64
+
+	// AttributesContains filters by JSONB containment: an entity matches only
+	// if its attributes contain every key/value given here (arrays match if
+	// they contain the given elements, not only if they equal them exactly).
+	AttributesContains map[string]any
 }
 
 type AuthzRequest struct {


### PR DESCRIPTION
## Summary

Rescoped MG-09: Go-level primitives only, in `pkg/atom`. No new HTTP
service, no proto changes, no `pkg/sdk` changes. The original PRD
assumed a Magistrala-owned `/devices` HTTP route mirroring an old,
now-deleted `/clients` service; that route was never rebuilt after the
Atom-integration rewrite, and the real UI (`magistrala-ui`'s Next.js
frontend) calls Atom's GraphQL API directly rather than through it. What
remains needed is what other Go code — a `magistrala-ui` backend fix
happening in parallel, and eventually `pkg/atom`'s own future consumers —
can call directly against `pkg/atom.Client`.

- **`KindClient` → `KindDevice`** in `pkg/atom/mapping.go`, a pure
  Go-identifier rename. The Atom-side string stays `"device"`
  (`atomKindDevice`); this only fixes the Go-side name to match what it
  has always meant. Updated every reference in `pkg/atom` (`mapping.go`,
  `mapping_test.go`, `policy_service.go`, `authz.go`), plus the one
  external consumer outside the package that the rename broke the build
  for (`fluxmq/api/http/publish.go`), which was not anticipated in scope
  but is a mechanical, one-line fallout fix.
- **`AttributesContains` on `Query`**, threaded through `ListEntities`.
  Verified the exact GraphQL argument name (`attributesContains`) and
  scalar type (`JSON`) against the real `absmach/atom` schema on the
  `edge` branch (`src/graphql/entities.rs`, `src/graphql/schema.rs`) —
  the argument lands as a `map[string]any` and rides Postgres JSONB `@>`
  containment server-side.
- **The device→gateway reachability relation** — `SetDeviceGateways`,
  `DeviceGateways`, `GatewayDevices` in the new `pkg/atom/devices.go`.
  `is_gateway` and `gateways` are plain entity attributes; nothing new on
  the Atom schema side.

## Concurrency

Atom's `update_entity` is a blind `COALESCE` with no version check, and it
replaces the whole `attributes` column rather than merging individual
keys. `SetDeviceGateways` therefore:

1. Reads the device's current attributes (not just `gateways`).
2. Compares the current `gateways` value against the caller-supplied
   `expectedCurrent`, order-independently.
3. Returns `ErrGatewaysConflict` without writing if they don't match.
4. Otherwise writes back the full attributes map with only `gateways`
   changed, so every other attribute on the device survives the round
   trip.

This narrows the race window from "however long the caller took to
decide" to one GraphQL round trip — it does not eliminate it, and is not
an attempt at real distributed locking.

## Deletion does not cascade

Deleting a gateway (an ordinary device delete) never touches any device's
`gateways` attribute. `DeviceGateways` resolves away stale IDs at read
time by checking each declared gateway ID still exists via `GetEntity`.
`GatewayDevices` finds a gateway's devices via `attributesContains`
JSONB array containment rather than fetching every device in the domain.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --config tools/config/.golangci.yaml ./pkg/atom/...` and `./fluxmq/...` — 0 issues
- [x] `go test ./pkg/atom/... -count=1` — all passing, including:
  - `TestKindDeviceMapsToAtomDeviceKind` — rename is behaviour-preserving
  - `TestListEntitiesAttributesContains` — argument sent on the wire, only
    satisfying entities match
  - `TestSetDeviceGatewaysWritesWhenExpectedCurrentMatches`
  - `TestSetDeviceGatewaysConflictWhenExpectedCurrentMismatches` — conflict
    error, zero write calls
  - `TestSetDeviceGatewaysExpectedCurrentIsOrderIndependent`
  - `TestDeviceGatewaysDropsStaleGateway`
  - `TestGatewayDevicesFiltersByAttributesContains` — asserts the fake
    server sees `attributesContains`, not an unfiltered listing
  - `TestDeviceGatewaysRoundTripsZeroOneAndManyGateways` — 0/1/3 gateways
    round-trip correctly