### PR TITLE
Fix pkg/atom group membership methods to use object-group mutations

### DIFF
--- a/pkg/atom/client.go
+++ b/pkg/atom/client.go
@@ -208,44 +208,104 @@ func (c *Client) UpdateGroup(ctx context.Context, id string, group Group) (Group
 	return out.UpdateGroup, err
 }
 
-// AddGroupMember adds an entity to a group. Membership is many-to-many and
-// additive: an entity already in other groups keeps those memberships, and
-// adding it to a group it already belongs to is a no-op.
+// AddGroupMember adds an entity to an object group (a group of
+// devices/channels). Membership is many-to-many and additive: an entity
+// already in other groups keeps those memberships, and adding it to a group
+// it already belongs to is a no-op.
+//
+// This method's name matches Atom's older, pre-existing addGroupMember
+// GraphQL mutation in spelling only. That mutation, along with
+// removeGroupMember/groupMembers/entityGroups, operates on
+// principal_groups/principal_group_members — Atom's tables for user/team
+// group membership — and is not what AddGroupMember calls. AddGroupMember
+// instead sends addEntityToObjectGroup, the mutation Atom purpose-built for
+// many-to-many object-group membership (backed by the object_group_entities
+// table), introduced alongside many-to-many object group support. That
+// mutation returns the updated Entity rather than a Boolean, but this method
+// only needs to know whether the call succeeded, so the response body is
+// discarded.
 func (c *Client) AddGroupMember(ctx context.Context, groupID, entityID string) error {
-	return c.graphQL(ctx, `mutation AddGroupMember($groupId: ID!, $entityId: ID!) {
-		addGroupMember(groupId: $groupId, entityId: $entityId)
-	}`, map[string]any{atomInputKeyGroupID: groupID, atomInputKeyEntityID: entityID}, nil)
+	return c.graphQL(ctx, `mutation AddEntityToObjectGroup($entityId: ID!, $objectGroupId: ID!) {
+		addEntityToObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) { id }
+	}`, map[string]any{atomInputKeyEntityID: entityID, atomInputKeyObjectGroupID: groupID}, nil)
 }
 
-// RemoveGroupMember removes membership in this group only; the entity may
-// still be reachable through other group memberships it holds.
+// RemoveGroupMember removes membership in this object group only; the entity
+// may still be reachable through other group memberships it holds.
+//
+// Like AddGroupMember, this method's name matches Atom's older
+// removeGroupMember GraphQL mutation in spelling only; that mutation targets
+// principal_groups membership, not object groups. RemoveGroupMember sends
+// removeEntityFromObjectGroup, the object-group counterpart.
 func (c *Client) RemoveGroupMember(ctx context.Context, groupID, entityID string) error {
-	return c.graphQL(ctx, `mutation RemoveGroupMember($groupId: ID!, $entityId: ID!) {
-		removeGroupMember(groupId: $groupId, entityId: $entityId)
-	}`, map[string]any{atomInputKeyGroupID: groupID, atomInputKeyEntityID: entityID}, nil)
+	return c.graphQL(ctx, `mutation RemoveEntityFromObjectGroup($entityId: ID!, $objectGroupId: ID!) {
+		removeEntityFromObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) { id }
+	}`, map[string]any{atomInputKeyEntityID: entityID, atomInputKeyObjectGroupID: groupID}, nil)
 }
 
-// GroupMembers lists the entities currently in a group.
+// groupMembersPageLimit caps each page GroupMembers requests from the
+// entities query. It matches the maximum page size Atom's entities query
+// enforces server-side, so a single page already covers the common case;
+// GroupMembers pages through offsets internally so a group with more members
+// than that still comes back complete in one call.
+const groupMembersPageLimit = 100
+
+// GroupMembers lists the entities currently in an object group.
+//
+// Unlike AddGroupMember/RemoveGroupMember, there is no purpose-built
+// "groupMembers" query on the object-group side, and the old groupMembers
+// query this method used to call is the principal-group one and returns the
+// wrong entities entirely. The correct way to list an object group's members
+// is the existing entities(parentGroupId: ...) query: despite its name,
+// parentGroupId filters by many-to-many object-group membership (via the
+// object_group_entities table), not a single-parent relationship, so it
+// already returns exactly what this method needs.
 func (c *Client) GroupMembers(ctx context.Context, groupID string) ([]Entity, error) {
-	var out struct {
-		GroupMembers []Entity `json:"groupMembers"`
+	var members []Entity
+	for offset := 0; ; offset += groupMembersPageLimit {
+		var out struct {
+			Entities EntityList `json:"entities"`
+		}
+		err := c.graphQL(ctx, `query GroupMembers($parentGroupId: ID!, $limit: Int, $offset: Int) {
+			entities(parentGroupId: $parentGroupId, limit: $limit, offset: $offset) {
+				total
+				items { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+			}
+		}`, map[string]any{
+			atomInputKeyParentGroupID: groupID,
+			"limit":                   groupMembersPageLimit,
+			"offset":                  offset,
+		}, &out)
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, out.Entities.Items...)
+		if len(out.Entities.Items) < groupMembersPageLimit || uint64(offset+len(out.Entities.Items)) >= out.Entities.Total {
+			break
+		}
 	}
-	err := c.graphQL(ctx, `query GroupMembers($groupId: ID!) {
-		groupMembers(groupId: $groupId) { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
-	}`, map[string]any{atomInputKeyGroupID: groupID}, &out)
-	return out.GroupMembers, err
+	return members, nil
 }
 
-// EntityGroups returns every group the entity belongs to. Membership is
-// many-to-many, so an entity can appear in more than one group at once.
+// EntityGroups returns every object group the entity belongs to. Membership
+// is many-to-many, so an entity can appear in more than one group at once.
+//
+// Like GroupMembers, there is no purpose-built "entityGroups" query on the
+// object-group side, and the old entityGroups query this method used to call
+// is the principal-group one. An entity's object-group memberships are
+// instead exposed as the objectGroupIds field on the entity itself, so this
+// method queries entity(id: ...) { objectGroupIds } rather than a top-level
+// query.
 func (c *Client) EntityGroups(ctx context.Context, entityID string) ([]string, error) {
 	var out struct {
-		EntityGroups []string `json:"entityGroups"`
+		Entity struct {
+			ObjectGroupIDs []string `json:"objectGroupIds"`
+		} `json:"entity"`
 	}
-	err := c.graphQL(ctx, `query EntityGroups($entityId: ID!) {
-		entityGroups(entityId: $entityId)
-	}`, map[string]any{atomInputKeyEntityID: entityID}, &out)
-	return out.EntityGroups, err
+	err := c.graphQL(ctx, `query EntityObjectGroups($id: ID!) {
+		entity(id: $id) { objectGroupIds }
+	}`, map[string]any{"id": entityID}, &out)
+	return out.Entity.ObjectGroupIDs, err
 }
 
 // SetGroupParent nests a group under a parent, replacing any existing parent.

--- a/pkg/atom/constants.go
+++ b/pkg/atom/constants.go
@@ -61,16 +61,17 @@ const (
 const atomDecisionAllow = "allow"
 
 const (
-	atomInputKeyAction       = "action"
-	atomInputKeyCredentialID = "credentialId"
-	atomInputKeyEntityID     = "entityId"
-	atomInputKeyGroupID      = "groupId"
-	atomInputKeyInput        = "input"
-	atomInputKeyKind         = "kind"
-	atomInputKeyName         = "name"
-	atomInputKeyObjectKind   = "objectKind"
-	atomInputKeyParentID     = "parentId"
-	atomInputKeySubjectID    = "subjectId"
+	atomInputKeyAction        = "action"
+	atomInputKeyCredentialID  = "credentialId"
+	atomInputKeyEntityID      = "entityId"
+	atomInputKeyInput         = "input"
+	atomInputKeyKind          = "kind"
+	atomInputKeyName          = "name"
+	atomInputKeyObjectGroupID = "objectGroupId"
+	atomInputKeyObjectKind    = "objectKind"
+	atomInputKeyParentGroupID = "parentGroupId"
+	atomInputKeyParentID      = "parentId"
+	atomInputKeySubjectID     = "subjectId"
 )
 
 const (

--- a/pkg/atom/group_grant_test.go
+++ b/pkg/atom/group_grant_test.go
@@ -70,6 +70,7 @@ func (a *groupGrantAtom) server(t *testing.T) *httptest.Server {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		payload := decodePayload(t, r)
+		assertNoLegacyGroupMembershipQuery(t, payload.Query)
 
 		a.mu.Lock()
 		defer a.mu.Unlock()
@@ -81,11 +82,11 @@ func (a *groupGrantAtom) server(t *testing.T) *httptest.Server {
 		case strings.Contains(payload.Query, "setObjectGroupParent"):
 			a.mutations["setObjectGroupParent"]++
 			a.handleSetObjectGroupParent(t, w, payload)
-		case strings.Contains(payload.Query, "addGroupMember"):
-			a.mutations["addGroupMember"]++
+		case strings.Contains(payload.Query, "addEntityToObjectGroup"):
+			a.mutations["addEntityToObjectGroup"]++
 			a.handleAddGroupMember(t, w, payload)
-		case strings.Contains(payload.Query, "removeGroupMember"):
-			a.mutations["removeGroupMember"]++
+		case strings.Contains(payload.Query, "removeEntityFromObjectGroup"):
+			a.mutations["removeEntityFromObjectGroup"]++
 			a.handleRemoveGroupMember(t, w, payload)
 		case strings.Contains(payload.Query, "query Actions"):
 			a.handleActions(w)
@@ -148,21 +149,21 @@ func (a *groupGrantAtom) handleSetObjectGroupParent(t *testing.T, w http.Respons
 
 func (a *groupGrantAtom) handleAddGroupMember(t *testing.T, w http.ResponseWriter, payload gqlPayload) {
 	t.Helper()
-	groupID, _ := payload.Variables[atomInputKeyGroupID].(string)
+	groupID, _ := payload.Variables[atomInputKeyObjectGroupID].(string)
 	entityID, _ := payload.Variables[atomInputKeyEntityID].(string)
 	if a.members[groupID] == nil {
 		a.members[groupID] = map[string]bool{}
 	}
 	a.members[groupID][entityID] = true
-	writeGraphQLData(t, w, "addGroupMember", true)
+	writeGraphQLData(t, w, "addEntityToObjectGroup", map[string]any{"id": entityID})
 }
 
 func (a *groupGrantAtom) handleRemoveGroupMember(t *testing.T, w http.ResponseWriter, payload gqlPayload) {
 	t.Helper()
-	groupID, _ := payload.Variables[atomInputKeyGroupID].(string)
+	groupID, _ := payload.Variables[atomInputKeyObjectGroupID].(string)
 	entityID, _ := payload.Variables[atomInputKeyEntityID].(string)
 	delete(a.members[groupID], entityID)
-	writeGraphQLData(t, w, "removeGroupMember", true)
+	writeGraphQLData(t, w, "removeEntityFromObjectGroup", map[string]any{"id": entityID})
 }
 
 func (a *groupGrantAtom) handleActions(w http.ResponseWriter) {
@@ -642,8 +643,8 @@ func TestGrantGroupAccessWriteCountIsConstantRegardlessOfMemberCount(t *testing.
 		}
 	}
 
-	if fake.mutations["addGroupMember"] != memberCount {
-		t.Fatalf("expected %d addGroupMember mutations, got %d", memberCount, fake.mutations["addGroupMember"])
+	if fake.mutations["addEntityToObjectGroup"] != memberCount {
+		t.Fatalf("expected %d addEntityToObjectGroup mutations, got %d", memberCount, fake.mutations["addEntityToObjectGroup"])
 	}
 	// The write count from the grant itself must not have grown with member count.
 	if fake.mutations["createPermissionBlock"] != 1 || fake.mutations["createDirectPolicy"] != 1 {

--- a/pkg/atom/group_membership_test.go
+++ b/pkg/atom/group_membership_test.go
@@ -28,6 +28,32 @@ func decodePayload(t *testing.T, r *http.Request) gqlPayload {
 	return payload
 }
 
+// legacyGroupMembershipFields are Atom's principal-group membership GraphQL
+// fields. addGroupMember/removeGroupMember/groupMembers/entityGroups operate
+// on principal_groups/principal_group_members (user/team membership), not
+// the object_group_entities table that device/channel sharing-group
+// membership needs. AddGroupMember, RemoveGroupMember, GroupMembers, and
+// EntityGroups must never send these.
+var legacyGroupMembershipFields = []string{"addGroupMember", "removeGroupMember", "groupMembers", "entityGroups"}
+
+// assertNoLegacyGroupMembershipQuery fails the test immediately if the
+// client sent one of Atom's principal-group membership fields instead of the
+// object-group equivalents (addEntityToObjectGroup,
+// removeEntityFromObjectGroup, entities(parentGroupId: ...), objectGroupIds)
+// that this package's object-group-membership methods must use. This is the
+// regression guard for the bug this file's tests were fixed to catch: the
+// fake server previously accepted the wrong, principal-group mutations as if
+// they were correct, so every test passed even though the client was calling
+// the wrong part of the schema.
+func assertNoLegacyGroupMembershipQuery(t *testing.T, query string) {
+	t.Helper()
+	for _, legacy := range legacyGroupMembershipFields {
+		if strings.Contains(query, legacy) {
+			t.Fatalf("client sent legacy principal-group field %q; object-group membership methods must use the object-group equivalents instead: %s", legacy, query)
+		}
+	}
+}
+
 func groupJSON(id, name, tenantID, parentID string) map[string]any {
 	return map[string]any{
 		"id":         id,
@@ -80,26 +106,37 @@ func TestObjectGroupMembersAddAndRemove(t *testing.T) {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		payload := decodePayload(t, r)
+		assertNoLegacyGroupMembershipQuery(t, payload.Query)
 		switch {
 		case strings.Contains(payload.Query, "createObjectGroup"):
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"createObjectGroup": groupJSON(groupID, "devices", testTenantID, "")},
 			})
-		case strings.Contains(payload.Query, "addGroupMember"):
-			if payload.Variables["groupId"] != groupID {
+		case strings.Contains(payload.Query, "addEntityToObjectGroup"):
+			if payload.Variables["objectGroupId"] != groupID {
 				t.Fatalf("unexpected group id: %+v", payload.Variables)
 			}
-			members[payload.Variables["entityId"].(string)] = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addGroupMember": true}})
-		case strings.Contains(payload.Query, "removeGroupMember"):
-			delete(members, payload.Variables["entityId"].(string))
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"removeGroupMember": true}})
-		case strings.Contains(payload.Query, "groupMembers"):
+			entityID := payload.Variables["entityId"].(string)
+			members[entityID] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addEntityToObjectGroup": map[string]any{"id": entityID}}})
+		case strings.Contains(payload.Query, "removeEntityFromObjectGroup"):
+			if payload.Variables["objectGroupId"] != groupID {
+				t.Fatalf("unexpected group id: %+v", payload.Variables)
+			}
+			entityID := payload.Variables["entityId"].(string)
+			delete(members, entityID)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"removeEntityFromObjectGroup": map[string]any{"id": entityID}}})
+		case strings.Contains(payload.Query, "entities(parentGroupId"):
+			if payload.Variables["parentGroupId"] != groupID {
+				t.Fatalf("unexpected group id: %+v", payload.Variables)
+			}
 			items := []map[string]any{}
 			for id := range members {
 				items = append(items, entityJSON(id, testTenantID))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"groupMembers": items}})
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"entities": map[string]any{"total": len(items), "items": items}},
+			})
 		default:
 			t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
 		}
@@ -160,24 +197,29 @@ func TestEntityGroupsReturnsAllMemberships(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := decodePayload(t, r)
+		assertNoLegacyGroupMembershipQuery(t, payload.Query)
 		switch {
 		case strings.Contains(payload.Query, "createObjectGroup"):
 			id := payload.Variables["input"].(map[string]any)["name"].(string)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"createObjectGroup": groupJSON(id, id, testTenantID, "")},
 			})
-		case strings.Contains(payload.Query, "addGroupMember"):
-			membership[payload.Variables["groupId"].(string)] = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addGroupMember": true}})
-		case strings.Contains(payload.Query, "entityGroups"):
-			if payload.Variables["entityId"] != entityID {
+		case strings.Contains(payload.Query, "addEntityToObjectGroup"):
+			groupID := payload.Variables["objectGroupId"].(string)
+			entityIDVar := payload.Variables["entityId"].(string)
+			membership[groupID] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addEntityToObjectGroup": map[string]any{"id": entityIDVar}}})
+		case strings.Contains(payload.Query, "objectGroupIds"):
+			if payload.Variables["id"] != entityID {
 				t.Fatalf("unexpected entity id: %+v", payload.Variables)
 			}
 			var ids []string
 			for id := range membership {
 				ids = append(ids, id)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"entityGroups": ids}})
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"entity": map[string]any{"objectGroupIds": ids}},
+			})
 		default:
 			t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
 		}
@@ -226,27 +268,32 @@ func TestGroupMembershipIsAdditiveNotMove(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := decodePayload(t, r)
+		assertNoLegacyGroupMembershipQuery(t, payload.Query)
 		switch {
 		case strings.Contains(payload.Query, "createObjectGroup"):
 			id := payload.Variables["input"].(map[string]any)["name"].(string)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"createObjectGroup": groupJSON("group-"+id, id, testTenantID, "")},
 			})
-		case strings.Contains(payload.Query, "addGroupMember"):
-			groupID := payload.Variables["groupId"].(string)
-			members[groupID][payload.Variables["entityId"].(string)] = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addGroupMember": true}})
-		case strings.Contains(payload.Query, "removeGroupMember"):
-			groupID := payload.Variables["groupId"].(string)
-			delete(members[groupID], payload.Variables["entityId"].(string))
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"removeGroupMember": true}})
-		case strings.Contains(payload.Query, "groupMembers"):
-			groupID := payload.Variables["groupId"].(string)
+		case strings.Contains(payload.Query, "addEntityToObjectGroup"):
+			groupID := payload.Variables["objectGroupId"].(string)
+			entityIDVar := payload.Variables["entityId"].(string)
+			members[groupID][entityIDVar] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addEntityToObjectGroup": map[string]any{"id": entityIDVar}}})
+		case strings.Contains(payload.Query, "removeEntityFromObjectGroup"):
+			groupID := payload.Variables["objectGroupId"].(string)
+			entityIDVar := payload.Variables["entityId"].(string)
+			delete(members[groupID], entityIDVar)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"removeEntityFromObjectGroup": map[string]any{"id": entityIDVar}}})
+		case strings.Contains(payload.Query, "entities(parentGroupId"):
+			groupID := payload.Variables["parentGroupId"].(string)
 			items := []map[string]any{}
 			for id := range members[groupID] {
 				items = append(items, entityJSON(id, testTenantID))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"groupMembers": items}})
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"entities": map[string]any{"total": len(items), "items": items}},
+			})
 		default:
 			t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
 		}
@@ -694,8 +741,9 @@ func TestAddGroupMemberRejectsCrossTenant(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := decodePayload(t, r)
+		assertNoLegacyGroupMembershipQuery(t, payload.Query)
 		switch {
-		case strings.Contains(payload.Query, "addGroupMember"):
+		case strings.Contains(payload.Query, "addEntityToObjectGroup"):
 			entityID := payload.Variables["entityId"].(string)
 			if entityID == "foreign-device" {
 				_ = json.NewEncoder(w).Encode(map[string]any{
@@ -704,7 +752,7 @@ func TestAddGroupMemberRejectsCrossTenant(t *testing.T) {
 				return
 			}
 			members[entityID] = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addGroupMember": true}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"addEntityToObjectGroup": map[string]any{"id": entityID}}})
 		default:
 			t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
 		}


### PR DESCRIPTION
## Summary

`pkg/atom/client.go`'s `AddGroupMember`, `RemoveGroupMember`, `GroupMembers`, and `EntityGroups` were calling Atom's `addGroupMember` / `removeGroupMember` / `groupMembers` / `entityGroups` GraphQL fields. Those fields operate on `principal_groups` / `principal_group_members` — Atom's tables for user/team group membership — not the `object_group_entities` table that device/channel sharing-group membership actually needs.

This means every write and read through these four Go methods was silently touching the wrong membership table in Atom, even though every existing test passed, because the hand-rolled fake Atom servers in the test suite matched on the old field names and answered as if they were correct.

- `AddGroupMember` now sends `addEntityToObjectGroup(entityId, objectGroupId)`.
- `RemoveGroupMember` now sends `removeEntityFromObjectGroup(entityId, objectGroupId)`.
- `GroupMembers` now uses the existing `entities(parentGroupId: ...)` query (which, despite its name, already filters by many-to-many object-group membership), paginating internally so it still returns a group's full membership in one call.
- `EntityGroups` now uses `entity(id: ...) { objectGroupIds }`, the field resolver Atom exposes for an entity's object-group memberships, since there's no top-level `entityGroups`-equivalent query on the object-group side.

Go method signatures are unchanged — same parameters, same return types — so no caller (current or future) needs to change.

Verified directly against `absmach/atom`'s `edge` branch schema (`src/identity/repo.rs`, `src/graphql/entities.rs`, `src/graphql/types/mod.rs`) before making any change, including confirming `add_entity_to_object_group` was introduced by the "Make object group membership many-to-many" commit and is not a rename of the older `add_group_member`.

## Test plan

- Both `pkg/atom/group_membership_test.go` and `pkg/atom/group_grant_test.go`'s fake Atom servers now match on the corrected GraphQL operation names (`addEntityToObjectGroup`, `removeEntityFromObjectGroup`, `entities(parentGroupId: ...)`, `objectGroupIds`) instead of the old, wrong ones.
- Added a shared `assertNoLegacyGroupMembershipQuery` regression guard, called from every relevant test in both files, that fails loudly if the client ever sends `addGroupMember`/`removeGroupMember`/`groupMembers`/`entityGroups` again. Verified locally (by temporarily reverting `AddGroupMember` to the old, buggy mutation) that this guard actually fires and fails the tests, rather than trusting it by inspection alone.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --config tools/config/.golangci.yaml ./pkg/atom/...` (0 issues)
- [x] `go test ./pkg/atom/... -count=1` (all green)

https://claude.ai/code/session_019jiL1FQFwqNXVeuqDK6v4x