### PR TITLE
MG-11: CLI, PAT scopes, permissions and OpenAPI catch up to Device/Gateway

### DIFF
--- a/apidocs/openapi/devices.yaml
+++ b/apidocs/openapi/devices.yaml
@@ -3,9 +3,9 @@
 
 openapi: 3.0.3
 info:
-  title: Magistrala Clients Service
+  title: Magistrala Devices Service
   description: |
-    This is the Clients Server based on the OpenAPI 3.0 specification.  It is the HTTP API for managing platform clients. You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    This is the Devices Server based on the OpenAPI 3.0 specification.  It is the HTTP API for managing platform devices. You can now help us improve the API whether it's by making changes to the definition itself or to the code.
     Some useful links:
     - [The Magistrala repository](https://github.com/absmach/magistrala)
   contact:
@@ -20,13 +20,13 @@ servers:
   - url: https://localhost:9006
 
 tags:
-  - name: Clients
-    description: CRUD operations for your clients
+  - name: Devices
+    description: CRUD operations for your devices
     externalDocs:
-      description: Find out more about clients
+      description: Find out more about devices
       url: https://magistrala.absmach.eu/docs/
   - name: Roles
-    description: All operations involving roles for clients
+    description: All operations involving roles for devices
     externalDocs:
       description: Find out more about roles
       url: https://magistrala.absmach.eu/docs/
@@ -37,22 +37,22 @@ tags:
       url: https://magistrala.absmach.eu/docs/
 
 paths:
-  /{domainID}/clients:
+  /{domainID}/devices:
     post:
-      operationId: createClient
+      operationId: createDevice
       tags:
-        - Clients
-      summary: Adds new client
+        - Devices
+      summary: Adds new device
       description: |
-        Adds new client to the list of clients owned by user identified using
+        Adds new device to the list of devices owned by user identified using
         the provided access token.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientCreateReq"
+        $ref: "#/components/requestBodies/DeviceCreateReq"
       responses:
         "201":
-          $ref: "#/components/responses/ClientCreateRes"
+          $ref: "#/components/responses/DeviceCreateRes"
         "400":
           description: Failed due to malformed JSON.
         "401":
@@ -71,13 +71,13 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     get:
-      operationId: listClients
+      operationId: listDevices
       tags:
-        - Clients
-      summary: Retrieves clients
+        - Devices
+      summary: Retrieves devices
       description: |
-        Retrieves a list of clients. Due to performance concerns, data
-        is retrieved in subsets. The API clients must ensure that the entire
+        Retrieves a list of devices. Due to performance concerns, data
+        is retrieved in subsets. The API caller must ensure that the entire
         dataset is consumed either by making subsequent requests, or by
         increasing the subset size of the initial request.
       parameters:
@@ -88,7 +88,7 @@ paths:
         - $ref: "#/components/parameters/Direction"
         - $ref: "#/components/parameters/Metadata"
         - $ref: "#/components/parameters/Status"
-        - $ref: "#/components/parameters/ClientName"
+        - $ref: "#/components/parameters/DeviceName"
         - $ref: "#/components/parameters/Tags"
         - $ref: "#/components/parameters/ID"
         - $ref: "./schemas/roles.yaml#/components/parameters/ActionsQuery"
@@ -106,7 +106,7 @@ paths:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientPageRes"
+          $ref: "#/components/responses/DevicePageRes"
         "400":
           description: Failed due to malformed query parameters.
         "401":
@@ -121,22 +121,22 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/bulk:
+  /{domainID}/devices/bulk:
     post:
-      operationId: bulkCreateClients
-      summary: Bulk provisions new clients
+      operationId: bulkCreateDevices
+      summary: Bulk provisions new devices
       description: |
-        Adds a list of new clients to the list of clients owned by user identified using
+        Adds a list of new devices to the list of devices owned by user identified using
         the provided access token.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
       tags:
-        - Clients
+        - Devices
       requestBody:
-        $ref: "#/components/requestBodies/ClientsCreateReq"
+        $ref: "#/components/requestBodies/DevicesCreateReq"
       responses:
         "200":
-          $ref: "#/components/responses/ClientPageRes"
+          $ref: "#/components/responses/DevicePageRes"
         "400":
           description: Failed due to malformed JSON.
         "401":
@@ -152,22 +152,22 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}:
+  /{domainID}/devices/{deviceID}:
     get:
-      operationId: getClient
-      summary: Retrieves client info
+      operationId: getDevice
+      summary: Retrieves device info
       description: |
-        Retrieves a specific client that is identified by the client ID.
+        Retrieves a specific device that is identified by the device ID.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientRes"
+          $ref: "#/components/responses/DeviceRes"
         "400":
           description: Failed due to malformed domain ID.
         "401":
@@ -182,24 +182,24 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     patch:
-      operationId: updateClient
-      summary: Updates name, metadata, and private metadata of the client.
+      operationId: updateDevice
+      summary: Updates name, metadata, and private metadata of the device.
       description: |
         Update is performed by replacing the current resource data with values
-        provided in a request payload. Note that the client's type and ID
+        provided in a request payload. Note that the device's type and ID
         cannot be changed.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientUpdateReq"
+        $ref: "#/components/requestBodies/DeviceUpdateReq"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientRes"
+          $ref: "#/components/responses/DeviceRes"
         "400":
           description: Failed due to malformed JSON.
         "401":
@@ -207,7 +207,7 @@ paths:
         "403":
           description: Failed to perform authorization over the entity.
         "404":
-          description: Failed due to non existing client.
+          description: Failed due to non existing device.
         "409":
           description: Failed due to using an existing identity.
         "415":
@@ -217,56 +217,56 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
     delete:
-      summary: Delete client for a client with the given id.
+      summary: Delete device for a device with the given id.
       description: |
-        Delete client removes a client with the given id from repo
-        and removes all the policies related to this client.
+        Delete device removes a device with the given id from repo
+        and removes all the policies related to this device.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       security:
         - bearerAuth: []
       responses:
         "204":
-          description: Client deleted.
+          description: Device deleted.
         "400":
           description: Failed due to malformed domain ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
-          description: Unauthorized access to client id.
+          description: Unauthorized access to device id.
         "404":
-          description: Missing client.
+          description: Missing device.
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/tags:
+  /{domainID}/devices/{deviceID}/tags:
     patch:
-      operationId: updateClientTags
-      summary: Updates tags the client.
+      operationId: updateDeviceTags
+      summary: Updates tags the device.
       description: |
-        Updates tags of the client with provided ID. Tags is updated using
+        Updates tags of the device with provided ID. Tags is updated using
         authorization token and the new tags received in request.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientUpdateTagsReq"
+        $ref: "#/components/requestBodies/DeviceUpdateTagsReq"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientRes"
+          $ref: "#/components/responses/DeviceRes"
         "400":
           description: Failed due to malformed JSON.
         "403":
           description: Failed to perform authorization over the entity.
         "404":
-          description: Failed due to non existing client.
+          description: Failed due to non existing device.
         "401":
           description: Missing or invalid access token provided.
         "422":
@@ -274,25 +274,25 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/secret:
+  /{domainID}/devices/{deviceID}/secret:
     patch:
-      operationId: updateClientSecret
-      summary: Updates Secret of the identified client.
+      operationId: updateDeviceSecret
+      summary: Updates Secret of the identified device.
       description: |
-        Updates secret of the identified in client. Secret is updated using
+        Updates secret of the identified in device. Secret is updated using
         authorization token and the new received info. Update is performed by replacing current key with a new one.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientUpdateSecretReq"
+        $ref: "#/components/requestBodies/DeviceUpdateSecretReq"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientRes"
+          $ref: "#/components/responses/DeviceRes"
         "400":
           description: Failed due to malformed JSON.
         "401":
@@ -300,7 +300,7 @@ paths:
         "403":
           description: Failed to perform authorization over the entity.
         "404":
-          description: Failed due to non existing client.
+          description: Failed due to non existing device.
         "409":
           description: Specified key already exists.
         "415":
@@ -310,24 +310,24 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/disable:
+  /{domainID}/devices/{deviceID}/disable:
     post:
-      operationId: disableClient
-      summary: Disables a client
+      operationId: disableDevice
+      summary: Disables a device
       description: |
-        Disables a specific client that is identified by the client ID.
+        Disables a specific device that is identified by the device ID.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/DisabledClientRes"
+          $ref: "#/components/responses/DisabledDeviceRes"
         "400":
-          description: Failed due to malformed client's ID.
+          description: Failed due to malformed device's ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
@@ -335,30 +335,30 @@ paths:
         "404":
           description: A non-existent entity request.
         "409":
-          description: Failed due to already disabled client.
+          description: Failed due to already disabled device.
         "422":
           description: Database can't process request.
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/enable:
+  /{domainID}/devices/{deviceID}/enable:
     post:
-      operationId: enableClient
-      summary: Enables a client
+      operationId: enableDevice
+      summary: Enables a device
       description: |
-        Enables a specific client that is identified by the client ID.
+        Enables a specific device that is identified by the device ID.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       security:
         - bearerAuth: []
       responses:
         "200":
-          $ref: "#/components/responses/ClientRes"
+          $ref: "#/components/responses/DeviceRes"
         "400":
-          description: Failed due to malformed client's ID.
+          description: Failed due to malformed device's ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
@@ -366,32 +366,32 @@ paths:
         "404":
           description: A non-existent entity request.
         "409":
-          description: Failed due to already enabled client.
+          description: Failed due to already enabled device.
         "422":
           description: Database can't process request.
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/parent:
+  /{domainID}/devices/{deviceID}/parent:
     post:
-      operationId: setClientParentGroup
-      summary: Sets a parent group for a client
+      operationId: setDeviceParentGroup
+      summary: Sets a parent group for a device
       description: |
-        Sets a parent group for a specific client that is identified by the client ID.
+        Sets a parent group for a specific device that is identified by the device ID.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientParentGroupReq"
+        $ref: "#/components/requestBodies/DeviceParentGroupReq"
       security:
         - bearerAuth: []
       responses:
         "200":
           description: Parent group set.
         "400":
-          description: Failed due to malformed client's ID.
+          description: Failed due to malformed device's ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
@@ -404,24 +404,24 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     delete:
-      operationId: removeClientParentGroup
-      summary: Removes a parent group from a client.
+      operationId: removeDeviceParentGroup
+      summary: Removes a parent group from a device.
       description: |
-        Removes a parent group from a specific client that is identified by the client ID.
+        Removes a parent group from a specific device that is identified by the device ID.
       tags:
-        - Clients
+        - Devices
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
-        $ref: "#/components/requestBodies/ClientParentGroupReq"
+        $ref: "#/components/requestBodies/DeviceParentGroupReq"
       security:
         - bearerAuth: []
       responses:
         "200":
           description: Parent group removed.
         "400":
-          description: Failed due to malformed client's ID.
+          description: Failed due to malformed device's ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
@@ -433,17 +433,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles:
+  /{domainID}/devices/{deviceID}/roles:
     post:
-      operationId: createClientRole
-      summary: Creates a role for a client
+      operationId: createDeviceRole
+      summary: Creates a role for a device
       description: |
-        Creates a role for a specific client that is identified by the client ID.
+        Creates a role for a specific device that is identified by the device ID.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/CreateRoleReq"
       security:
@@ -452,7 +452,7 @@ paths:
         "201":
           $ref: "./schemas/roles.yaml#/components/responses/CreateRoleRes"
         "400":
-          description: Failed due to malformed client's ID.
+          description: Failed due to malformed device's ID.
         "401":
           description: Missing or invalid access token provided.
         "403":
@@ -465,18 +465,18 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     get:
-      operationId: listClientRoles
+      operationId: listDeviceRoles
       tags:
         - Roles
-      summary: Retrieves clients roles.
+      summary: Retrieves devices roles.
       description: |
-        Retrieves a list of client roles. Due to performance concerns, data
-        is retrieved in subsets. The API clients must ensure that the entire
+        Retrieves a list of device roles. Due to performance concerns, data
+        is retrieved in subsets. The API caller must ensure that the entire
         dataset is consumed either by making subsequent requests, or by
         increasing the subset size of the initial request.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "#/components/parameters/Limit"
         - $ref: "#/components/parameters/Offset"
       security:
@@ -498,17 +498,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/members:
+  /{domainID}/devices/{deviceID}/roles/members:
     get:
-      operationId: getClientMembers
+      operationId: getDeviceMembers
       tags:
         - Roles
-      summary: Retrieves client members from all roles.
+      summary: Retrieves device members from all roles.
       description: |
-        Retrieves members from role for the specific client.
+        Retrieves members from role for the specific device.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
       security:
         - bearerAuth: []
       responses:
@@ -528,17 +528,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}:
+  /{domainID}/devices/{deviceID}/roles/{roleID}:
     get:
-      operationId: getClientRole
+      operationId: getDeviceRole
       tags:
         - Roles
-      summary: Retrieves client role.
+      summary: Retrieves device role.
       description: |
-        Retrieves a specific client role that is identified by the role name.
+        Retrieves a specific device role that is identified by the role name.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -560,15 +560,15 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     put:
-      operationId: updateClientRole
-      summary: Updates client role.
+      operationId: updateDeviceRole
+      summary: Updates device role.
       description: |
-        Updates a specific client role that is identified by the role name.
+        Updates a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/UpdateRoleReq"
@@ -592,15 +592,15 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     delete:
-      operationId: deleteClientRole
-      summary: Deletes client role.
+      operationId: deleteDeviceRole
+      summary: Deletes device role.
       description: |
-        Deletes a specific client role that is identified by the role name.
+        Deletes a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -621,17 +621,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/actions:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/actions:
     post:
-      operationId: addClientRoleAction
-      summary: Adds a role action for a client role.
+      operationId: addDeviceRoleAction
+      summary: Adds a role action for a device role.
       description: |
-        Adds a role action for a specific client role that is identified by the role name.
+        Adds a role action for a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/AddRoleActionsReq"
@@ -655,15 +655,15 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     get:
-      operationId: listClientRoleActions
+      operationId: listDeviceRoleActions
       tags:
         - Roles
-      summary: Lists client role actions.
+      summary: Lists device role actions.
       description: |
-        Retrieves a list of client role actions.
+        Retrieves a list of device role actions.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -684,17 +684,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/actions/delete:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/actions/delete:
     post:
-      operationId: deleteClientRoleAction
-      summary: Deletes role actions for a client role.
+      operationId: deleteDeviceRoleAction
+      summary: Deletes role actions for a device role.
       description: |
-        Deletes a role action for a specific client role that is identified by the role name.
+        Deletes a role action for a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/AddRoleActionsReq"
@@ -717,17 +717,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/actions/delete-all:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/actions/delete-all:
     post:
-      operationId: deleteAllClientRoleActions
-      summary: Deletes all role actions for a client role.
+      operationId: deleteAllDeviceRoleActions
+      summary: Deletes all role actions for a device role.
       description: |
-        Deletes all role actions for a specific client role that is identified by the role name.
+        Deletes all role actions for a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -748,17 +748,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/members:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/members:
     post:
-      operationId: addClientRoleMember
-      summary: Adds a member to a client role.
+      operationId: addDeviceRoleMember
+      summary: Adds a member to a device role.
       description: |
-        Adds a member to a specific client role that is identified by the role name.
+        Adds a member to a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/AddRoleMembersReq"
@@ -782,15 +782,15 @@ paths:
           $ref: "#/components/responses/ServiceError"
 
     get:
-      operationId: listClientRoleMembers
+      operationId: listDeviceRoleMembers
       tags:
         - Roles
-      summary: Lists client role members.
+      summary: Lists device role members.
       description: |
-        Retrieves a list of client role members.
+        Retrieves a list of device role members.
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -811,17 +811,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/members/delete:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/members/delete:
     post:
-      operationId: deleteClientRoleMembers
-      summary: Deletes members from a client role.
+      operationId: deleteDeviceRoleMembers
+      summary: Deletes members from a device role.
       description: |
-        Deletes a member from a specific client role that is identified by the role name.
+        Deletes a member from a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       requestBody:
         $ref: "./schemas/roles.yaml#/components/requestBodies/AddRoleMembersReq"
@@ -844,17 +844,17 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/{clientID}/roles/{roleID}/members/delete-all:
+  /{domainID}/devices/{deviceID}/roles/{roleID}/members/delete-all:
     post:
-      operationId: deleteAllClientRoleMembers
-      summary: Deletes all members from a client role.
+      operationId: deleteAllDeviceRoleMembers
+      summary: Deletes all members from a device role.
       description: |
-        Deletes all members from a specific client role that is identified by the role name.
+        Deletes all members from a specific device role that is identified by the role name.
       tags:
         - Roles
       parameters:
         - $ref: "auth.yaml#/components/parameters/DomainID"
-        - $ref: "#/components/parameters/clientID"
+        - $ref: "#/components/parameters/deviceID"
         - $ref: "./schemas/roles.yaml#/components/parameters/RoleID"
       security:
         - bearerAuth: []
@@ -875,7 +875,7 @@ paths:
         "500":
           $ref: "#/components/responses/ServiceError"
 
-  /{domainID}/clients/roles/available-actions:
+  /{domainID}/devices/roles/available-actions:
     get:
       operationId: listAvailableActions
       tags:
@@ -918,27 +918,27 @@ paths:
 
 components:
   schemas:
-    ClientReqObj:
+    DeviceReqObj:
       type: object
       properties:
         name:
           type: string
-          example: clientName
-          description: Client name.
+          example: deviceName
+          description: Device name.
         tags:
           type: array
           minItems: 0
           items:
             type: string
           example: ["tag1", "tag2"]
-          description: Client tags.
+          description: Device tags.
         credentials:
           type: object
           properties:
             identity:
               type: string
-              example: "clientIDentity"
-              description: Client's identity will be used as its unique identifier
+              example: "deviceIDentity"
+              description: Device's identity will be used as its unique identifier
             secret:
               type: string
               format: password
@@ -948,14 +948,14 @@ components:
         private_metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data private to the client.
+          description: Arbitrary, object-encoded device's data private to the device.
         metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data visible to other clients.
+          description: Arbitrary, object-encoded device's data visible to other devices.
         status:
           type: string
-          description: Client Status
+          description: Device Status
           format: string
           example: enabled
       required:
@@ -972,52 +972,52 @@ components:
       required:
         - parent_group_id
 
-    Client:
+    Device:
       type: object
       properties:
         id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: Client unique identifier.
+          description: Device unique identifier.
         name:
           type: string
-          example: clientName
-          description: Client name.
+          example: deviceName
+          description: Device name.
         tags:
           type: array
           minItems: 0
           items:
             type: string
           example: ["tag1", "tag2"]
-          description: Client tags.
+          description: Device tags.
         domain_id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: ID of the domain to which client belongs.
+          description: ID of the domain to which device belongs.
         credentials:
           type: object
           properties:
             identity:
               type: string
-              example: clientIDentity
-              description: Client Identity for example email address.
+              example: deviceIDentity
+              description: Device Identity for example email address.
             secret:
               type: string
               example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-              description: Client secret password.
+              description: Device secret password.
         private_metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data private to the client.
+          description: Arbitrary, object-encoded device's data private to the device.
         metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data visible to other clients.
+          description: Arbitrary, object-encoded device's data visible to other devices.
         status:
           type: string
-          description: Client Status
+          description: Device Status
           format: string
           example: enabled
         created_at:
@@ -1031,54 +1031,54 @@ components:
           example: "2019-11-26 13:31:52"
           description: Time when the channel was created.
       xml:
-        name: client
+        name: device
 
-    ClientWithEmptySecret:
+    DeviceWithEmptySecret:
       type: object
       properties:
         id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: Client unique identifier.
+          description: Device unique identifier.
         name:
           type: string
-          example: clientName
-          description: Client name.
+          example: deviceName
+          description: Device name.
         tags:
           type: array
           minItems: 0
           items:
             type: string
           example: ["tag1", "tag2"]
-          description: Client tags.
+          description: Device tags.
         domain_id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: ID of the domain to which client belongs.
+          description: ID of the domain to which device belongs.
         credentials:
           type: object
           properties:
             identity:
               type: string
-              example: clientIDentity
-              description: Client Identity for example email address.
+              example: deviceIDentity
+              description: Device Identity for example email address.
             secret:
               type: string
               example: ""
-              description: Client secret password.
+              description: Device secret password.
         private_metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data private to the client.
+          description: Arbitrary, object-encoded device's data private to the device.
         metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data visible to other clients.
+          description: Arbitrary, object-encoded device's data visible to other devices.
         status:
           type: string
-          description: Client Status
+          description: Device Status
           format: string
           example: enabled
         created_at:
@@ -1092,17 +1092,17 @@ components:
           example: "2019-11-26 13:31:52"
           description: Time when the channel was created.
       xml:
-        name: client
+        name: device
 
-    ClientsPage:
+    DevicesPage:
       type: object
       properties:
-        clients:
+        devices:
           type: array
           minItems: 0
           uniqueItems: true
           items:
-            $ref: "#/components/schemas/ClientWithEmptySecret"
+            $ref: "#/components/schemas/DeviceWithEmptySecret"
         total:
           type: integer
           example: 1
@@ -1117,80 +1117,80 @@ components:
       required:
         - total
 
-    ClientUpdate:
+    DeviceUpdate:
       type: object
       properties:
         name:
           type: string
-          example: clientName
-          description: Client name.
+          example: deviceName
+          description: Device name.
         metadata:
           type: object
           example: { "role": "general" }
-          description: Arbitrary, object-encoded client's data visible to other clients.
+          description: Arbitrary, object-encoded device's data visible to other devices.
         private_metadata:
           type: object
           example: { "role": "general" }
-          description: Arbitrary, object-encoded client's data private to the client.
+          description: Arbitrary, object-encoded device's data private to the device.
       required:
         - name
         - private_metadata
         - metadata
 
-    ClientTags:
+    DeviceTags:
       type: object
       properties:
         tags:
           type: array
           example: ["tag1", "tag2"]
-          description: Client tags.
+          description: Device tags.
           minItems: 0
           uniqueItems: true
           items:
             type: string
 
-    DisabledClient:
+    DisabledDevice:
       type: object
       properties:
         id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: Client unique identifier.
+          description: Device unique identifier.
         name:
           type: string
-          example: clientName
-          description: Client name.
+          example: deviceName
+          description: Device name.
         tags:
           type: array
           minItems: 0
           items:
             type: string
           example: ["tag1", "tag2"]
-          description: Client tags.
+          description: Device tags.
         domain_id:
           type: string
           format: uuid
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: ID of the domain to which client belongs.
+          description: ID of the domain to which device belongs.
         credentials:
           type: object
           properties:
             identity:
               type: string
-              example: clientIDentity
-              description: Client Identity for example email address.
+              example: deviceIDentity
+              description: Device Identity for example email address.
             secret:
               type: string
               example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-              description: Client secret password.
+              description: Device secret password.
         metadata:
           type: object
           example: { "model": "example" }
-          description: Arbitrary, object-encoded client's data visible to other clients.
+          description: Arbitrary, object-encoded device's data visible to other devices.
         status:
           type: string
-          description: Client Status
+          description: Device Status
           format: string
           example: disabled
         created_at:
@@ -1204,15 +1204,15 @@ components:
           example: "2019-11-26 13:31:52"
           description: Time when the channel was created.
       xml:
-        name: client
+        name: device
 
-    ClientSecret:
+    DeviceSecret:
       type: object
       properties:
         secret:
           type: string
           example: bb7edb32-2eac-4aad-aebe-ed96fe073879
-          description: New client secret.
+          description: New device secret.
       required:
         - secret
 
@@ -1243,16 +1243,16 @@ components:
         description:
           type: string
           description: Service description.
-          example: clients service
+          example: devices service
         build_time:
           type: string
           description: Service build time.
           example: 1970-01-01_00:00:00
 
   parameters:
-    clientID:
-      name: clientID
-      description: Unique client identifier.
+    deviceID:
+      name: deviceID
+      description: Unique device identifier.
       in: path
       schema:
         type: string
@@ -1263,18 +1263,18 @@ components:
       required: true
       example: bb7edb32-2eac-4aad-aebe-ed96fe073879
 
-    ClientName:
+    DeviceName:
       name: name
-      description: Client's name.
+      description: Device's name.
       in: query
       schema:
         type: string
       required: false
-      example: "clientName"
+      example: "deviceName"
 
     Status:
       name: status
-      description: Client account status.
+      description: Device account status.
       in: query
       schema:
         type: string
@@ -1284,7 +1284,7 @@ components:
 
     Tags:
       name: tags
-      description: Clients tags. Multiple tags can be specified separated by comma for OR condition and plus for AND condition.
+      description: Devices tags. Multiple tags can be specified separated by comma for OR condition and plus for AND condition.
       in: query
       schema:
         type: string
@@ -1345,7 +1345,7 @@ components:
 
     ID:
       name: id
-      description: List clients with the given ID.
+      description: List devices with the given ID.
       in: query
       schema:
         type: string
@@ -1355,7 +1355,7 @@ components:
 
     AccessType:
       name: access_type
-      description: Type of access the user has on the client.
+      description: Type of access the user has on the device.
       in: query
       schema:
         type: string
@@ -1369,7 +1369,7 @@ components:
 
     OnlyTotal:
       name: only_total
-      description: If true, the response will contain only the total number of clients that match the query parameters.
+      description: If true, the response will contain only the total number of devices that match the query parameters.
       in: query
       schema:
         type: boolean
@@ -1378,7 +1378,7 @@ components:
 
     Channel:
       name: channel
-      description: If provided lists clients connected to a channel with the provided ID.
+      description: If provided lists devices connected to a channel with the provided ID.
       in: query
       schema:
         type: string
@@ -1389,7 +1389,7 @@ components:
 
     ConnectionType:
       name: connection_type
-      description: If provided with channel parameter lists clients connected to the channel with the provided connection type.
+      description: If provided with channel parameter lists devices connected to the channel with the provided connection type.
       in: query
       schema:
         type: string
@@ -1401,7 +1401,7 @@ components:
 
     Group:
       name: group
-      description: If provided lists clients belonging to a group with the provided ID.
+      description: If provided lists devices belonging to a group with the provided ID.
       in: query
       schema:
         type: string
@@ -1412,7 +1412,7 @@ components:
 
     User:
       name: user
-      description: If provided lists clients associated with a user with the provided ID. Only available for admin users.
+      description: If provided lists devices associated with a user with the provided ID. Only available for admin users.
       in: query
       schema:
         type: string
@@ -1423,7 +1423,7 @@ components:
     
     CreatedFrom:
       name: created_from
-      description: Filter clients created from this date (inclusive).
+      description: Filter devices created from this date (inclusive).
       in: query
       schema:
         type: string
@@ -1433,7 +1433,7 @@ components:
 
     CreatedTo:
       name: created_to
-      description: Filter clients created up to this date (inclusive).
+      description: Filter devices created up to this date (inclusive).
       in: query
       schema:
         type: string
@@ -1442,50 +1442,50 @@ components:
       example: "2023-12-31T23:59:59Z"
 
   requestBodies:
-    ClientCreateReq:
-      description: JSON-formatted document describing the new client to be registered
+    DeviceCreateReq:
+      description: JSON-formatted document describing the new device to be registered
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientReqObj"
+            $ref: "#/components/schemas/DeviceReqObj"
 
-    ClientsCreateReq:
-      description: JSON-formatted document describing the new clients.
+    DevicesCreateReq:
+      description: JSON-formatted document describing the new devices.
       required: true
       content:
         application/json:
           schema:
             type: array
             items:
-              $ref: "#/components/schemas/ClientReqObj"
+              $ref: "#/components/schemas/DeviceReqObj"
 
-    ClientUpdateReq:
-      description: JSON-formated document describing the metadata, private metadata and name of client to be update
+    DeviceUpdateReq:
+      description: JSON-formated document describing the metadata, private metadata and name of device to be update
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientUpdate"
+            $ref: "#/components/schemas/DeviceUpdate"
 
-    ClientUpdateTagsReq:
-      description: JSON-formated document describing the tags of client to be update
+    DeviceUpdateTagsReq:
+      description: JSON-formated document describing the tags of device to be update
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientTags"
+            $ref: "#/components/schemas/DeviceTags"
 
-    ClientUpdateSecretReq:
-      description: Secret change data. Client can change its secret.
+    DeviceUpdateSecretReq:
+      description: Secret change data. Device can change its secret.
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientSecret"
+            $ref: "#/components/schemas/DeviceSecret"
 
-    ClientParentGroupReq:
-      description: JSON-formated document describing the parent group to be set to or removed from a client.
+    DeviceParentGroupReq:
+      description: JSON-formated document describing the parent group to be set to or removed from a device.
       required: true
       content:
         application/json:
@@ -1493,71 +1493,71 @@ components:
             $ref: "#/components/schemas/ParentGroupReqObj"
 
   responses:
-    ClientCreateRes:
-      description: Registered new client.
+    DeviceCreateRes:
+      description: Registered new device.
       headers:
         Location:
           schema:
             type: string
             format: url
-          description: Registered client relative URL in the format `clients/<client_id>`
+          description: Registered device relative URL in the format `devices/<device_id>`
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Client"
+            $ref: "#/components/schemas/Device"
       links:
         get:
-          operationId: getClient
+          operationId: getDevice
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
         update:
-          operationId: updateClient
+          operationId: updateDevice
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
         update_tags:
-          operationId: updateClientTags
+          operationId: updateDeviceTags
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
         update_secret:
-          operationId: updateClientSecret
+          operationId: updateDeviceSecret
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
         disable:
-          operationId: disableClient
+          operationId: disableDevice
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
         enable:
-          operationId: enableClient
+          operationId: enableDevice
           parameters:
-            clientID: $response.body#/id
+            deviceID: $response.body#/id
 
-    ClientRes:
+    DeviceRes:
       description: Data retrieved.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Client"
+            $ref: "#/components/schemas/Device"
 
-    DisabledClientRes:
+    DisabledDeviceRes:
       description: Data retrieved.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/DisabledClient"
+            $ref: "#/components/schemas/DisabledDevice"
 
-    ClientPageRes:
+    DevicePageRes:
       description: Data retrieved.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientsPage"
+            $ref: "#/components/schemas/DevicesPage"
 
-    ClientsPageRes:
+    DevicesPageRes:
       description: Data retrieved.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ClientsPage"
+            $ref: "#/components/schemas/DevicesPage"
 
     HealthRes:
       description: Service Health Check.
@@ -1579,7 +1579,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        * Client access: "Authorization: Bearer <user_access_token>"
+        * Device access: "Authorization: Bearer <user_access_token>"
 
 security:
   - bearerAuth: []

--- a/auth/pat.go
+++ b/auth/pat.go
@@ -24,8 +24,8 @@ const (
 	OpCreate = "create"
 	OpList   = "list"
 
-	OpCreateClients  = "create_clients"
-	OpListClients    = "list_clients"
+	OpCreateDevices  = "create_devices"
+	OpListDevices    = "list_devices"
 	OpCreateChannels = "create_channels"
 	OpListChannels   = "list_channels"
 	OpCreateGroups   = "create_groups"
@@ -72,23 +72,27 @@ const (
 
 type EntityType uint32
 
+// Pinned explicitly rather than left as iota: EntityType is never persisted
+// or transmitted as a number (spec §8 C2), but pinning means this block can
+// never become load-bearing by accident later. 2 (former ClientsType) is
+// retired, not reused, so no future constant silently inherits old meaning.
 const (
-	GroupsType EntityType = iota
-	ChannelsType
-	ClientsType
-	BootstrapType
-	DashboardType
-	MessagesType
-	DomainsType
-	UsersType
-	RulesType
-	ReportsType
+	GroupsType    EntityType = 0
+	ChannelsType  EntityType = 1
+	BootstrapType EntityType = 3
+	DashboardType EntityType = 4
+	MessagesType  EntityType = 5
+	DomainsType   EntityType = 6
+	UsersType     EntityType = 7
+	RulesType     EntityType = 8
+	ReportsType   EntityType = 9
+	DevicesType   EntityType = 10
 )
 
 const (
 	GroupsScopeStr   = "groups"
 	ChannelsScopeStr = "channels"
-	ClientsScopeStr  = "clients"
+	DevicesScopeStr  = "devices"
 	BootstrapStr     = "bootstrap"
 	DashboardsStr    = "dashboards"
 	MessagesStr      = "messages"
@@ -104,8 +108,8 @@ func (et EntityType) String() string {
 		return GroupsScopeStr
 	case ChannelsType:
 		return ChannelsScopeStr
-	case ClientsType:
-		return ClientsScopeStr
+	case DevicesType:
+		return DevicesScopeStr
 	case BootstrapType:
 		return BootstrapStr
 	case DashboardType:
@@ -131,8 +135,8 @@ func ParseEntityType(et string) (EntityType, error) {
 		return GroupsType, nil
 	case ChannelsScopeStr:
 		return ChannelsType, nil
-	case ClientsScopeStr:
-		return ClientsType, nil
+	case DevicesScopeStr:
+		return DevicesType, nil
 	case BootstrapStr:
 		return BootstrapType, nil
 	case DashboardsStr:
@@ -175,7 +179,7 @@ func (et *EntityType) UnmarshalText(data []byte) (err error) {
 
 func IsValidOperationForEntity(entityType EntityType, operation string) bool {
 	switch entityType {
-	case ClientsType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
+	case DevicesType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
 		return true
 	case DashboardType:
 		return operation == OpDashboardShare || operation == OpDashboardUnshare
@@ -203,7 +207,7 @@ func IsValidOperationForEntity(entityType EntityType, operation string) bool {
 //     },
 //     {
 //         "domain_id": "domain_1",
-//         "entity_type": "clients",
+//         "entity_type": "devices",
 //         "operation": "update",
 //         "entity_id": "*"
 //     }
@@ -227,12 +231,12 @@ func (s *Scope) UnmarshalJSON(data []byte) error {
 	}
 
 	switch s.EntityType {
-	case ClientsType:
+	case DevicesType:
 		switch s.Operation {
 		case OpCreate:
-			s.Operation = OpCreateClients
+			s.Operation = OpCreateDevices
 		case OpList:
-			s.Operation = OpListClients
+			s.Operation = OpListDevices
 		}
 	case ChannelsType:
 		switch s.Operation {

--- a/auth/pat_test.go
+++ b/auth/pat_test.go
@@ -27,9 +27,9 @@ func TestEntityTypeString(t *testing.T) {
 			expected: "channels",
 		},
 		{
-			desc:     "Clients entity type",
-			et:       auth.ClientsType,
-			expected: "clients",
+			desc:     "Devices entity type",
+			et:       auth.DevicesType,
+			expected: "devices",
 		},
 		{
 			desc:     "Bootstrap entity type",
@@ -91,9 +91,9 @@ func TestParseEntityType(t *testing.T) {
 			err:      false,
 		},
 		{
-			desc:     "Parse clients",
-			et:       "clients",
-			expected: auth.ClientsType,
+			desc:     "Parse devices",
+			et:       "devices",
+			expected: auth.DevicesType,
 			err:      false,
 		},
 		{
@@ -161,9 +161,9 @@ func TestEntityTypeMarshalJSON(t *testing.T) {
 			err:      nil,
 		},
 		{
-			desc:     "Marshal clients",
-			et:       auth.ClientsType,
-			expected: []byte(`"clients"`),
+			desc:     "Marshal devices",
+			et:       auth.DevicesType,
+			expected: []byte(`"devices"`),
 			err:      nil,
 		},
 		{

--- a/auth/postgres/init.go
+++ b/auth/postgres/init.go
@@ -143,6 +143,17 @@ func Migration() *migrate.MemoryMigrationSource {
 					`DROP INDEX IF EXISTS idx_pats_user_id;`,
 				},
 			},
+			{
+				// ClientsType was removed; rows keep working under the new name
+				// rather than failing ParseEntityType (edge/architecture.md §8 C2).
+				Id: "auth_9",
+				Up: []string{
+					`UPDATE pat_scopes SET entity_type = 'devices' WHERE entity_type = 'clients';`,
+				},
+				Down: []string{
+					`UPDATE pat_scopes SET entity_type = 'clients' WHERE entity_type = 'devices';`,
+				},
+			},
 		},
 	}
 }

--- a/auth/postgres/pat_scope_migration_test.go
+++ b/auth/postgres/pat_scope_migration_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/absmach/magistrala/auth"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPatScopesClientsMigration proves the auth_9 migration statement turns a
+// pre-change 'clients' scope row into 'devices' instead of leaving it to fail
+// ParseEntityType once ClientsType is gone (edge/architecture.md §8 C2).
+func TestPatScopesClientsMigration(t *testing.T) {
+	ctx := context.Background()
+	patID := generateID(t)
+	scopeID := generateID(t)
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pats (id, name) VALUES ($1, $2)`, patID, "legacy-pat")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM pats WHERE id = $1`, patID)
+	})
+
+	// Simulates a scope row written before ClientsType was removed.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO pat_scopes (id, pat_id, domain_id, entity_type, operation, entity_id)
+		VALUES ($1, $2, $3, 'clients', 'update', $4)`,
+		scopeID, patID, generateID(t), auth.AnyIDs)
+	require.NoError(t, err)
+
+	// Re-runs the auth_9 up statement to prove it rewrites the stale row.
+	_, err = db.ExecContext(ctx, `UPDATE pat_scopes SET entity_type = 'devices' WHERE entity_type = 'clients'`)
+	require.NoError(t, err)
+
+	var entityType string
+	err = db.QueryRowContext(ctx, `SELECT entity_type FROM pat_scopes WHERE id = $1`, scopeID).Scan(&entityType)
+	require.NoError(t, err)
+	require.Equal(t, "devices", entityType)
+
+	parsed, err := auth.ParseEntityType(entityType)
+	require.NoError(t, err)
+	require.Equal(t, auth.DevicesType, parsed)
+}
+
+// TestParseEntityTypeRejectsRemovedClientsScope documents that an unmigrated
+// 'clients' scope is rejected outright rather than silently accepted under
+// old vocabulary — the migration above is the only path back to working.
+func TestParseEntityTypeRejectsRemovedClientsScope(t *testing.T) {
+	_, err := auth.ParseEntityType("clients")
+	require.Error(t, err)
+}

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -938,7 +938,7 @@ func TestAuthorize(t *testing.T) {
 			patAuthz: &auth.PATAuthz{
 				PatID:      validID,
 				UserID:     userID,
-				EntityType: auth.ClientsType,
+				EntityType: auth.DevicesType,
 				EntityID:   validID,
 				Operation:  "read",
 				Domain:     domainID,
@@ -1029,7 +1029,7 @@ func TestAuthorize(t *testing.T) {
 			patAuthz: &auth.PATAuthz{
 				PatID:      validID,
 				UserID:     userID,
-				EntityType: auth.ClientsType,
+				EntityType: auth.DevicesType,
 				EntityID:   validID,
 				Operation:  "read",
 				Domain:     domainID,
@@ -1052,7 +1052,7 @@ func TestAuthorize(t *testing.T) {
 			patAuthz: &auth.PATAuthz{
 				PatID:      validID,
 				UserID:     userID,
-				EntityType: auth.ClientsType,
+				EntityType: auth.DevicesType,
 				EntityID:   validID,
 				Operation:  "write",
 				Domain:     domainID,

--- a/cli/atom.go
+++ b/cli/atom.go
@@ -1,0 +1,15 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import "github.com/absmach/magistrala/pkg/atom"
+
+// Keep the Atom client handle in a package-level var, mirroring sdk.go's
+// smqsdk.SDK. Whoever restores cmd/cli/main.go wires this up; unused for now.
+var atomClient *atom.Client
+
+// SetAtomClient sets the Atom client instance used by devices/gateways commands.
+func SetAtomClient(c *atom.Client) {
+	atomClient = c
+}

--- a/cli/atom_fake_test.go
+++ b/cli/atom_fake_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+)
+
+type gqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+// fakeAtom is a minimal in-memory Atom GraphQL stand-in for command-level CLI
+// tests, mirroring pkg/atom/devices_test.go's fake server on the atom side —
+// duplicated rather than imported since that helper is unexported there.
+type fakeAtom struct {
+	t        *testing.T
+	entities map[string]atom.Entity
+	seq      int
+	requests []gqlRequest
+
+	getCount    map[string]int
+	mutateAtGet map[string]int
+	mutateAttrs map[string]atom.Attributes
+}
+
+// mutateOnNthGet swaps id's attributes in after its nth GetEntity call,
+// simulating a concurrent write landing between the CLI's DeviceGateways
+// read and SetDeviceGateways' own internal re-read.
+func (fa *fakeAtom) mutateOnNthGet(id string, n int, attrs atom.Attributes) {
+	if fa.mutateAtGet == nil {
+		fa.mutateAtGet = map[string]int{}
+		fa.mutateAttrs = map[string]atom.Attributes{}
+	}
+	fa.mutateAtGet[id] = n
+	fa.mutateAttrs[id] = attrs
+}
+
+func newFakeAtom(t *testing.T, seed ...atom.Entity) *fakeAtom {
+	t.Helper()
+	fa := &fakeAtom{t: t, entities: map[string]atom.Entity{}, getCount: map[string]int{}}
+	for _, e := range seed {
+		fa.entities[e.ID] = e
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fa.handle))
+	t.Cleanup(srv.Close)
+	cli.SetAtomClient(atom.NewClient(atom.Config{URL: srv.URL}))
+	return fa
+}
+
+func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
+	var req gqlRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		fa.t.Fatalf("decode graphql request: %v", err)
+	}
+	fa.requests = append(fa.requests, req)
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case strings.Contains(req.Query, "mutation CreateEntity"):
+		fa.handleCreate(w, req)
+	case strings.Contains(req.Query, "mutation UpdateEntity"):
+		fa.handleUpdate(w, req)
+	case strings.Contains(req.Query, "mutation DeleteEntity"):
+		fa.handleDelete(w, req)
+	case strings.Contains(req.Query, "query Entity("):
+		fa.handleGet(w, req)
+	case strings.Contains(req.Query, "query Entities("):
+		fa.handleList(w, req)
+	default:
+		fa.t.Fatalf("unexpected graphql query: %s", req.Query)
+	}
+}
+
+func (fa *fakeAtom) handleCreate(w http.ResponseWriter, req gqlRequest) {
+	input, _ := req.Variables["input"].(map[string]any)
+	fa.seq++
+	e := atom.Entity{
+		ID:         fmt.Sprintf("device-%d", fa.seq),
+		Kind:       strVal(input["kind"]),
+		Name:       strVal(input["name"]),
+		TenantID:   strVal(input["tenantId"]),
+		Status:     "active",
+		Attributes: attrsVal(input["attributes"]),
+	}
+	fa.entities[e.ID] = e
+	writeGQLData(fa.t, w, map[string]any{"createEntity": entityJSON(e)})
+}
+
+func (fa *fakeAtom) handleUpdate(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	e, ok := fa.entities[id]
+	if !ok {
+		writeGQLError(fa.t, w, "entity not found")
+		return
+	}
+	input, _ := req.Variables["input"].(map[string]any)
+	if name := strVal(input["name"]); name != "" {
+		e.Name = name
+	}
+	if status := strVal(input["status"]); status != "" {
+		e.Status = status
+	}
+	if attrs, ok := input["attributes"].(map[string]any); ok {
+		e.Attributes = atom.Attributes(attrs)
+	}
+	fa.entities[id] = e
+	writeGQLData(fa.t, w, map[string]any{"updateEntity": entityJSON(e)})
+}
+
+func (fa *fakeAtom) handleDelete(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	if _, ok := fa.entities[id]; !ok {
+		writeGQLError(fa.t, w, "entity not found")
+		return
+	}
+	delete(fa.entities, id)
+	writeGQLData(fa.t, w, map[string]any{"deleteEntity": true})
+}
+
+func (fa *fakeAtom) handleGet(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	fa.getCount[id]++
+	if n, ok := fa.mutateAtGet[id]; ok && fa.getCount[id] == n {
+		e := fa.entities[id]
+		e.Attributes = fa.mutateAttrs[id]
+		fa.entities[id] = e
+	}
+
+	e, ok := fa.entities[id]
+	if !ok {
+		writeGQLError(fa.t, w, "entity not found")
+		return
+	}
+	writeGQLData(fa.t, w, map[string]any{"entity": entityJSON(e)})
+}
+
+func (fa *fakeAtom) handleList(w http.ResponseWriter, req gqlRequest) {
+	kind := strVal(req.Variables["kind"])
+	tenantID := strVal(req.Variables["tenantId"])
+	contains, _ := req.Variables["attributesContains"].(map[string]any)
+
+	var items []map[string]any
+	for _, e := range fa.entities {
+		if kind != "" && e.Kind != kind {
+			continue
+		}
+		if tenantID != "" && e.TenantID != tenantID {
+			continue
+		}
+		if contains != nil && !entityMatchesContains(e, contains) {
+			continue
+		}
+		items = append(items, entityJSON(e))
+	}
+	writeGQLData(fa.t, w, map[string]any{"entities": map[string]any{"items": items, "total": len(items)}})
+}
+
+func strVal(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func attrsVal(v any) atom.Attributes {
+	m, _ := v.(map[string]any)
+	if m == nil {
+		return atom.Attributes{}
+	}
+	return atom.Attributes(m)
+}
+
+func entityJSON(e atom.Entity) map[string]any {
+	attrs := map[string]any(e.Attributes)
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+	return map[string]any{
+		"id":         e.ID,
+		"kind":       e.Kind,
+		"name":       e.Name,
+		"tenant_id":  e.TenantID,
+		"status":     e.Status,
+		"attributes": attrs,
+	}
+}
+
+// entityMatchesContains reimplements Atom's JSONB containment just enough
+// for these tests: every key must be present, list values match by element.
+// Attributes seeded directly hold []string; attributes that passed through a
+// real GraphQL round-trip decode to []any — normalise both before comparing.
+func entityMatchesContains(e atom.Entity, contains map[string]any) bool {
+	for k, want := range contains {
+		got, ok := e.Attributes[k]
+		if !ok {
+			return false
+		}
+		wantList := toStringSlice(want)
+		if wantList == nil {
+			if got != want {
+				return false
+			}
+			continue
+		}
+		gotList := toStringSlice(got)
+		for _, w := range wantList {
+			found := false
+			for _, g := range gotList {
+				if g == w {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func toStringSlice(v any) []string {
+	switch vv := v.(type) {
+	case []string:
+		return vv
+	case []any:
+		out := make([]string, 0, len(vv))
+		for _, item := range vv {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func writeGQLData(t *testing.T, w http.ResponseWriter, data map[string]any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(map[string]any{"data": data}); err != nil {
+		t.Fatalf("encode graphql response: %v", err)
+	}
+}
+
+func writeGQLError(t *testing.T, w http.ResponseWriter, message string) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"errors": []map[string]string{{"message": message}},
+	}); err != nil {
+		t.Fatalf("encode graphql error response: %v", err)
+	}
+}

--- a/cli/devices.go
+++ b/cli/devices.go
@@ -1,0 +1,226 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/spf13/cobra"
+)
+
+// atomKindDevice is the literal Atom wire kind for CreateEntity/ListEntities.
+// atom.KindDevice and atom.KindClient are both the Magistrala-internal label
+// "client" — entityCreateInput passes Kind through unmodified, so using
+// either constant here would send the wrong value to Atom.
+const atomKindDevice = "device"
+
+// UpdateEntity passes Status straight to Atom's GraphQL EntityStatus enum
+// without going through pkg/atom's enabled/disabled translator, so the wire
+// vocabulary here is Atom's (active/inactive), not Magistrala's.
+const (
+	atomEntityStatusActive   = "active"
+	atomEntityStatusInactive = "inactive"
+)
+
+const (
+	usageDeviceCreate  = "cli devices create <JSON_device> <domain_id>"
+	usageDeviceGet     = "cli devices <device_id|all> get <domain_id>"
+	usageDeviceUpdate  = "cli devices <device_id> update <JSON_string>"
+	usageDeviceDelete  = "cli devices <device_id> delete"
+	usageDeviceEnable  = "cli devices <device_id> enable"
+	usageDeviceDisable = "cli devices <device_id> disable"
+)
+
+func NewDevicesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "devices <device_id|all|create> [operation] [args...]",
+		Short: "Devices management",
+		Long: `Format:
+  devices create <JSON_device> <domain_id>
+  devices <device_id|all> <operation> [args...]
+
+Operations (require device_id/all): get, update, delete, enable, disable
+
+A gateway is a device with attributes.is_gateway set — create or update one
+with this command, then use "gateways" to manage its reachability relation.
+
+Examples:
+  devices create <JSON_device> <domain_id>
+  devices all get <domain_id>
+  devices <device_id> get
+  devices <device_id> update <JSON_string>
+  devices <device_id> delete
+  devices <device_id> enable
+  devices <device_id> disable`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+
+			if args[0] == create {
+				handleDeviceCreate(cmd, args[1:])
+				return
+			}
+
+			if len(args) < 2 {
+				logUsageCmd(*cmd, "devices <device_id|all> <get|update|delete|enable|disable> [args...]")
+				return
+			}
+
+			deviceParams := args[0]
+			operation := args[1]
+			opArgs := args[2:]
+
+			switch operation {
+			case get:
+				handleDeviceGet(cmd, deviceParams, opArgs)
+			case update:
+				handleDeviceUpdate(cmd, deviceParams, opArgs)
+			case delete:
+				handleDeviceDelete(cmd, deviceParams, opArgs)
+			case enable:
+				handleDeviceEnable(cmd, deviceParams, opArgs)
+			case disable:
+				handleDeviceDisable(cmd, deviceParams, opArgs)
+			default:
+				logErrorCmd(*cmd, fmt.Errorf("unknown operation: %s", operation))
+			}
+		},
+	}
+
+	return cmd
+}
+
+func handleDeviceCreate(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		logUsageCmd(*cmd, usageDeviceCreate)
+		return
+	}
+
+	var device atom.Entity
+	if err := json.Unmarshal([]byte(args[0]), &device); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+	device.Kind = atomKindDevice
+	device.TenantID = args[1]
+
+	created, err := atomClient.CreateEntity(cmd.Context(), device)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleDeviceGet's "all" branch lists devices in a domain, mirroring
+// channels.go's get-with-all-sentinel shape; a single device ID needs no
+// domain argument since GetEntity takes only the entity ID.
+func handleDeviceGet(cmd *cobra.Command, deviceID string, args []string) {
+	if deviceID == all {
+		if len(args) != 1 {
+			logUsageCmd(*cmd, usageDeviceGet)
+			return
+		}
+
+		q := atom.Query{
+			Kind:     atomKindDevice,
+			TenantID: args[0],
+			Q:        Name,
+			Limit:    Limit,
+			Offset:   Offset,
+		}
+		l, err := atomClient.ListEntities(cmd.Context(), q)
+		if err != nil {
+			logErrorCmd(*cmd, err)
+			return
+		}
+
+		logJSONCmd(*cmd, l)
+		return
+	}
+
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceGet)
+		return
+	}
+
+	d, err := atomClient.GetEntity(cmd.Context(), deviceID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, d)
+}
+
+func handleDeviceUpdate(cmd *cobra.Command, deviceID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageDeviceUpdate)
+		return
+	}
+
+	var device atom.Entity
+	if err := json.Unmarshal([]byte(args[0]), &device); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	updated, err := atomClient.UpdateEntity(cmd.Context(), deviceID, device)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, updated)
+}
+
+func handleDeviceDelete(cmd *cobra.Command, deviceID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceDelete)
+		return
+	}
+
+	if err := atomClient.DeleteEntity(cmd.Context(), deviceID); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logOKCmd(*cmd)
+}
+
+func handleDeviceEnable(cmd *cobra.Command, deviceID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceEnable)
+		return
+	}
+
+	d, err := atomClient.UpdateEntity(cmd.Context(), deviceID, atom.Entity{Status: atomEntityStatusActive})
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, d)
+}
+
+func handleDeviceDisable(cmd *cobra.Command, deviceID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceDisable)
+		return
+	}
+
+	d, err := atomClient.UpdateEntity(cmd.Context(), deviceID, atom.Entity{Status: atomEntityStatusInactive})
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, d)
+}

--- a/cli/devices_test.go
+++ b/cli/devices_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevicesCreateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	deviceJSON := `{"name":"pump-1","attributes":{"is_gateway":true}}`
+	out := executeCommand(t, rootCmd, createCmd, deviceJSON, "domain-1")
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device", got.Kind)
+	assert.Equal(t, "pump-1", got.Name)
+	assert.Equal(t, "domain-1", got.TenantID)
+	assert.Equal(t, true, got.Attributes["is_gateway"])
+
+	// The literal wire kind must be "device" — atom.KindDevice/KindClient
+	// both equal "client" and would be wrong here (see cli/devices.go).
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "device", input["kind"])
+}
+
+func TestDevicesGetCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Name: "pump-1", TenantID: "domain-1"})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", getCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device-1", got.ID)
+	assert.Equal(t, "pump-1", got.Name)
+}
+
+func TestDevicesGetAllCmd(t *testing.T) {
+	newFakeAtom(t,
+		atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"},
+		atom.Entity{ID: "device-2", Kind: "device", TenantID: "domain-1"},
+		atom.Entity{ID: "device-3", Kind: "device", TenantID: "domain-2"},
+	)
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd, "domain-1")
+
+	var got atom.EntityList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+}
+
+func TestDevicesUpdateCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Name: "old-name", TenantID: "domain-1"})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", updateCmd, `{"name":"new-name"}`)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "new-name", got.Name)
+}
+
+func TestDevicesDeleteCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device"})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", deleteCmd)
+
+	assert.Contains(t, out, "ok")
+	_, exists := fa.entities["device-1"]
+	assert.False(t, exists)
+}
+
+// TestDevicesEnableCmd pins the trap: UpdateEntity's status wire value is
+// Atom's vocabulary (active/inactive), not Magistrala's (enabled/disabled).
+func TestDevicesEnableCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Status: "inactive"})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", enableCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "active", got.Status)
+
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "active", input["status"], "must send Atom's wire vocabulary, not \"enabled\"")
+}
+
+func TestDevicesDisableCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Status: "active"})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", disableCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "inactive", got.Status)
+
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "inactive", input["status"], "must send Atom's wire vocabulary, not \"disabled\"")
+}
+
+func TestDevicesCmdUsageOnMissingArgs(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", updateCmd)
+
+	assert.Contains(t, out, "usage")
+}

--- a/cli/gateways.go
+++ b/cli/gateways.go
@@ -1,0 +1,120 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/spf13/cobra"
+)
+
+const (
+	usageGatewaysSet     = "cli gateways set <device_id> <gateway_id1,gateway_id2,...>"
+	usageGatewaysDevices = "cli gateways <gateway_id> devices <domain_id>"
+)
+
+// NewGatewaysCmd is a thin view over devices filtered by is_gateway, not a
+// separate entity surface — creating/editing a gateway is "devices" with
+// attributes.is_gateway set (spec §8 A12).
+func NewGatewaysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gateways <set|gateway_id> [operation] [args...]",
+		Short: "Device-gateway reachability",
+		Long: `Format:
+  gateways set <device_id> <gateway_id1,gateway_id2,...>
+  gateways <gateway_id> devices <domain_id>
+
+Examples:
+  gateways set device-123 gw-1,gw-2
+  gateways gw-1 devices domain-1`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+
+			if args[0] == "set" {
+				handleSetDeviceGateways(cmd, args[1:])
+				return
+			}
+
+			if len(args) < 2 {
+				logUsageCmd(*cmd, usageGatewaysDevices)
+				return
+			}
+
+			gatewayID := args[0]
+			operation := args[1]
+			opArgs := args[2:]
+
+			switch operation {
+			case "devices":
+				handleGatewayDevices(cmd, gatewayID, opArgs)
+			default:
+				logErrorCmd(*cmd, fmt.Errorf("unknown operation: %s", operation))
+			}
+		},
+	}
+
+	return cmd
+}
+
+// handleSetDeviceGateways reads the device's current gateways to use as
+// expectedCurrent, so a conflicting concurrent write is reported rather than
+// silently clobbered (pkg/atom/devices.go's optimistic-concurrency contract).
+func handleSetDeviceGateways(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		logUsageCmd(*cmd, usageGatewaysSet)
+		return
+	}
+
+	deviceID := args[0]
+	var gatewayIDs []string
+	if args[1] != "" {
+		gatewayIDs = strings.Split(args[1], ",")
+	}
+
+	ctx := cmd.Context()
+	current, err := atomClient.DeviceGateways(ctx, deviceID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	if err := atomClient.SetDeviceGateways(ctx, deviceID, gatewayIDs, current); err != nil {
+		if errors.Is(err, atom.ErrGatewaysConflict) {
+			logErrorCmd(*cmd, fmt.Errorf("gateways changed since last read, re-run to retry: %w", err))
+			return
+		}
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logOKCmd(*cmd)
+}
+
+func handleGatewayDevices(cmd *cobra.Command, gatewayID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageGatewaysDevices)
+		return
+	}
+
+	q := atom.Query{
+		TenantID: args[0],
+		Limit:    Limit,
+		Offset:   Offset,
+	}
+
+	l, err := atomClient.GatewayDevices(cmd.Context(), gatewayID, q)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, l)
+}

--- a/cli/gateways_test.go
+++ b/cli/gateways_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewaysSetCmd(t *testing.T) {
+	fa := newFakeAtom(t,
+		atom.Entity{ID: "device-1", Kind: "device", Attributes: atom.Attributes{"gateways": []string{"gw-old"}}},
+		atom.Entity{ID: "gw-old", Kind: "device", Attributes: atom.Attributes{"is_gateway": true}},
+	)
+	rootCmd := setFlags(cli.NewGatewaysCmd())
+
+	out := executeCommand(t, rootCmd, "set", "device-1", "gw-1,gw-2")
+
+	assert.Contains(t, out, "ok")
+	gws := toStringSlice(fa.entities["device-1"].Attributes["gateways"])
+	assert.ElementsMatch(t, []string{"gw-1", "gw-2"}, gws)
+}
+
+func TestGatewaysSetCmdClearsList(t *testing.T) {
+	// gw-old must resolve as a live entity: DeviceGateways silently drops
+	// stale references (pkg/atom/devices.go), and an unseeded ID here would
+	// make the CLI's "current" disagree with the raw stored value, always
+	// conflicting for the wrong reason.
+	fa := newFakeAtom(t,
+		atom.Entity{ID: "device-1", Kind: "device", Attributes: atom.Attributes{"gateways": []string{"gw-old"}}},
+		atom.Entity{ID: "gw-old", Kind: "device", Attributes: atom.Attributes{"is_gateway": true}},
+	)
+	rootCmd := setFlags(cli.NewGatewaysCmd())
+
+	out := executeCommand(t, rootCmd, "set", "device-1", "")
+
+	assert.Contains(t, out, "ok")
+	gws := toStringSlice(fa.entities["device-1"].Attributes["gateways"])
+	assert.Empty(t, gws)
+}
+
+// TestGatewaysSetCmdConflict simulates a concurrent write landing between
+// the CLI's read and write, and asserts it surfaces as a clear error rather
+// than silently clobbering (pkg/atom/devices.go's concurrency contract).
+func TestGatewaysSetCmdConflict(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Attributes: atom.Attributes{"gateways": []string{"gw-old"}}})
+	fa.mutateOnNthGet("device-1", 2, atom.Attributes{"gateways": []string{"gw-changed"}})
+
+	rootCmd := setFlags(cli.NewGatewaysCmd())
+	out := executeCommand(t, rootCmd, "set", "device-1", "gw-1,gw-2")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "gateways changed")
+
+	// The write must not have happened.
+	gws := toStringSlice(fa.entities["device-1"].Attributes["gateways"])
+	assert.Equal(t, []string{"gw-changed"}, gws)
+}
+
+func TestGatewaysDevicesCmd(t *testing.T) {
+	newFakeAtom(t,
+		atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1", Attributes: atom.Attributes{"gateways": []string{"gw-1"}}},
+		atom.Entity{ID: "device-2", Kind: "device", TenantID: "domain-1", Attributes: atom.Attributes{"gateways": []string{"gw-2"}}},
+		atom.Entity{ID: "device-3", Kind: "device", TenantID: "domain-1", Attributes: atom.Attributes{"gateways": []string{"gw-1", "gw-2"}}},
+	)
+	rootCmd := setFlags(cli.NewGatewaysCmd())
+
+	out := executeCommand(t, rootCmd, "gw-1", "devices", "domain-1")
+
+	var got atom.EntityList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+
+	ids := map[string]bool{}
+	for _, item := range got.Items {
+		ids[item.ID] = true
+	}
+	assert.True(t, ids["device-1"])
+	assert.True(t, ids["device-3"])
+	assert.False(t, ids["device-2"])
+}

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test constants mirror cli package's unexported operation names (create,
+// get, update, delete, enable, disable) — can't reference those directly
+// from this external test package.
+const (
+	createCmd  = "create"
+	getCmd     = "get"
+	updateCmd  = "update"
+	deleteCmd  = "delete"
+	enableCmd  = "enable"
+	disableCmd = "disable"
+	allCmd     = "all"
+)
+
+func executeCommand(t *testing.T, root *cobra.Command, args ...string) string {
+	t.Helper()
+	buffer := new(bytes.Buffer)
+	root.SetOut(buffer)
+	root.SetErr(buffer)
+	root.SetArgs(args)
+	err := root.Execute()
+	assert.NoError(t, err, "Error executing command")
+	return buffer.String()
+}
+
+func setFlags(rootCmd *cobra.Command) *cobra.Command {
+	rootCmd.PersistentFlags().BoolVarP(&cli.RawOutput, "raw", "r", cli.RawOutput, "Enables raw output mode for easier parsing of output")
+	rootCmd.PersistentFlags().Uint64VarP(&cli.Limit, "limit", "l", 10, "Limit query parameter")
+	rootCmd.PersistentFlags().Uint64VarP(&cli.Offset, "offset", "o", 0, "Offset query parameter")
+	rootCmd.PersistentFlags().StringVarP(&cli.Name, "name", "n", "", "Name query parameter")
+
+	return rootCmd
+}

--- a/docker/permission.yaml
+++ b/docker/permission.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Abstract Machines
 # SPDX-License-Identifier: Apache-2.0
 
-clients:
+devices:
   operations:
     - view: read_permission
     - update: update_permission
@@ -14,6 +14,7 @@ clients:
     - remove_parent_group: set_parent_group_permission
     - connect_to_channel: connect_to_channel_permission
     - disconnect_from_channel: connect_to_channel_permission
+    - set_gateways: set_gateways_permission
   roles_operations:
     - add: manage_role_permission
     - remove: manage_role_permission

--- a/pkg/permissions/config_test.go
+++ b/pkg/permissions/config_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package permissions_test
+
+import (
+	"testing"
+
+	"github.com/absmach/magistrala/pkg/permissions"
+	"github.com/stretchr/testify/require"
+)
+
+// permissionsFilePath points at the real deployed config, not a fixture —
+// this is what actually ships, so it is what must validate.
+const permissionsFilePath = "../../docker/permission.yaml"
+
+func TestParsePermissionsFileValidates(t *testing.T) {
+	_, err := permissions.ParsePermissionsFile(permissionsFilePath)
+	require.NoError(t, err)
+}
+
+func TestDevicesEntityReplacesClients(t *testing.T) {
+	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
+	require.NoError(t, err)
+
+	// "clients" must be gone (acceptance criterion 9).
+	_, _, err = cfg.GetEntityPermissions("clients")
+	require.Error(t, err)
+
+	ops, roleOps, err := cfg.GetEntityPermissions("devices")
+	require.NoError(t, err)
+	require.NotEmpty(t, roleOps)
+
+	perm, ok := ops["set_gateways"]
+	require.True(t, ok, "devices block must declare set_gateways")
+	require.Equal(t, permissions.Permission("set_gateways_permission"), perm)
+
+	// A representative sample of the ordinary CRUD ops carried over unchanged.
+	for _, op := range []string{"view", "update", "enable", "disable", "delete"} {
+		_, ok := ops[op]
+		require.True(t, ok, "devices block must still declare %s", op)
+	}
+}
+
+func TestNoGatewaysEntityBlock(t *testing.T) {
+	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
+	require.NoError(t, err)
+
+	// A gateway is a device (spec §8 A12) — there must be no separate block.
+	_, _, err = cfg.GetEntityPermissions("gateways")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Implements MG-11 — the four remaining surfaces still speaking `client` after MG-09's Device/Gateway model landed in `pkg/atom`: the CLI, PAT scopes, the permission matrix, and the published OpenAPI docs.

- **CLI** (`cli/devices.go`, `cli/gateways.go`, `cli/atom.go` — net-new): create/get(view+list)/update/enable/disable/delete for devices, and a thin gateways view (`set` a device's gateway list, list a gateway's declared devices). Wired through `pkg/atom.Client` directly rather than `pkg/sdk`, since `pkg/sdk` hits HTTP routes no `cmd/` binary serves anymore — same pattern already used in `magistrala-ui`'s solutions installer. `cmd/cli/main.go` stays deleted (confirmed out of scope); these commands are tested at the package level only.
- **PAT scopes** (`auth/pat.go`): `ClientsType` removed outright, `DevicesType` added, no separate `GatewaysType` (a gateway is a device). `EntityType`'s values are pinned as explicit literals instead of `iota` — every surviving member keeps its exact prior value, only the retired slot (2) isn't reused. A new `auth_9` migration rewrites stale `pat_scopes` rows from `entity_type='clients'` to `'devices'` rather than dropping them.
- **Permissions** (`docker/permission.yaml`): the `clients:` block becomes `devices:`, unchanged operations carried over, plus a new `set_gateways` operation with its **own** permission (`set_gateways_permission`) rather than folding it into `update_permission` — re-pointing a device's gateways is a meaningfully more sensitive act than an ordinary field rename, and least-privilege grants should be able to separate them. No `gateways:` block. `pkg/permissions` is confirmed config-driven with no hardcoded `"clients"` string anywhere in Go — no code changes needed there, just a new test loading the real file.
- **OpenAPI** (`apidocs/openapi/clients.yaml` → `devices.yaml`): full mechanical rename across ~1585 lines — title, tags, paths, operationIds, schema names, parameters, request/response bodies, examples — keeping `$ref` consistency throughout. Two false-positive matches from the mechanical pass ("the API clients must ensure...", meaning API callers, not the entity) were manually corrected to "the API caller must ensure...".

## Traps traced against source rather than assumed (per the PRD)

- `Entity.Kind` for `CreateEntity` must be the literal string `"device"` — `atom.KindDevice`/`atom.KindClient` both equal the Magistrala-internal label `"client"`, and `entityCreateInput` passes `Kind` through unmodified.
- `UpdateEntity`'s `Status` field is sent to Atom's GraphQL `EntityStatus` enum **verbatim** — `entityUpdateInput` does not call the `enabled`/`disabled` → `active`/`inactive` translator. Confirmed against `absmach/atom`'s `GqlEntityStatus` (`rename_items = "snake_case"`, values `active`/`inactive`/`suspended`) that the wire vocabulary is Atom's, not Magistrala's. `enable`/`disable` in the CLI send `active`/`inactive` directly.
- `pkg/atom.Entity` has no first-class `Serial`/`ExternalID` field — ATOM-06's `externalId` never made it into `entityCreateInput`/`entityUpdateInput` on the Go side (confirmed by grep). `serial` and `is_gateway` are both plain attributes for now, set via the JSON body's `attributes` map, matching how `gateways` is already handled.
- `EntityType` is never persisted or transmitted as a number (DB column, JSON, text, gRPC all carry the name string) — confirmed against `auth/postgres/init.go`, `auth/pat.go`'s (un)marshalling, and the gRPC proto — so renumbering is safe and the pinned values are a hygiene move, not a compatibility requirement.

## Known pre-existing "client" surfaces left untouched (out of this PR's explicit scope)

- `docker/spicedb/schema.zed` — a large SpiceDB permission schema still deeply modeled around `client_*` relations/permissions. `docker/permission.yaml`'s `domains:` block references two of those permission names (`client_create_permission`, `client_read_permission`) by literal string, so its `create_clients`/`list_clients` operation keys were left alone too — renaming either side without the other would break the mapping, and rewriting the SpiceDB schema is well beyond "replace the `clients:` block with `devices:`".
- `.github/workflows/api-tests.yaml` references `apidocs/openapi/clients.yaml` and `clients/api/http/**`; the latter directory is already deleted, so that CI job is already a no-op regardless of this PR.
- `cli/channels.go`, `cli/provision.go` — pre-existing, call the dead `pkg/sdk` HTTP path, explicitly out of scope per the PRD.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — empty
- [x] `go test ./...` — all pass
- [x] `auth/pat_test.go`: `EntityType` round-trips through `String()`/`ParseEntityType()`/JSON/text (table test, updated for `DevicesType`)
- [x] `auth/postgres/pat_scope_migration_test.go`: seeds a pre-change `entity_type='clients'` scope row, re-runs the `auth_9` migration statement, confirms it becomes `devices` and parses as `DevicesType`; a second test pins that a raw `'clients'` scope is rejected once `ClientsType` is gone
- [x] `pkg/permissions/config_test.go`: loads the real `docker/permission.yaml`, confirms `devices` replaces `clients`, no separate `gateways` block exists, and `set_gateways` is present with its own permission
- [x] `cli/devices_test.go`, `cli/gateways_test.go`, `cli/atom_fake_test.go`: command-level tests against a fake in-memory Atom GraphQL server (httptest) covering all seven device operations, the `kind`/`status` wire-value traps above, gateway set/clear/conflict handling, and gateway→devices listing
- [x] `apidocs/openapi/devices.yaml` validated with `openapi-spec-validator` (no swagger/redocly lint target exists in this repo's Makefile/CI, so I used the same tool via `uvx`)
- [x] `grep -rln "clients.yaml|Client" apidocs/` re-checked after the rename — no dangling filename references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jiL1FQFwqNXVeuqDK6v4x