### PR TITLE
Remove rejected parent_group_id attribute from pkg/atom mapping

### DIFF
--- a/pkg/atom/mapping.go
+++ b/pkg/atom/mapping.go
@@ -31,6 +31,8 @@ func TenantFromFields(f ObjectFields) Tenant {
 	}
 }
 
+// Object-group membership is many-to-many; Atom rejects parent_group_id as
+// an entity attribute, so it isn't set here — use AddGroupMember instead.
 func EntityFromFields(f ObjectFields) Entity {
 	return Entity{
 		ID:       f.ID,
@@ -44,7 +46,6 @@ func EntityFromFields(f ObjectFields) Entity {
 			atomAttributeTags:      cloneStrings(f.Tags),
 			atomAttributeMetadata:  cloneMap(f.Metadata),
 			"private_metadata":     cloneMap(f.Private),
-			"parent_group_id":      f.ParentID,
 			atomAttributeCreatedAt: timeString(f.CreatedAt),
 			atomAttributeUpdatedAt: timeString(f.UpdatedAt),
 			atomAttributeUpdatedBy: f.UpdatedBy,
@@ -116,6 +117,8 @@ func GroupFromFields(f ObjectFields) Group {
 	}
 }
 
+// Object-group membership is many-to-many; Atom rejects parent_group_id as
+// a resource attribute, so it isn't set here — use AddGroupMember instead.
 func ResourceFromFields(f ObjectFields) Resource {
 	return Resource{
 		ID:       f.ID,
@@ -127,7 +130,6 @@ func ResourceFromFields(f ObjectFields) Resource {
 			atomAttributeSource:    atomAttributeSourceMagistrala,
 			atomAttributeStatus:    f.Status,
 			atomAttributeRoute:     f.Route,
-			"parent_group_id":      f.ParentID,
 			atomAttributeTags:      cloneStrings(f.Tags),
 			atomAttributeMetadata:  cloneMap(f.Metadata),
 			atomAttributeCreatedAt: timeString(f.CreatedAt),

--- a/pkg/atom/mapping_test.go
+++ b/pkg/atom/mapping_test.go
@@ -49,8 +49,8 @@ func TestEntityFromFields(t *testing.T) {
 	if got.Attributes["magistrala_kind"] != KindDevice {
 		t.Fatalf("missing magistrala kind: %+v", got.Attributes)
 	}
-	if got.Attributes["parent_group_id"] != "group-1" {
-		t.Fatalf("missing parent group: %+v", got.Attributes)
+	if _, ok := got.Attributes["parent_group_id"]; ok {
+		t.Fatalf("parent_group_id is a rejected Atom attribute and must not be set: %+v", got.Attributes)
 	}
 }
 
@@ -75,5 +75,19 @@ func TestResourceFromFieldsOmitsEmptyValues(t *testing.T) {
 	}
 	if got.Attributes["source"] != "magistrala" {
 		t.Fatalf("missing source attribute: %+v", got.Attributes)
+	}
+}
+
+func TestResourceFromFieldsExcludesParentGroupID(t *testing.T) {
+	got := ResourceFromFields(ObjectFields{
+		ID:       "channel-1",
+		Kind:     KindChannel,
+		Name:     "telemetry",
+		TenantID: "domain-1",
+		ParentID: "group-1",
+	})
+
+	if _, ok := got.Attributes["parent_group_id"]; ok {
+		t.Fatalf("parent_group_id is a rejected Atom attribute and must not be set: %+v", got.Attributes)
 	}
 }


### PR DESCRIPTION
## Summary

Atom's many-to-many object-group migration rejects `parent_group_id` as an entity/resource attribute outright (`identity/repo.rs`'s `reject_parent_group_attribute`). `EntityFromFields`/`ResourceFromFields` in `pkg/atom/mapping.go` still wrote it, encoding a write path Atom no longer accepts.

Found while investigating a live bug report: the same class of stale `parentGroupId` handling was breaking magistrala-ui's entity/resource queries and silently no-opping group assignment on device/channel creation (fixed separately in that repo). While confirming the Go side, `EntityFromFields`/`ResourceFromFields` turned out to have zero callers anywhere in this codebase — so this doesn't change runtime behavior, group membership already goes through `Client.AddGroupMember` — but it removes a landmine for whoever wires these functions up next.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/atom/...` (full suite)
- [x] `gofmt -l` clean
- [x] Added `TestResourceFromFieldsExcludesParentGroupID` and strengthened `TestEntityFromFields` to assert the rejected attribute is never set, even when `ParentID` is supplied