### PR TITLE
Trim over-explained comments in pkg/atom

### DIFF
--- a/pkg/atom/client.go
+++ b/pkg/atom/client.go
@@ -208,58 +208,30 @@ func (c *Client) UpdateGroup(ctx context.Context, id string, group Group) (Group
 	return out.UpdateGroup, err
 }
 
-// AddGroupMember adds an entity to an object group (a group of
-// devices/channels). Membership is many-to-many and additive: an entity
-// already in other groups keeps those memberships, and adding it to a group
-// it already belongs to is a no-op.
-//
-// This method's name matches Atom's older, pre-existing addGroupMember
-// GraphQL mutation in spelling only. That mutation, along with
-// removeGroupMember/groupMembers/entityGroups, operates on
-// principal_groups/principal_group_members — Atom's tables for user/team
-// group membership — and is not what AddGroupMember calls. AddGroupMember
-// instead sends addEntityToObjectGroup, the mutation Atom purpose-built for
-// many-to-many object-group membership (backed by the object_group_entities
-// table), introduced alongside many-to-many object group support. That
-// mutation returns the updated Entity rather than a Boolean, but this method
-// only needs to know whether the call succeeded, so the response body is
-// discarded.
+// AddGroupMember adds an entity to an object group (device/channel sharing).
+// Despite the name, this sends addEntityToObjectGroup, not Atom's
+// principal-group addGroupMember mutation — same spelling, different table.
 func (c *Client) AddGroupMember(ctx context.Context, groupID, entityID string) error {
 	return c.graphQL(ctx, `mutation AddEntityToObjectGroup($entityId: ID!, $objectGroupId: ID!) {
 		addEntityToObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) { id }
 	}`, map[string]any{atomInputKeyEntityID: entityID, atomInputKeyObjectGroupID: groupID}, nil)
 }
 
-// RemoveGroupMember removes membership in this object group only; the entity
-// may still be reachable through other group memberships it holds.
-//
-// Like AddGroupMember, this method's name matches Atom's older
-// removeGroupMember GraphQL mutation in spelling only; that mutation targets
-// principal_groups membership, not object groups. RemoveGroupMember sends
-// removeEntityFromObjectGroup, the object-group counterpart.
+// RemoveGroupMember removes membership in this object group only — the
+// entity may still be reachable through other groups. Like AddGroupMember,
+// it sends the object-group mutation despite matching a principal-group name.
 func (c *Client) RemoveGroupMember(ctx context.Context, groupID, entityID string) error {
 	return c.graphQL(ctx, `mutation RemoveEntityFromObjectGroup($entityId: ID!, $objectGroupId: ID!) {
 		removeEntityFromObjectGroup(entityId: $entityId, objectGroupId: $objectGroupId) { id }
 	}`, map[string]any{atomInputKeyEntityID: entityID, atomInputKeyObjectGroupID: groupID}, nil)
 }
 
-// groupMembersPageLimit caps each page GroupMembers requests from the
-// entities query. It matches the maximum page size Atom's entities query
-// enforces server-side, so a single page already covers the common case;
-// GroupMembers pages through offsets internally so a group with more members
-// than that still comes back complete in one call.
+// groupMembersPageLimit matches Atom's server-side max page size for the entities query.
 const groupMembersPageLimit = 100
 
-// GroupMembers lists the entities currently in an object group.
-//
-// Unlike AddGroupMember/RemoveGroupMember, there is no purpose-built
-// "groupMembers" query on the object-group side, and the old groupMembers
-// query this method used to call is the principal-group one and returns the
-// wrong entities entirely. The correct way to list an object group's members
-// is the existing entities(parentGroupId: ...) query: despite its name,
-// parentGroupId filters by many-to-many object-group membership (via the
-// object_group_entities table), not a single-parent relationship, so it
-// already returns exactly what this method needs.
+// GroupMembers lists an object group's entities via entities(parentGroupId:
+// ...) — despite the name, that filters by many-to-many object-group
+// membership, not a single parent. There is no dedicated "groupMembers" query.
 func (c *Client) GroupMembers(ctx context.Context, groupID string) ([]Entity, error) {
 	var members []Entity
 	for offset := 0; ; offset += groupMembersPageLimit {
@@ -287,15 +259,8 @@ func (c *Client) GroupMembers(ctx context.Context, groupID string) ([]Entity, er
 	return members, nil
 }
 
-// EntityGroups returns every object group the entity belongs to. Membership
-// is many-to-many, so an entity can appear in more than one group at once.
-//
-// Like GroupMembers, there is no purpose-built "entityGroups" query on the
-// object-group side, and the old entityGroups query this method used to call
-// is the principal-group one. An entity's object-group memberships are
-// instead exposed as the objectGroupIds field on the entity itself, so this
-// method queries entity(id: ...) { objectGroupIds } rather than a top-level
-// query.
+// EntityGroups returns every object group the entity belongs to, via
+// entity(id: ...) { objectGroupIds } — there is no top-level "entityGroups" query.
 func (c *Client) EntityGroups(ctx context.Context, entityID string) ([]string, error) {
 	var out struct {
 		Entity struct {

--- a/pkg/atom/client_test.go
+++ b/pkg/atom/client_test.go
@@ -116,10 +116,7 @@ func TestListEntitiesAttributesContains(t *testing.T) {
 		}
 		gateways, _ := contains["gateways"].([]any)
 
-		// Only entities whose gateways attribute actually satisfies the
-		// requested containment are returned - proving the fake server (and
-		// therefore the argument sent) drives the result, not an unfiltered
-		// listing.
+		// Only entities matching the requested containment are returned.
 		items := []Entity{}
 		if len(gateways) == 1 && gateways[0] == "gw-1" {
 			items = append(items, Entity{ID: "device-1", Kind: atomKindDevice})

--- a/pkg/atom/devices.go
+++ b/pkg/atom/devices.go
@@ -9,24 +9,14 @@ import (
 	"sort"
 )
 
-// ErrGatewaysConflict is returned by SetDeviceGateways when the device's
-// current gateways attribute no longer matches expectedCurrent, so the
-// caller's view of it is stale and the write was not performed.
+// ErrGatewaysConflict means the device's gateways attribute no longer
+// matches expectedCurrent — the caller's view was stale, so nothing was written.
 var ErrGatewaysConflict = errors.New("atom: device gateways changed since last read")
 
-// SetDeviceGateways replaces a device's entire gateway list.
-//
-// Atom's update_entity overwrites the whole attributes column rather than
-// merging individual keys, so this reads the device's current attributes
-// first and writes them back with only the gateways key changed - every
-// other attribute on the device is preserved unmodified.
-//
-// expectedCurrent must match the gateway list last read for this device
-// (order-independent), or the call fails with ErrGatewaysConflict instead of
-// writing. Atom offers no compare-and-swap primitive, so there remains a
-// window between the read below and the write; this check narrows it from
-// "however long the caller took to decide" to one GraphQL round trip. It is
-// not a substitute for real distributed locking, and does not attempt to be.
+// SetDeviceGateways replaces a device's entire gateway list, preserving its
+// other attributes. expectedCurrent must match what was last read (order
+// independent) or it fails with ErrGatewaysConflict — Atom has no
+// compare-and-swap, so this only narrows the race window, not closes it.
 func (c *Client) SetDeviceGateways(ctx context.Context, deviceID string, gatewayIDs, expectedCurrent []string) error {
 	device, err := c.GetEntity(ctx, deviceID)
 	if err != nil {
@@ -44,10 +34,8 @@ func (c *Client) SetDeviceGateways(ctx context.Context, deviceID string, gateway
 	return err
 }
 
-// DeviceGateways returns the gateway IDs a device declares, resolving away
-// any stale IDs pointing at gateways that no longer exist (or were deleted).
-// Deleting a gateway leaves it referenced in the devices that named it -
-// nothing sweeps those references - so this is where they get dropped.
+// DeviceGateways returns the gateway IDs a device declares, dropping any
+// that point at a since-deleted gateway (nothing else sweeps those).
 func (c *Client) DeviceGateways(ctx context.Context, deviceID string) ([]string, error) {
 	device, err := c.GetEntity(ctx, deviceID)
 	if err != nil {
@@ -68,9 +56,8 @@ func (c *Client) DeviceGateways(ctx context.Context, deviceID string) ([]string,
 	return live, nil
 }
 
-// GatewayDevices lists devices whose gateways attribute contains gatewayID,
-// via attributesContains JSONB array containment. Any AttributesContains
-// already set on q is preserved alongside the gateways filter.
+// GatewayDevices lists devices whose gateways attribute contains gatewayID.
+// Any AttributesContains already set on q is preserved alongside it.
 func (c *Client) GatewayDevices(ctx context.Context, gatewayID string, q Query) (EntityList, error) {
 	filter := make(map[string]any, len(q.AttributesContains)+1)
 	for k, v := range q.AttributesContains {
@@ -113,10 +100,8 @@ func mergeContainsString(existing any, value string) any {
 	}
 }
 
-// attrStrings reads a []string-valued attribute. Values come back from the
-// GraphQL client as []any (each element a string), since Attributes decodes
-// from JSON, but a []string is accepted too so callers can build one without
-// a round trip.
+// attrStrings reads a []string-valued attribute, accepting both []string and
+// the []any that JSON decoding actually produces.
 func attrStrings(attrs Attributes, key string) []string {
 	if attrs == nil {
 		return nil
@@ -137,9 +122,7 @@ func attrStrings(attrs Attributes, key string) []string {
 	}
 }
 
-// cloneAttributes returns a shallow, mutable copy of attrs, never nil, so
-// callers can add or overwrite a key without affecting the source map or
-// panicking on a nil map.
+// cloneAttributes returns a shallow, mutable, never-nil copy of attrs.
 func cloneAttributes(attrs Attributes) Attributes {
 	out := make(Attributes, len(attrs)+1)
 	for k, v := range attrs {

--- a/pkg/atom/devices_test.go
+++ b/pkg/atom/devices_test.go
@@ -13,12 +13,8 @@ import (
 	"time"
 )
 
-// fakeAtomDevices is a minimal in-memory Atom stand-in backing entity,
-// updateEntity and entities - enough surface to exercise
-// SetDeviceGateways / DeviceGateways / GatewayDevices without a real server.
-//
-// It also mirrors a real behaviour these tests depend on: updateEntity
-// replaces the whole attributes column rather than merging individual keys.
+// fakeAtomDevices is a minimal in-memory Atom stand-in. Like the real Atom,
+// its updateEntity replaces the whole attributes column rather than merging keys.
 type fakeAtomDevices struct {
 	t           *testing.T
 	entities    map[string]Entity
@@ -106,11 +102,8 @@ func deviceEntityJSON(e Entity) map[string]any {
 	}
 }
 
-// entityMatchesContains reimplements, for the fake server only, the JSONB
-// containment semantics the real Atom applies: every key in contains must be
-// present in the entity's attributes, and for list-valued attributes every
-// element of the wanted list must appear in the entity's list (order
-// irrelevant, extra elements on the entity side allowed).
+// entityMatchesContains reimplements Atom's JSONB containment for the fake
+// server: every key must be present, list values match by element containment.
 func entityMatchesContains(e Entity, contains map[string]any) bool {
 	for key, want := range contains {
 		got, ok := e.Attributes[key]

--- a/pkg/atom/group_membership_test.go
+++ b/pkg/atom/group_membership_test.go
@@ -28,23 +28,12 @@ func decodePayload(t *testing.T, r *http.Request) gqlPayload {
 	return payload
 }
 
-// legacyGroupMembershipFields are Atom's principal-group membership GraphQL
-// fields. addGroupMember/removeGroupMember/groupMembers/entityGroups operate
-// on principal_groups/principal_group_members (user/team membership), not
-// the object_group_entities table that device/channel sharing-group
-// membership needs. AddGroupMember, RemoveGroupMember, GroupMembers, and
-// EntityGroups must never send these.
+// legacyGroupMembershipFields are Atom's principal-group mutations — the
+// object-group methods in this package must never send these.
 var legacyGroupMembershipFields = []string{"addGroupMember", "removeGroupMember", "groupMembers", "entityGroups"}
 
-// assertNoLegacyGroupMembershipQuery fails the test immediately if the
-// client sent one of Atom's principal-group membership fields instead of the
-// object-group equivalents (addEntityToObjectGroup,
-// removeEntityFromObjectGroup, entities(parentGroupId: ...), objectGroupIds)
-// that this package's object-group-membership methods must use. This is the
-// regression guard for the bug this file's tests were fixed to catch: the
-// fake server previously accepted the wrong, principal-group mutations as if
-// they were correct, so every test passed even though the client was calling
-// the wrong part of the schema.
+// assertNoLegacyGroupMembershipQuery is the regression guard for the bug
+// where these methods sent principal-group fields instead of object-group ones.
 func assertNoLegacyGroupMembershipQuery(t *testing.T, query string) {
 	t.Helper()
 	for _, legacy := range legacyGroupMembershipFields {

--- a/pkg/atom/types.go
+++ b/pkg/atom/types.go
@@ -66,9 +66,8 @@ type Query struct {
 	Limit    uint64
 	Offset   uint64
 
-	// AttributesContains filters by JSONB containment: an entity matches only
-	// if its attributes contain every key/value given here (arrays match if
-	// they contain the given elements, not only if they equal them exactly).
+	// AttributesContains filters by JSONB containment — an entity must contain
+	// every key/value given here (array values match by containment, not equality).
 	AttributesContains map[string]any
 }
 


### PR DESCRIPTION
## Summary
- Cuts multi-paragraph doc comments added across #3572 and #3573 down to one or two lines each, keeping only the non-obvious fact each one was making.
- No functional changes — comment-only diff, verified against `go build`/`go vet`/`gofmt`/`go test` for the full module.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./pkg/atom/... ./fluxmq/...`