### PR TITLE
NOISSUE - Restore CLI with Atom GraphQL commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ endif
 
 FILTERED_SERVICES = $(filter-out $(RUN_ADDON_ARGS), $(SERVICES))
 
-all: $(SERVICES)
+all: $(SERVICES) $(CLI)
 
 .PHONY: all help $(SERVICES) $(CLI) dockers dockers_dev latest release provision_atom_tokens provision-atom-tokens migrate_atom run_latest run_latest_ci run_tls run_stable run_addons grpc_mtls_certs check_mtls check_certs check_fluxmq_service_certs check_re_trace_key test_api mocks
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ override MG_DOCKER_IMAGE_NAME_PREFIX := ghcr.io/absmach/magistrala
 MG_DOCKER_VOLUME_NAME_PREFIX ?= magistrala
 BUILD_DIR ?= build
 SERVICES = atom-bootstrap certs postgres-writer postgres-reader timescale-writer timescale-reader fluxmq
+CLI = cli
 TEST_API_SERVICES = certs clients users channels groups domains
 TEST_API = $(addprefix test_api_,$(TEST_API_SERVICES))
 DOCKERS = $(addprefix docker_,$(SERVICES))
@@ -227,7 +228,7 @@ FILTERED_SERVICES = $(filter-out $(RUN_ADDON_ARGS), $(SERVICES))
 
 all: $(SERVICES)
 
-.PHONY: all help $(SERVICES) dockers dockers_dev latest release provision_atom_tokens provision-atom-tokens migrate_atom run_latest run_latest_ci run_tls run_stable run_addons grpc_mtls_certs check_mtls check_certs check_fluxmq_service_certs check_re_trace_key test_api mocks
+.PHONY: all help $(SERVICES) $(CLI) dockers dockers_dev latest release provision_atom_tokens provision-atom-tokens migrate_atom run_latest run_latest_ci run_tls run_stable run_addons grpc_mtls_certs check_mtls check_certs check_fluxmq_service_certs check_re_trace_key test_api mocks
 
 help:
 	@printf 'Usage:\n  make <target> [VARIABLE=value ...]\n\nAvailable targets:\n'
@@ -305,6 +306,9 @@ proto:
 	protoc -I $(INTERNAL_PROTO_DIR) --go_out=$(PKG_PROTO_GEN_OUT_DIR) --go_opt=paths=source_relative --go-grpc_out=$(PKG_PROTO_GEN_OUT_DIR) --go-grpc_opt=paths=source_relative $(INTERNAL_PROTO_FILES)
 
 $(FILTERED_SERVICES):
+	$(call compile_service,$(@))
+
+$(CLI):
 	$(call compile_service,$(@))
 
 $(DOCKERS):

--- a/README.md
+++ b/README.md
@@ -402,9 +402,13 @@ old tokens do not survive it.
 
 ```bash
 make cli
-./build/cli --graphql-url http://localhost:8080/graphql login admin 12345678
-./build/cli --token "$MG_ATOM_TOKEN" domains list
+./build/cli login admin 12345678
+./build/cli --token "$ATOM_ADMIN_TOKEN" domains list
 ```
+
+The CLI reads the same `ATOM_URL`, `ATOM_SERVICE_TOKEN`/`ATOM_ADMIN_TOKEN` and
+`ATOM_TIMEOUT` variables the services use, so a shell that has sourced
+`docker/.env` needs no extra flags.
 
 See [cli/README.md](cli/README.md) for the Atom GraphQL-backed command reference.
 

--- a/README.md
+++ b/README.md
@@ -402,8 +402,11 @@ old tokens do not survive it.
 
 ```bash
 make cli
-./build/cli health <service>
+./build/cli --graphql-url http://localhost:8080/graphql login admin 12345678
+./build/cli --token "$MG_ATOM_TOKEN" domains list
 ```
+
+See [cli/README.md](cli/README.md) for the Atom GraphQL-backed command reference.
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,22 +14,36 @@ The binary is written to `build/cli`.
 
 ## Configuration
 
-The CLI defaults to `http://localhost:8080/graphql`.
+The CLI reuses the Atom variables the rest of the deployment already sets, so a
+shell that has sourced `docker/.env` is configured:
 
-You can configure the endpoint and token with flags:
+| Variable             | Purpose                                             |
+| -------------------- | --------------------------------------------------- |
+| `ATOM_URL`           | Atom base URL; the endpoint is this plus `/graphql` |
+| `ATOM_GRAPHQL_URL`   | Full GraphQL endpoint, overrides `ATOM_URL`         |
+| `ATOM_SERVICE_TOKEN` | Bearer token, falling back to `ATOM_ADMIN_TOKEN`    |
+| `ATOM_TIMEOUT`       | Request timeout, `5s` by default                    |
+
+Without `ATOM_URL` the CLI defaults to `http://localhost:8080/graphql`.
+
+Both settings also have flags, which win over the environment:
 
 ```bash
-./build/cli --graphql-url http://localhost:8080/graphql --token "$MG_ATOM_TOKEN" domains list
+./build/cli --graphql-url http://localhost:8080/graphql --token "$ATOM_ADMIN_TOKEN" domains list
 ```
 
-Or with environment variables:
+`--graphql-url` also configures the `pkg/atom` client behind `devices`,
+`gateways` and `devicetypes`: the Atom base URL is the endpoint minus its
+trailing `/graphql`.
 
-```bash
-export MG_ATOM_GRAPHQL_URL=http://localhost:8080/graphql
-export MG_ATOM_TOKEN=<token>
-```
+These persistent flags apply to every listing command:
 
-`MAGISTRALA_TOKEN` is also accepted as a token fallback.
+| Flag | Purpose |
+| --- | --- |
+| `-l`, `--limit` | page size, `10` by default |
+| `-o`, `--offset` | records to skip |
+| `-n`, `--name` | name search, used by `devices all get` |
+| `-r`, `--raw` | raw output for easier parsing |
 
 ## Login
 
@@ -56,12 +70,15 @@ Domains map to Atom tenants.
 
 ## Clients
 
-Clients map to Atom entities. The default entity kind is `device`.
+Clients map to Atom entities. The default entity kind is `device`; the other
+`EntityKind` values are `human`, `service`, `workload` and `application`. Pass
+an empty `--kind` to list every kind.
 
 ```bash
 ./build/cli clients create <domain_id> "Thermostat 1"
 ./build/cli clients create <domain_id> "Gateway" --kind application --attributes '{"site":"lab"}'
 ./build/cli clients list <domain_id>
+./build/cli clients list <domain_id> --kind ""
 ./build/cli clients get <client_id>
 ```
 
@@ -73,6 +90,7 @@ Channels map to Atom resources with `kind="channel"`.
 ./build/cli channels create <domain_id> "Measurements"
 ./build/cli channels create <domain_id> "Alerts" --attributes '{"retention":"7d"}'
 ./build/cli channels list <domain_id>
+./build/cli channels list <domain_id> --kind ""
 ./build/cli channels get <channel_id>
 ```
 
@@ -91,4 +109,50 @@ Channels map to Atom resources with `kind="channel"`.
 ./build/cli authz check <subject_id> publish --resource-id <channel_id>
 ```
 
-All management commands except `login` require a bearer token through `--token`, `MG_ATOM_TOKEN`, or `MAGISTRALA_TOKEN`.
+## Devices, gateways and device types
+
+These commands go through `pkg/atom`'s typed client rather than the raw
+GraphQL path the commands above use. Devices are Atom entities of kind
+`device`, so `devices all get <domain_id>` and `clients list <domain_id>`
+return the same objects.
+
+```bash
+./build/cli devices create <JSON_device> <domain_id>
+./build/cli devices all get <domain_id>
+./build/cli devices <device_id> get
+./build/cli devices <device_id> update <JSON_string>
+./build/cli devices <device_id> enable
+./build/cli devices <device_id> disable
+./build/cli devices <device_id> delete
+```
+
+A gateway is a device with `attributes.is_gateway` set; `gateways` manages the
+reachability relation between devices and gateways.
+
+```bash
+./build/cli gateways set <device_id> <gateway_id1,gateway_id2,...>
+./build/cli gateways <gateway_id> devices <domain_id>
+```
+
+```bash
+./build/cli devicetypes create <JSON_device_type> <domain_id>
+./build/cli devicetypes all get <domain_id>
+./build/cli devicetypes <device_type_id> update <JSON_string>
+./build/cli devicetypes <device_type_id> versions
+./build/cli devicetypes <device_type_id> create-version <JSON_version>
+./build/cli devicetypes <device_type_id> active-version
+./build/cli devicetypes <device_type_id> bind <device_id> [version_id]
+```
+
+## Health
+
+`health` is the one command still served by the per-service HTTP APIs rather
+than by Atom. It covers `certs` and `fluxmq`, and reads `MG_CERTS_URL` and
+`MG_HTTP_ADAPTER_URL`.
+
+```bash
+./build/cli health certs
+```
+
+All management commands except `login` and `health` require a bearer token
+through `--token`, `ATOM_SERVICE_TOKEN`, or `ATOM_ADMIN_TOKEN`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,7 @@
 # Magistrala CLI
 
+The Magistrala CLI is backed by Atom GraphQL. It talks to the Atom GraphQL endpoint directly instead of the removed legacy HTTP management APIs.
+
 ## Build
 
 From the project root:
@@ -8,322 +10,85 @@ From the project root:
 make cli
 ```
 
-## Usage
+The binary is written to `build/cli`.
 
-### Service
+## Configuration
 
-#### Get Magistrala Services Health Check
+The CLI defaults to `http://localhost:8080/graphql`.
 
-```bash
-magistrala-cli health <service>
-```
-
-### Users management
-
-#### Create User
+You can configure the endpoint and token with flags:
 
 ```bash
-magistrala-cli users create <user_name> <user_email> <user_password>
-
-magistrala-cli users create <user_name> <user_email> <user_password> <user_token>
+./build/cli --graphql-url http://localhost:8080/graphql --token "$MG_ATOM_TOKEN" domains list
 ```
 
-#### Login User
+Or with environment variables:
 
 ```bash
-magistrala-cli users token <user_email> <user_password>
+export MG_ATOM_GRAPHQL_URL=http://localhost:8080/graphql
+export MG_ATOM_TOKEN=<token>
 ```
 
-#### Get User
+`MAGISTRALA_TOKEN` is also accepted as a token fallback.
+
+## Login
 
 ```bash
-magistrala-cli users get <user_id> <user_token>
+./build/cli login admin 12345678
 ```
 
-#### Get Users
+Tenant-scoped credentials can pass either a tenant ID or alias:
 
 ```bash
-magistrala-cli users get all <user_token>
+./build/cli login user@example.com secret --tenant-id <domain_id>
+./build/cli login user@example.com secret --tenant-alias <domain_alias>
 ```
 
-#### Update User Metadata
+## Domains
+
+Domains map to Atom tenants.
 
 ```bash
-magistrala-cli users update <user_id> '{"name":"value1", "metadata":{"value2": "value3"}}' <user_token>
+./build/cli domains create "Demo Domain" --alias demo
+./build/cli domains list --limit 20 --offset 0
+./build/cli domains get <domain_id>
 ```
 
-#### Update User Password
+## Clients
+
+Clients map to Atom entities. The default entity kind is `device`.
 
 ```bash
-magistrala-cli users password <old_password> <password> <user_token>
+./build/cli clients create <domain_id> "Thermostat 1"
+./build/cli clients create <domain_id> "Gateway" --kind application --attributes '{"site":"lab"}'
+./build/cli clients list <domain_id>
+./build/cli clients get <client_id>
 ```
 
-#### Enable User
+## Channels
+
+Channels map to Atom resources with `kind="channel"`.
 
 ```bash
-magistrala-cli users enable <user_id> <user_token>
+./build/cli channels create <domain_id> "Measurements"
+./build/cli channels create <domain_id> "Alerts" --attributes '{"retention":"7d"}'
+./build/cli channels list <domain_id>
+./build/cli channels get <channel_id>
 ```
 
-#### Disable User
+## Groups
 
 ```bash
-magistrala-cli users disable <user_id> <user_token>
+./build/cli groups create <domain_id> "Factory Floor" --type object --description "Plant devices"
+./build/cli groups list <domain_id>
+./build/cli groups get <group_id>
 ```
 
-### System Provisioning
-
-#### Create Client
+## Authorization
 
 ```bash
-magistrala-cli clients create '{"name":"myClient"}' <user_token>
+./build/cli authz check <subject_id> read --object-kind resource --object-id <resource_id>
+./build/cli authz check <subject_id> publish --resource-id <channel_id>
 ```
 
-#### Create Client with metadata
-
-```bash
-magistrala-cli clients create '{"name":"myClient", "metadata": {"key1":"value1"}}' <user_token>
-```
-
-#### Update Client
-
-```bash
-magistrala-cli clients update <client_id> '{"name":"value1", "metadata":{"key1": "value2"}}' <user_token>
-```
-
-#### Identify Client
-
-```bash
-magistrala-cli clients identify <client_key>
-```
-
-#### Enable Client
-
-```bash
-magistrala-cli clients enable <client_id> <user_token>
-```
-
-#### Disable Client
-
-```bash
-magistrala-cli clients disable <client_id> <user_token>
-```
-
-#### Get Client
-
-```bash
-magistrala-cli clients get <client_id> <user_token>
-```
-
-#### Get Clients
-
-```bash
-magistrala-cli clients get all <user_token>
-```
-
-#### Get a subset list of provisioned Clients
-
-```bash
-magistrala-cli clients get all --offset=1 --limit=5 <user_token>
-```
-
-#### Create Channel
-
-```bash
-magistrala-cli channels create '{"name":"myChannel"}' <user_token>
-```
-
-#### Bulk Provision Channels
-
-```bash
-magistrala-cli provision channels <file> <user_token>
-```
-
-- `file` - A CSV or JSON file containing channel names (must have extension `.csv` or `.json`)
-- `user_token` - A valid user auth token for the current system
-
-An example CSV file might be:
-
-```csv
-<channel1_name>,
-<channel2_name>,
-<channel3_name>,
-```
-
-in which the first column is channel names.
-
-A comparable JSON file would be
-
-```json
-[
-  {
-    "name": "<channel1_name>",
-    "description": "<channel1_description>",
-    "status": "enabled"
-  },
-  {
-    "name": "<channel2_name>",
-    "description": "<channel2_description>",
-    "status": "disabled"
-  },
-  {
-    "name": "<channel3_name>",
-    "description": "<channel3_description>",
-    "status": "enabled"
-  }
-]
-```
-
-With JSON you can be able to specify more fields of the channels you want to create
-
-#### Update Channel
-
-```bash
-magistrala-cli channels update '{"id":"<channel_id>","name":"myNewName"}' <user_token>
-```
-
-#### Enable Channel
-
-```bash
-magistrala-cli channels enable <channel_id> <user_token>
-```
-
-#### Disable Channel
-
-```bash
-magistrala-cli channels disable <channel_id> <user_token>
-```
-
-#### Get Channel
-
-```bash
-magistrala-cli channels get <channel_id> <user_token>
-```
-
-#### Get Channels
-
-```bash
-magistrala-cli channels get all <user_token>
-```
-
-#### Get a subset list of provisioned Channels
-
-```bash
-magistrala-cli channels get all --offset=1 --limit=5 <user_token>
-```
-
-### Access control
-
-#### Connect Client to Channel
-
-```bash
-magistrala-cli clients connect <client_id> <channel_id> <user_token>
-```
-
-#### Bulk Connect Clients to Channels
-
-```bash
-magistrala-cli provision connect <file> <user_token>
-```
-
-- `file` - A CSV or JSON file containing client and channel ids (must have extension `.csv` or `.json`)
-- `user_token` - A valid user auth token for the current system
-
-An example CSV file might be
-
-```csv
-<client_id1>,<channel_id1>
-<client_id2>,<channel_id2>
-```
-
-in which the first column is client IDs and the second column is channel IDs. A connection will be created for each client to each channel. This example would result in 4 connections being created.
-
-A comparable JSON file would be
-
-```json
-{
-  "client_ids": ["<client_id1>", "<client_id2>"],
-  "group_ids": ["<channel_id1>", "<channel_id2>"]
-}
-```
-
-#### Disconnect Client from Channel
-
-```bash
-magistrala-cli clients disconnect <client_id> <channel_id> <user_token>
-```
-
-#### Get a subset list of Channels connected to Client
-
-```bash
-magistrala-cli clients connections <client_id> <user_token>
-```
-
-#### Get a subset list of Clients connected to Channel
-
-```bash
-magistrala-cli channels connections <channel_id> <user_token>
-```
-
-### Messaging
-
-#### Send a message over HTTP
-
-```bash
-magistrala-cli messages send <domain_id> <channel_id/subtopic> <secret> '[{"bn":"Dev1","n":"temp","v":20}, {"n":"hum","v":40}, {"bn":"Dev2", "n":"temp","v":20}, {"n":"hum","v":40}]'
-```
-
-### Groups
-
-#### Create Group
-
-```bash
-magistrala-cli groups create '{"name":"<group_name>","description":"<description>","parentID":"<parent_id>","metadata":"<metadata>"}' <user_token>
-```
-
-#### Get Group
-
-```bash
-magistrala-cli groups get <group_id> <user_token>
-```
-
-#### Get Groups
-
-```bash
-magistrala-cli groups get all <user_token>
-```
-
-#### Get Group Members
-
-```bash
-magistrala-cli groups members <group_id> <user_token>
-```
-
-#### Get Memberships
-
-```bash
-magistrala-cli groups membership <member_id> <user_token>
-```
-
-#### Assign Members to Group
-
-```bash
-magistrala-cli groups assign <member_ids> <member_type> <group_id> <user_token>
-```
-
-#### Unassign Members to Group
-
-```bash
-magistrala-cli groups unassign <member_ids> <group_id>  <user_token>
-```
-
-#### Enable Group
-
-```bash
-magistrala-cli groups enable <group_id> <user_token>
-```
-
-#### Disable Group
-
-```bash
-magistrala-cli groups disable <group_id> <user_token>
-```
+All management commands except `login` require a bearer token through `--token`, `MG_ATOM_TOKEN`, or `MAGISTRALA_TOKEN`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,8 +96,13 @@ Channels map to Atom resources with `kind="channel"`.
 
 ## Groups
 
+Atom exposes one mutation per group type, so `--type` selects between
+`createObjectGroup` and `createPrincipalGroup`. It defaults to `object`, and
+any other value is rejected before the request is sent.
+
 ```bash
-./build/cli groups create <domain_id> "Factory Floor" --type object --description "Plant devices"
+./build/cli groups create <domain_id> "Factory Floor" --description "Plant devices"
+./build/cli groups create <domain_id> "Operators" --type principal
 ./build/cli groups list <domain_id>
 ./build/cli groups get <group_id>
 ```

--- a/cli/atom_commands.go
+++ b/cli/atom_commands.go
@@ -3,7 +3,11 @@
 
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 // Command names, also used by the GraphQL responses that carry the same name.
 const (
@@ -25,7 +29,6 @@ const (
 	varAlias       = "alias"
 	varAttributes  = "attributes"
 	varDescription = "description"
-	varGroupType   = "groupType"
 	varOwnerID     = "ownerId"
 )
 
@@ -42,8 +45,12 @@ const (
 	respResources      = "resources"
 	respCreateResource = "createResource"
 	respGroup          = "group"
-	respCreateGroup    = "createGroup"
 	respAuthzCheck     = "authzCheck"
+
+	// Atom exposes one mutation per group type; both take CreateGroupInput
+	// and set group_type themselves.
+	respCreateObjectGroup    = "createObjectGroup"
+	respCreatePrincipalGroup = "createPrincipalGroup"
 )
 
 const (
@@ -53,6 +60,9 @@ const (
 
 	defaultEntityKind   = "device"
 	defaultResourceKind = "channel"
+
+	groupTypeObject    = "object"
+	groupTypePrincipal = "principal"
 )
 
 const (
@@ -130,8 +140,10 @@ const (
   }
 }`
 
-	createGroupMutation = `mutation CreateGroup($input: CreateGroupInput!) {
-  createGroup(input: $input) { ` + groupFields + ` }
+	// createGroupMutationFormat is completed with the mutation name for the
+	// requested group type.
+	createGroupMutationFormat = `mutation CreateGroup($input: CreateGroupInput!) {
+  %s(input: $input) { ` + groupFields + ` }
 }`
 
 	authzCheckMutation = `mutation AuthzCheck($input: AuthzCheckInput!) {
@@ -151,6 +163,9 @@ type gqlCmdConfig struct {
 	query string
 	// field is the top-level GraphQL response field to print.
 	field string
+	// operation resolves the document and response field when they depend on a
+	// flag. query and field are used verbatim when it is nil.
+	operation func() (query, field string, err error)
 	// anonymous commands run without a bearer token; every other command
 	// requires one.
 	anonymous bool
@@ -184,7 +199,14 @@ func newGQLCmd(opts *rootOptions, cfg gqlCmdConfig) *cobra.Command {
 				return err
 			}
 
-			value, err := client.do(cmd.Context(), cfg.query, variables, cfg.field)
+			query, field := cfg.query, cfg.field
+			if cfg.operation != nil {
+				if query, field, err = cfg.operation(); err != nil {
+					return err
+				}
+			}
+
+			value, err := client.do(cmd.Context(), query, variables, field)
 			if err != nil {
 				return err
 			}
@@ -440,22 +462,34 @@ func newGroupCreateCmd(opts *rootOptions) *cobra.Command {
 		use:   useCreateInDomain,
 		short: "Create a group",
 		args:  cobra.ExactArgs(2),
-		query: createGroupMutation,
-		field: respCreateGroup,
+		operation: func() (string, string, error) {
+			var mutation string
+			switch groupType {
+			case groupTypeObject:
+				mutation = respCreateObjectGroup
+			case groupTypePrincipal:
+				mutation = respCreatePrincipalGroup
+			default:
+				return "", "", fmt.Errorf("unsupported group type %q: expected object or principal", groupType)
+			}
+
+			return fmt.Sprintf(createGroupMutationFormat, mutation), mutation, nil
+		},
 		vars: func(args []string) (map[string]any, error) {
 			attributes, err := parseJSONFlag(attrs)
 			if err != nil {
 				return nil, err
 			}
+			// The specialized mutations set group_type themselves, so sending
+			// it in the input would only be overwritten.
 			input := gqlInput{varTenantID: args[0], varName: args[1]}
-			input.setString(varGroupType, groupType)
 			input.setString(varDescription, description)
 			input.setObject(varAttributes, attributes)
 
 			return map[string]any{varInput: input}, nil
 		},
 		flags: func(cmd *cobra.Command) {
-			cmd.Flags().StringVar(&groupType, "type", "", "group type")
+			cmd.Flags().StringVar(&groupType, "type", groupTypeObject, "group type: object or principal")
 			cmd.Flags().StringVar(&description, varDescription, "", "group description")
 			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
 		},

--- a/cli/atom_commands.go
+++ b/cli/atom_commands.go
@@ -1,0 +1,524 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	tenantFields   = "id name alias status tags attributes createdAt updatedAt"
+	entityFields   = "id kind profileId profileVersionId name alias tenantId parentGroupId status attributes createdAt updatedAt"
+	resourceFields = "id kind name alias tenantId ownerId parentGroupId attributes createdAt updatedAt"
+	groupFields    = "id name tenantId groupType description parentId status attributes createdAt updatedAt"
+)
+
+func newLoginCmd(opts *rootOptions) *cobra.Command {
+	var tenantID, tenantAlias, kind string
+	cmd := &cobra.Command{
+		Use:   "login <identifier> <secret>",
+		Short: "Authenticate against Atom",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input := map[string]any{
+				"identifier":  args[0],
+				"secret":      args[1],
+				"kind":        kind,
+				"tenantId":    optionalString(tenantID),
+				"tenantAlias": optionalString(tenantAlias),
+			}
+			var out struct {
+				Login map[string]any `json:"login"`
+			}
+			err := opts.client().do(context.Background(), `
+mutation Login($input: LoginInput!) {
+  login(input: $input) {
+    token
+    entityId
+    sessionId
+    expiresAt
+    emailVerified
+    verificationRequired
+  }
+}`, map[string]any{"input": input}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Login)
+		},
+	}
+	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "tenant ID for tenant-scoped credentials")
+	cmd.Flags().StringVar(&tenantAlias, "tenant-alias", "", "tenant alias for tenant-scoped credentials")
+	cmd.Flags().StringVar(&kind, "kind", "password", "credential kind")
+	return cmd
+}
+
+func newDomainsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "domains", Short: "Manage Magistrala domains through Atom tenants"}
+	cmd.AddCommand(newDomainCreateCmd(opts), newDomainListCmd(opts), newDomainGetCmd(opts))
+	return cmd
+}
+
+func newDomainCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, attrs string
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a domain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return err
+			}
+			var out struct {
+				CreateTenant map[string]any `json:"createTenant"`
+			}
+			err = client.do(context.Background(), `
+mutation CreateDomain($input: CreateTenantInput!) {
+  createTenant(input: $input) { `+tenantFields+` }
+}`, map[string]any{"input": map[string]any{
+				"name":       args[0],
+				"alias":      optionalString(alias),
+				"attributes": optionalObject(attributes),
+			}}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.CreateTenant)
+		},
+	}
+	cmd.Flags().StringVar(&alias, "alias", "", "domain alias")
+	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
+	return cmd
+}
+
+func newDomainListCmd(opts *rootOptions) *cobra.Command {
+	var limit, offset int
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List domains",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Tenants map[string]any `json:"tenants"`
+			}
+			err = client.do(context.Background(), `
+query ListDomains($limit: Int, $offset: Int) {
+  tenants(limit: $limit, offset: $offset) {
+    total
+    items { `+tenantFields+` }
+  }
+}`, map[string]any{"limit": limit, "offset": offset}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Tenants)
+		},
+	}
+	commonListFlags(cmd, &limit, &offset)
+	return cmd
+}
+
+func newDomainGetCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <domain_id>",
+		Short: "Get a domain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Tenant map[string]any `json:"tenant"`
+			}
+			err = client.do(context.Background(), `
+query GetDomain($id: ID!) {
+  tenant(id: $id) { `+tenantFields+` }
+}`, map[string]any{"id": args[0]}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Tenant)
+		},
+	}
+	return cmd
+}
+
+func newGraphQLClientsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "clients", Short: "Manage Magistrala clients through Atom entities"}
+	cmd.AddCommand(newClientCreateCmd(opts), newClientListCmd(opts), newClientGetCmd(opts))
+	return cmd
+}
+
+func newClientCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, kind, attrs string
+	cmd := &cobra.Command{
+		Use:   "create <domain_id> <name>",
+		Short: "Create a client",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return err
+			}
+			var out struct {
+				CreateEntity map[string]any `json:"createEntity"`
+			}
+			err = client.do(context.Background(), `
+mutation CreateClient($input: CreateEntityInput!) {
+  createEntity(input: $input) { `+entityFields+` }
+}`, map[string]any{"input": map[string]any{
+				"tenantId":   args[0],
+				"name":       args[1],
+				"kind":       kind,
+				"alias":      optionalString(alias),
+				"attributes": optionalObject(attributes),
+			}}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.CreateEntity)
+		},
+	}
+	cmd.Flags().StringVar(&alias, "alias", "", "client alias")
+	cmd.Flags().StringVar(&kind, "kind", "device", "Atom EntityKind value")
+	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
+	return cmd
+}
+
+func newClientListCmd(opts *rootOptions) *cobra.Command {
+	var limit, offset int
+	var kind string
+	cmd := &cobra.Command{
+		Use:   "list <domain_id>",
+		Short: "List clients",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Entities map[string]any `json:"entities"`
+			}
+			err = client.do(context.Background(), `
+query ListClients($tenantId: ID!, $kind: EntityKind, $limit: Int, $offset: Int) {
+  entities(tenantId: $tenantId, kind: $kind, limit: $limit, offset: $offset) {
+    total
+    items { `+entityFields+` }
+  }
+}`, map[string]any{"tenantId": args[0], "kind": kind, "limit": limit, "offset": offset}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Entities)
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "device", "Atom EntityKind value")
+	commonListFlags(cmd, &limit, &offset)
+	return cmd
+}
+
+func newClientGetCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <client_id>",
+		Short: "Get a client",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Entity map[string]any `json:"entity"`
+			}
+			err = client.do(context.Background(), `
+query GetClient($id: ID!) {
+  entity(id: $id) { `+entityFields+` }
+}`, map[string]any{"id": args[0]}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Entity)
+		},
+	}
+	return cmd
+}
+
+func newGraphQLChannelsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "channels", Short: "Manage Magistrala channels through Atom resources"}
+	cmd.AddCommand(newChannelCreateCmd(opts), newChannelListCmd(opts), newChannelGetCmd(opts))
+	return cmd
+}
+
+func newChannelCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, kind, ownerID, attrs string
+	cmd := &cobra.Command{
+		Use:   "create <domain_id> <name>",
+		Short: "Create a channel",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return err
+			}
+			var out struct {
+				CreateResource map[string]any `json:"createResource"`
+			}
+			err = client.do(context.Background(), `
+mutation CreateChannel($input: CreateResourceInput!) {
+  createResource(input: $input) { `+resourceFields+` }
+}`, map[string]any{"input": map[string]any{
+				"tenantId":   args[0],
+				"name":       args[1],
+				"kind":       kind,
+				"alias":      optionalString(alias),
+				"ownerId":    optionalString(ownerID),
+				"attributes": optionalObject(attributes),
+			}}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.CreateResource)
+		},
+	}
+	cmd.Flags().StringVar(&alias, "alias", "", "channel alias")
+	cmd.Flags().StringVar(&kind, "kind", "channel", "Atom resource kind")
+	cmd.Flags().StringVar(&ownerID, "owner-id", "", "owner entity ID")
+	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
+	return cmd
+}
+
+func newChannelListCmd(opts *rootOptions) *cobra.Command {
+	var limit, offset int
+	var kind string
+	cmd := &cobra.Command{
+		Use:   "list <domain_id>",
+		Short: "List channels",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Resources map[string]any `json:"resources"`
+			}
+			err = client.do(context.Background(), `
+query ListChannels($tenantId: ID!, $kind: String, $limit: Int, $offset: Int) {
+  resources(tenantId: $tenantId, kind: $kind, limit: $limit, offset: $offset) {
+    total
+    items { `+resourceFields+` }
+  }
+}`, map[string]any{"tenantId": args[0], "kind": kind, "limit": limit, "offset": offset}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Resources)
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "channel", "Atom resource kind")
+	commonListFlags(cmd, &limit, &offset)
+	return cmd
+}
+
+func newChannelGetCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <channel_id>",
+		Short: "Get a channel",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Resource map[string]any `json:"resource"`
+			}
+			err = client.do(context.Background(), `
+query GetChannel($id: ID!) {
+  resource(id: $id) { `+resourceFields+` }
+}`, map[string]any{"id": args[0]}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Resource)
+		},
+	}
+	return cmd
+}
+
+func newGraphQLGroupsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "groups", Short: "Manage Magistrala groups through Atom groups"}
+	cmd.AddCommand(newGroupCreateCmd(opts), newGroupListCmd(opts), newGroupGetCmd(opts))
+	return cmd
+}
+
+func newGroupCreateCmd(opts *rootOptions) *cobra.Command {
+	var groupType, description, attrs string
+	cmd := &cobra.Command{
+		Use:   "create <domain_id> <name>",
+		Short: "Create a group",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return err
+			}
+			var out struct {
+				CreateGroup map[string]any `json:"createGroup"`
+			}
+			err = client.do(context.Background(), `
+mutation CreateGroup($input: CreateGroupInput!) {
+  createGroup(input: $input) { `+groupFields+` }
+}`, map[string]any{"input": map[string]any{
+				"tenantId":    args[0],
+				"name":        args[1],
+				"groupType":   optionalString(groupType),
+				"description": optionalString(description),
+				"attributes":  optionalObject(attributes),
+			}}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.CreateGroup)
+		},
+	}
+	cmd.Flags().StringVar(&groupType, "type", "", "group type")
+	cmd.Flags().StringVar(&description, "description", "", "group description")
+	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
+	return cmd
+}
+
+func newGroupListCmd(opts *rootOptions) *cobra.Command {
+	var limit, offset int
+	cmd := &cobra.Command{
+		Use:   "list <domain_id>",
+		Short: "List groups",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Groups map[string]any `json:"groups"`
+			}
+			err = client.do(context.Background(), `
+query ListGroups($tenantId: ID!, $limit: Int, $offset: Int) {
+  groups(tenantId: $tenantId, limit: $limit, offset: $offset) {
+    total
+    items { `+groupFields+` }
+  }
+}`, map[string]any{"tenantId": args[0], "limit": limit, "offset": offset}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Groups)
+		},
+	}
+	commonListFlags(cmd, &limit, &offset)
+	return cmd
+}
+
+func newGroupGetCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <group_id>",
+		Short: "Get a group",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			var out struct {
+				Group map[string]any `json:"group"`
+			}
+			err = client.do(context.Background(), `
+query GetGroup($id: ID!) {
+  group(id: $id) { `+groupFields+` }
+}`, map[string]any{"id": args[0]}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.Group)
+		},
+	}
+	return cmd
+}
+
+func newAuthzCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "authz", Short: "Run Atom authorization checks"}
+	cmd.AddCommand(newAuthzCheckCmd(opts))
+	return cmd
+}
+
+func newAuthzCheckCmd(opts *rootOptions) *cobra.Command {
+	var objectKind, objectID, resourceID, contextJSON string
+	cmd := &cobra.Command{
+		Use:   "check <subject_id> <action>",
+		Short: "Check whether a subject can perform an action",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := opts.authedClient()
+			if err != nil {
+				return err
+			}
+			contextValue, err := parseJSONFlag(contextJSON)
+			if err != nil {
+				return err
+			}
+			var out struct {
+				AuthzCheck map[string]any `json:"authzCheck"`
+			}
+			err = client.do(context.Background(), `
+mutation AuthzCheck($input: AuthzCheckInput!) {
+  authzCheck(input: $input) {
+    allowed
+    reason
+    details
+  }
+}`, map[string]any{"input": map[string]any{
+				"subjectId":  args[0],
+				"action":     args[1],
+				"resourceId": optionalString(resourceID),
+				"objectKind": optionalString(objectKind),
+				"objectId":   optionalString(objectID),
+				"context":    optionalObject(contextValue),
+			}}, &out)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, out.AuthzCheck)
+		},
+	}
+	cmd.Flags().StringVar(&objectKind, "object-kind", "", "object kind")
+	cmd.Flags().StringVar(&objectID, "object-id", "", "object ID")
+	cmd.Flags().StringVar(&resourceID, "resource-id", "", "resource ID")
+	cmd.Flags().StringVar(&contextJSON, "context", "", "JSON context")
+	return cmd
+}

--- a/cli/atom_commands.go
+++ b/cli/atom_commands.go
@@ -3,38 +3,67 @@
 
 package cli
 
-import (
-	"context"
+import "github.com/spf13/cobra"
 
-	"github.com/spf13/cobra"
+// Command names, also used by the GraphQL responses that carry the same name.
+const (
+	cmdDomains  = "domains"
+	cmdClients  = "clients"
+	cmdChannels = "channels"
+	cmdGroups   = "groups"
+)
+
+// GraphQL variable and input object keys.
+const (
+	varInput       = "input"
+	varID          = "id"
+	varTenantID    = "tenantId"
+	varKind        = "kind"
+	varLimit       = "limit"
+	varOffset      = "offset"
+	varName        = "name"
+	varAlias       = "alias"
+	varAttributes  = "attributes"
+	varDescription = "description"
+	varGroupType   = "groupType"
+	varOwnerID     = "ownerId"
+)
+
+// Top-level response fields selected out of the GraphQL data object.
+const (
+	respLogin          = "login"
+	respTenant         = "tenant"
+	respTenants        = "tenants"
+	respCreateTenant   = "createTenant"
+	respEntity         = "entity"
+	respEntities       = "entities"
+	respCreateEntity   = "createEntity"
+	respResource       = "resource"
+	respResources      = "resources"
+	respCreateResource = "createResource"
+	respGroup          = "group"
+	respCreateGroup    = "createGroup"
+	respAuthzCheck     = "authzCheck"
+)
+
+const (
+	useList           = "list"
+	useCreateInDomain = "create <domain_id> <name>"
+	useListInDomain   = "list <domain_id>"
+
+	defaultEntityKind   = "device"
+	defaultResourceKind = "channel"
 )
 
 const (
 	tenantFields   = "id name alias status tags attributes createdAt updatedAt"
-	entityFields   = "id kind profileId profileVersionId name alias tenantId parentGroupId status attributes createdAt updatedAt"
-	resourceFields = "id kind name alias tenantId ownerId parentGroupId attributes createdAt updatedAt"
+	entityFields   = "id kind profileId profileVersionId name alias externalId tenantId objectGroupIds status attributes createdAt updatedAt"
+	resourceFields = "id kind name alias tenantId ownerId objectGroupIds attributes createdAt updatedAt"
 	groupFields    = "id name tenantId groupType description parentId status attributes createdAt updatedAt"
 )
 
-func newLoginCmd(opts *rootOptions) *cobra.Command {
-	var tenantID, tenantAlias, kind string
-	cmd := &cobra.Command{
-		Use:   "login <identifier> <secret>",
-		Short: "Authenticate against Atom",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			input := map[string]any{
-				"identifier":  args[0],
-				"secret":      args[1],
-				"kind":        kind,
-				"tenantId":    optionalString(tenantID),
-				"tenantAlias": optionalString(tenantAlias),
-			}
-			var out struct {
-				Login map[string]any `json:"login"`
-			}
-			err := opts.client().do(context.Background(), `
-mutation Login($input: LoginInput!) {
+const (
+	loginMutation = `mutation Login($input: LoginInput!) {
   login(input: $input) {
     token
     entityId
@@ -43,482 +72,446 @@ mutation Login($input: LoginInput!) {
     emailVerified
     verificationRequired
   }
-}`, map[string]any{"input": input}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Login)
-		},
-	}
-	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "tenant ID for tenant-scoped credentials")
-	cmd.Flags().StringVar(&tenantAlias, "tenant-alias", "", "tenant alias for tenant-scoped credentials")
-	cmd.Flags().StringVar(&kind, "kind", "password", "credential kind")
-	return cmd
-}
+}`
 
-func newDomainsCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{Use: "domains", Short: "Manage Magistrala domains through Atom tenants"}
-	cmd.AddCommand(newDomainCreateCmd(opts), newDomainListCmd(opts), newDomainGetCmd(opts))
-	return cmd
-}
+	getDomainQuery = `query GetDomain($id: ID!) {
+  tenant(id: $id) { ` + tenantFields + ` }
+}`
 
-func newDomainCreateCmd(opts *rootOptions) *cobra.Command {
-	var alias, attrs string
-	cmd := &cobra.Command{
-		Use:   "create <name>",
-		Short: "Create a domain",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			attributes, err := parseJSONFlag(attrs)
-			if err != nil {
-				return err
-			}
-			var out struct {
-				CreateTenant map[string]any `json:"createTenant"`
-			}
-			err = client.do(context.Background(), `
-mutation CreateDomain($input: CreateTenantInput!) {
-  createTenant(input: $input) { `+tenantFields+` }
-}`, map[string]any{"input": map[string]any{
-				"name":       args[0],
-				"alias":      optionalString(alias),
-				"attributes": optionalObject(attributes),
-			}}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.CreateTenant)
-		},
-	}
-	cmd.Flags().StringVar(&alias, "alias", "", "domain alias")
-	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
-	return cmd
-}
-
-func newDomainListCmd(opts *rootOptions) *cobra.Command {
-	var limit, offset int
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List domains",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Tenants map[string]any `json:"tenants"`
-			}
-			err = client.do(context.Background(), `
-query ListDomains($limit: Int, $offset: Int) {
+	listDomainsQuery = `query ListDomains($limit: Int, $offset: Int) {
   tenants(limit: $limit, offset: $offset) {
     total
-    items { `+tenantFields+` }
+    items { ` + tenantFields + ` }
   }
-}`, map[string]any{"limit": limit, "offset": offset}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Tenants)
-		},
-	}
-	commonListFlags(cmd, &limit, &offset)
-	return cmd
-}
+}`
 
-func newDomainGetCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <domain_id>",
-		Short: "Get a domain",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Tenant map[string]any `json:"tenant"`
-			}
-			err = client.do(context.Background(), `
-query GetDomain($id: ID!) {
-  tenant(id: $id) { `+tenantFields+` }
-}`, map[string]any{"id": args[0]}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Tenant)
-		},
-	}
-	return cmd
-}
+	createDomainMutation = `mutation CreateDomain($input: CreateTenantInput!) {
+  createTenant(input: $input) { ` + tenantFields + ` }
+}`
 
-func newGraphQLClientsCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{Use: "clients", Short: "Manage Magistrala clients through Atom entities"}
-	cmd.AddCommand(newClientCreateCmd(opts), newClientListCmd(opts), newClientGetCmd(opts))
-	return cmd
-}
+	getClientQuery = `query GetClient($id: ID!) {
+  entity(id: $id) { ` + entityFields + ` }
+}`
 
-func newClientCreateCmd(opts *rootOptions) *cobra.Command {
-	var alias, kind, attrs string
-	cmd := &cobra.Command{
-		Use:   "create <domain_id> <name>",
-		Short: "Create a client",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			attributes, err := parseJSONFlag(attrs)
-			if err != nil {
-				return err
-			}
-			var out struct {
-				CreateEntity map[string]any `json:"createEntity"`
-			}
-			err = client.do(context.Background(), `
-mutation CreateClient($input: CreateEntityInput!) {
-  createEntity(input: $input) { `+entityFields+` }
-}`, map[string]any{"input": map[string]any{
-				"tenantId":   args[0],
-				"name":       args[1],
-				"kind":       kind,
-				"alias":      optionalString(alias),
-				"attributes": optionalObject(attributes),
-			}}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.CreateEntity)
-		},
-	}
-	cmd.Flags().StringVar(&alias, "alias", "", "client alias")
-	cmd.Flags().StringVar(&kind, "kind", "device", "Atom EntityKind value")
-	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
-	return cmd
-}
-
-func newClientListCmd(opts *rootOptions) *cobra.Command {
-	var limit, offset int
-	var kind string
-	cmd := &cobra.Command{
-		Use:   "list <domain_id>",
-		Short: "List clients",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Entities map[string]any `json:"entities"`
-			}
-			err = client.do(context.Background(), `
-query ListClients($tenantId: ID!, $kind: EntityKind, $limit: Int, $offset: Int) {
+	listClientsQuery = `query ListClients($tenantId: ID, $kind: EntityKind, $limit: Int, $offset: Int) {
   entities(tenantId: $tenantId, kind: $kind, limit: $limit, offset: $offset) {
     total
-    items { `+entityFields+` }
+    items { ` + entityFields + ` }
   }
-}`, map[string]any{"tenantId": args[0], "kind": kind, "limit": limit, "offset": offset}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Entities)
-		},
-	}
-	cmd.Flags().StringVar(&kind, "kind", "device", "Atom EntityKind value")
-	commonListFlags(cmd, &limit, &offset)
-	return cmd
-}
+}`
 
-func newClientGetCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <client_id>",
-		Short: "Get a client",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Entity map[string]any `json:"entity"`
-			}
-			err = client.do(context.Background(), `
-query GetClient($id: ID!) {
-  entity(id: $id) { `+entityFields+` }
-}`, map[string]any{"id": args[0]}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Entity)
-		},
-	}
-	return cmd
-}
+	createClientMutation = `mutation CreateClient($input: CreateEntityInput!) {
+  createEntity(input: $input) { ` + entityFields + ` }
+}`
 
-func newGraphQLChannelsCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{Use: "channels", Short: "Manage Magistrala channels through Atom resources"}
-	cmd.AddCommand(newChannelCreateCmd(opts), newChannelListCmd(opts), newChannelGetCmd(opts))
-	return cmd
-}
+	getChannelQuery = `query GetChannel($id: ID!) {
+  resource(id: $id) { ` + resourceFields + ` }
+}`
 
-func newChannelCreateCmd(opts *rootOptions) *cobra.Command {
-	var alias, kind, ownerID, attrs string
-	cmd := &cobra.Command{
-		Use:   "create <domain_id> <name>",
-		Short: "Create a channel",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			attributes, err := parseJSONFlag(attrs)
-			if err != nil {
-				return err
-			}
-			var out struct {
-				CreateResource map[string]any `json:"createResource"`
-			}
-			err = client.do(context.Background(), `
-mutation CreateChannel($input: CreateResourceInput!) {
-  createResource(input: $input) { `+resourceFields+` }
-}`, map[string]any{"input": map[string]any{
-				"tenantId":   args[0],
-				"name":       args[1],
-				"kind":       kind,
-				"alias":      optionalString(alias),
-				"ownerId":    optionalString(ownerID),
-				"attributes": optionalObject(attributes),
-			}}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.CreateResource)
-		},
-	}
-	cmd.Flags().StringVar(&alias, "alias", "", "channel alias")
-	cmd.Flags().StringVar(&kind, "kind", "channel", "Atom resource kind")
-	cmd.Flags().StringVar(&ownerID, "owner-id", "", "owner entity ID")
-	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
-	return cmd
-}
-
-func newChannelListCmd(opts *rootOptions) *cobra.Command {
-	var limit, offset int
-	var kind string
-	cmd := &cobra.Command{
-		Use:   "list <domain_id>",
-		Short: "List channels",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Resources map[string]any `json:"resources"`
-			}
-			err = client.do(context.Background(), `
-query ListChannels($tenantId: ID!, $kind: String, $limit: Int, $offset: Int) {
+	listChannelsQuery = `query ListChannels($tenantId: ID, $kind: String, $limit: Int, $offset: Int) {
   resources(tenantId: $tenantId, kind: $kind, limit: $limit, offset: $offset) {
     total
-    items { `+resourceFields+` }
+    items { ` + resourceFields + ` }
   }
-}`, map[string]any{"tenantId": args[0], "kind": kind, "limit": limit, "offset": offset}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Resources)
-		},
-	}
-	cmd.Flags().StringVar(&kind, "kind", "channel", "Atom resource kind")
-	commonListFlags(cmd, &limit, &offset)
-	return cmd
-}
+}`
 
-func newChannelGetCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <channel_id>",
-		Short: "Get a channel",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Resource map[string]any `json:"resource"`
-			}
-			err = client.do(context.Background(), `
-query GetChannel($id: ID!) {
-  resource(id: $id) { `+resourceFields+` }
-}`, map[string]any{"id": args[0]}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Resource)
-		},
-	}
-	return cmd
-}
+	createChannelMutation = `mutation CreateChannel($input: CreateResourceInput!) {
+  createResource(input: $input) { ` + resourceFields + ` }
+}`
 
-func newGraphQLGroupsCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{Use: "groups", Short: "Manage Magistrala groups through Atom groups"}
-	cmd.AddCommand(newGroupCreateCmd(opts), newGroupListCmd(opts), newGroupGetCmd(opts))
-	return cmd
-}
+	getGroupQuery = `query GetGroup($id: ID!) {
+  group(id: $id) { ` + groupFields + ` }
+}`
 
-func newGroupCreateCmd(opts *rootOptions) *cobra.Command {
-	var groupType, description, attrs string
-	cmd := &cobra.Command{
-		Use:   "create <domain_id> <name>",
-		Short: "Create a group",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			attributes, err := parseJSONFlag(attrs)
-			if err != nil {
-				return err
-			}
-			var out struct {
-				CreateGroup map[string]any `json:"createGroup"`
-			}
-			err = client.do(context.Background(), `
-mutation CreateGroup($input: CreateGroupInput!) {
-  createGroup(input: $input) { `+groupFields+` }
-}`, map[string]any{"input": map[string]any{
-				"tenantId":    args[0],
-				"name":        args[1],
-				"groupType":   optionalString(groupType),
-				"description": optionalString(description),
-				"attributes":  optionalObject(attributes),
-			}}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.CreateGroup)
-		},
-	}
-	cmd.Flags().StringVar(&groupType, "type", "", "group type")
-	cmd.Flags().StringVar(&description, "description", "", "group description")
-	cmd.Flags().StringVar(&attrs, "attributes", "", "JSON attributes")
-	return cmd
-}
-
-func newGroupListCmd(opts *rootOptions) *cobra.Command {
-	var limit, offset int
-	cmd := &cobra.Command{
-		Use:   "list <domain_id>",
-		Short: "List groups",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Groups map[string]any `json:"groups"`
-			}
-			err = client.do(context.Background(), `
-query ListGroups($tenantId: ID!, $limit: Int, $offset: Int) {
+	listGroupsQuery = `query ListGroups($tenantId: ID, $limit: Int, $offset: Int) {
   groups(tenantId: $tenantId, limit: $limit, offset: $offset) {
     total
-    items { `+groupFields+` }
+    items { ` + groupFields + ` }
   }
-}`, map[string]any{"tenantId": args[0], "limit": limit, "offset": offset}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Groups)
-		},
-	}
-	commonListFlags(cmd, &limit, &offset)
-	return cmd
-}
+}`
 
-func newGroupGetCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get <group_id>",
-		Short: "Get a group",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			var out struct {
-				Group map[string]any `json:"group"`
-			}
-			err = client.do(context.Background(), `
-query GetGroup($id: ID!) {
-  group(id: $id) { `+groupFields+` }
-}`, map[string]any{"id": args[0]}, &out)
-			if err != nil {
-				return err
-			}
-			return writeOutput(cmd, out.Group)
-		},
-	}
-	return cmd
-}
+	createGroupMutation = `mutation CreateGroup($input: CreateGroupInput!) {
+  createGroup(input: $input) { ` + groupFields + ` }
+}`
 
-func newAuthzCmd(opts *rootOptions) *cobra.Command {
-	cmd := &cobra.Command{Use: "authz", Short: "Run Atom authorization checks"}
-	cmd.AddCommand(newAuthzCheckCmd(opts))
-	return cmd
-}
-
-func newAuthzCheckCmd(opts *rootOptions) *cobra.Command {
-	var objectKind, objectID, resourceID, contextJSON string
-	cmd := &cobra.Command{
-		Use:   "check <subject_id> <action>",
-		Short: "Check whether a subject can perform an action",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := opts.authedClient()
-			if err != nil {
-				return err
-			}
-			contextValue, err := parseJSONFlag(contextJSON)
-			if err != nil {
-				return err
-			}
-			var out struct {
-				AuthzCheck map[string]any `json:"authzCheck"`
-			}
-			err = client.do(context.Background(), `
-mutation AuthzCheck($input: AuthzCheckInput!) {
+	authzCheckMutation = `mutation AuthzCheck($input: AuthzCheckInput!) {
   authzCheck(input: $input) {
     allowed
     reason
     details
   }
-}`, map[string]any{"input": map[string]any{
-				"subjectId":  args[0],
-				"action":     args[1],
-				"resourceId": optionalString(resourceID),
-				"objectKind": optionalString(objectKind),
-				"objectId":   optionalString(objectID),
-				"context":    optionalObject(contextValue),
-			}}, &out)
+}`
+)
+
+// gqlCmdConfig describes one Atom GraphQL-backed CLI command.
+type gqlCmdConfig struct {
+	use   string
+	short string
+	args  cobra.PositionalArgs
+	query string
+	// field is the top-level GraphQL response field to print.
+	field string
+	// anonymous commands run without a bearer token; every other command
+	// requires one.
+	anonymous bool
+	// vars builds the GraphQL variables from the positional arguments. It runs
+	// after flag parsing, so it may read flag-backed values.
+	vars func(args []string) (map[string]any, error)
+	// flags registers command specific flags.
+	flags func(cmd *cobra.Command)
+}
+
+func newGQLCmd(opts *rootOptions, cfg gqlCmdConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   cfg.use,
+		Short: cfg.short,
+		Args:  cfg.args,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Arguments and flags already parsed, so any failure past this
+			// point is a runtime one and printing usage would only be noise.
+			cmd.SilenceUsage = true
+
+			client := opts.client()
+			if !cfg.anonymous {
+				var err error
+				if client, err = opts.authedClient(); err != nil {
+					return err
+				}
+			}
+
+			variables, err := cfg.vars(args)
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd, out.AuthzCheck)
+
+			value, err := client.do(cmd.Context(), cfg.query, variables, cfg.field)
+			if err != nil {
+				return err
+			}
+
+			return writeOutput(cmd, value)
 		},
 	}
-	cmd.Flags().StringVar(&objectKind, "object-kind", "", "object kind")
-	cmd.Flags().StringVar(&objectID, "object-id", "", "object ID")
-	cmd.Flags().StringVar(&resourceID, "resource-id", "", "resource ID")
-	cmd.Flags().StringVar(&contextJSON, "context", "", "JSON context")
+	if cfg.flags != nil {
+		cfg.flags(cmd)
+	}
+
 	return cmd
+}
+
+// newGetCmd builds the shared "get one object by ID" command.
+func newGetCmd(opts *rootOptions, use, short, query, field string) *cobra.Command {
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   use,
+		short: short,
+		args:  cobra.ExactArgs(1),
+		query: query,
+		field: field,
+		vars: func(args []string) (map[string]any, error) {
+			return map[string]any{varID: args[0]}, nil
+		},
+	})
+}
+
+func newLoginCmd(opts *rootOptions) *cobra.Command {
+	var tenantID, tenantAlias, kind string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:       "login <identifier> <secret>",
+		short:     "Authenticate against Atom",
+		args:      cobra.ExactArgs(2),
+		query:     loginMutation,
+		field:     respLogin,
+		anonymous: true,
+		vars: func(args []string) (map[string]any, error) {
+			input := gqlInput{"identifier": args[0], "secret": args[1]}
+			input.setString(varKind, kind)
+			input.setString(varTenantID, tenantID)
+			input.setString("tenantAlias", tenantAlias)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&tenantID, "tenant-id", "", "tenant ID for tenant-scoped credentials")
+			cmd.Flags().StringVar(&tenantAlias, "tenant-alias", "", "tenant alias for tenant-scoped credentials")
+			cmd.Flags().StringVar(&kind, varKind, "password", "credential kind")
+		},
+	})
+}
+
+func newDomainsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: cmdDomains, Short: "Manage Magistrala domains through Atom tenants"}
+	cmd.AddCommand(
+		newDomainCreateCmd(opts),
+		newDomainListCmd(opts),
+		newGetCmd(opts, "get <domain_id>", "Get a domain", getDomainQuery, respTenant),
+	)
+
+	return cmd
+}
+
+func newDomainCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, attrs string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   "create <name>",
+		short: "Create a domain",
+		args:  cobra.ExactArgs(1),
+		query: createDomainMutation,
+		field: respCreateTenant,
+		vars: func(args []string) (map[string]any, error) {
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return nil, err
+			}
+			input := gqlInput{varName: args[0]}
+			input.setString(varAlias, alias)
+			input.setObject(varAttributes, attributes)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&alias, varAlias, "", "domain alias")
+			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
+		},
+	})
+}
+
+func newDomainListCmd(opts *rootOptions) *cobra.Command {
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useList,
+		short: "List domains",
+		args:  cobra.NoArgs,
+		query: listDomainsQuery,
+		field: respTenants,
+		vars: func(_ []string) (map[string]any, error) {
+			return listVariables(), nil
+		},
+	})
+}
+
+func newGraphQLClientsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: cmdClients, Short: "Manage Magistrala clients through Atom entities"}
+	cmd.AddCommand(
+		newClientCreateCmd(opts),
+		newClientListCmd(opts),
+		newGetCmd(opts, "get <client_id>", "Get a client", getClientQuery, respEntity),
+	)
+
+	return cmd
+}
+
+func newClientCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, kind, attrs string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useCreateInDomain,
+		short: "Create a client",
+		args:  cobra.ExactArgs(2),
+		query: createClientMutation,
+		field: respCreateEntity,
+		vars: func(args []string) (map[string]any, error) {
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return nil, err
+			}
+			input := gqlInput{varTenantID: args[0], varName: args[1]}
+			input.setString(varKind, kind)
+			input.setString(varAlias, alias)
+			input.setObject(varAttributes, attributes)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&alias, varAlias, "", "client alias")
+			cmd.Flags().StringVar(&kind, varKind, defaultEntityKind, "Atom EntityKind value")
+			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
+		},
+	})
+}
+
+func newClientListCmd(opts *rootOptions) *cobra.Command {
+	var kind string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useListInDomain,
+		short: "List clients",
+		args:  cobra.ExactArgs(1),
+		query: listClientsQuery,
+		field: respEntities,
+		vars: func(args []string) (map[string]any, error) {
+			variables := listVariables()
+			variables[varTenantID] = args[0]
+			// An empty kind is not a valid EntityKind, so it means "no filter".
+			if kind != "" {
+				variables[varKind] = kind
+			}
+
+			return variables, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&kind, varKind, defaultEntityKind, "Atom EntityKind filter, empty lists every kind")
+		},
+	})
+}
+
+func newGraphQLChannelsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: cmdChannels, Short: "Manage Magistrala channels through Atom resources"}
+	cmd.AddCommand(
+		newChannelCreateCmd(opts),
+		newChannelListCmd(opts),
+		newGetCmd(opts, "get <channel_id>", "Get a channel", getChannelQuery, respResource),
+	)
+
+	return cmd
+}
+
+func newChannelCreateCmd(opts *rootOptions) *cobra.Command {
+	var alias, kind, ownerID, attrs string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useCreateInDomain,
+		short: "Create a channel",
+		args:  cobra.ExactArgs(2),
+		query: createChannelMutation,
+		field: respCreateResource,
+		vars: func(args []string) (map[string]any, error) {
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return nil, err
+			}
+			// kind is non-null in CreateResourceInput, so it is always sent.
+			input := gqlInput{varTenantID: args[0], varName: args[1], varKind: kind}
+			input.setString(varAlias, alias)
+			input.setString(varOwnerID, ownerID)
+			input.setObject(varAttributes, attributes)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&alias, varAlias, "", "channel alias")
+			cmd.Flags().StringVar(&kind, varKind, defaultResourceKind, "Atom resource kind")
+			cmd.Flags().StringVar(&ownerID, "owner-id", "", "owner entity ID")
+			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
+		},
+	})
+}
+
+func newChannelListCmd(opts *rootOptions) *cobra.Command {
+	var kind string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useListInDomain,
+		short: "List channels",
+		args:  cobra.ExactArgs(1),
+		query: listChannelsQuery,
+		field: respResources,
+		vars: func(args []string) (map[string]any, error) {
+			variables := listVariables()
+			variables[varTenantID] = args[0]
+			// Filtering on an empty kind would match nothing.
+			if kind != "" {
+				variables[varKind] = kind
+			}
+
+			return variables, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&kind, varKind, defaultResourceKind, "Atom resource kind filter, empty lists every kind")
+		},
+	})
+}
+
+func newGraphQLGroupsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: cmdGroups, Short: "Manage Magistrala groups through Atom groups"}
+	cmd.AddCommand(
+		newGroupCreateCmd(opts),
+		newGroupListCmd(opts),
+		newGetCmd(opts, "get <group_id>", "Get a group", getGroupQuery, respGroup),
+	)
+
+	return cmd
+}
+
+func newGroupCreateCmd(opts *rootOptions) *cobra.Command {
+	var groupType, description, attrs string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useCreateInDomain,
+		short: "Create a group",
+		args:  cobra.ExactArgs(2),
+		query: createGroupMutation,
+		field: respCreateGroup,
+		vars: func(args []string) (map[string]any, error) {
+			attributes, err := parseJSONFlag(attrs)
+			if err != nil {
+				return nil, err
+			}
+			input := gqlInput{varTenantID: args[0], varName: args[1]}
+			input.setString(varGroupType, groupType)
+			input.setString(varDescription, description)
+			input.setObject(varAttributes, attributes)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&groupType, "type", "", "group type")
+			cmd.Flags().StringVar(&description, varDescription, "", "group description")
+			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
+		},
+	})
+}
+
+func newGroupListCmd(opts *rootOptions) *cobra.Command {
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   useListInDomain,
+		short: "List groups",
+		args:  cobra.ExactArgs(1),
+		query: listGroupsQuery,
+		field: cmdGroups,
+		vars: func(args []string) (map[string]any, error) {
+			variables := listVariables()
+			variables[varTenantID] = args[0]
+
+			return variables, nil
+		},
+	})
+}
+
+func newAuthzCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "authz", Short: "Run Atom authorization checks"}
+	cmd.AddCommand(newAuthzCheckCmd(opts))
+
+	return cmd
+}
+
+func newAuthzCheckCmd(opts *rootOptions) *cobra.Command {
+	var objectKind, objectID, resourceID, contextJSON string
+
+	return newGQLCmd(opts, gqlCmdConfig{
+		use:   "check <subject_id> <action>",
+		short: "Check whether a subject can perform an action",
+		args:  cobra.ExactArgs(2),
+		query: authzCheckMutation,
+		field: respAuthzCheck,
+		vars: func(args []string) (map[string]any, error) {
+			contextValue, err := parseJSONFlag(contextJSON)
+			if err != nil {
+				return nil, err
+			}
+			input := gqlInput{"subjectId": args[0], "action": args[1]}
+			input.setString("resourceId", resourceID)
+			input.setString("objectKind", objectKind)
+			input.setString("objectId", objectID)
+			input.setObject("context", contextValue)
+
+			return map[string]any{varInput: input}, nil
+		},
+		flags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVar(&objectKind, "object-kind", "", "object kind")
+			cmd.Flags().StringVar(&objectID, "object-id", "", "object ID")
+			cmd.Flags().StringVar(&resourceID, "resource-id", "", "resource ID")
+			cmd.Flags().StringVar(&contextJSON, "context", "", "JSON context")
+		},
+	})
 }

--- a/cli/atom_commands_test.go
+++ b/cli/atom_commands_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// recordingServer answers every GraphQL call with body and captures the request
+// for assertions on the test goroutine, since the handler runs on its own.
+func recordingServer(t *testing.T, body string) (*httptest.Server, *graphQLRequest) {
+	t.Helper()
+	var req graphQLRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &req
+}
+
+func runRootCmd(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := NewRootCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	return cmd.Execute()
+}
+
+func TestClientAndChannelSelectionsUseAtomObjectGroupFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		data    string
+	}{
+		{name: "clients list", command: cmdClients, data: `{"data":{"entities":{"total":0,"items":[]}}}`},
+		{name: "channels list", command: cmdChannels, data: `{"data":{"resources":{"total":0,"items":[]}}}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearAtomEnv(t)
+			server, req := recordingServer(t, tc.data)
+
+			err := runRootCmd(t, "--graphql-url", server.URL, "--token", "test-token", tc.command, useList, "domain-1")
+			if err != nil {
+				t.Fatalf("execute command: %v", err)
+			}
+
+			if strings.Contains(req.Query, "parentGroupId") {
+				t.Errorf("query uses stale parentGroupId field: %s", req.Query)
+			}
+			if !strings.Contains(req.Query, "objectGroupIds") {
+				t.Errorf("query does not select objectGroupIds: %s", req.Query)
+			}
+		})
+	}
+}
+
+func TestGroupCreateUsesSpecializedAtomMutations(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupType    string
+		mutationName string
+	}{
+		{name: "object group", groupType: groupTypeObject, mutationName: respCreateObjectGroup},
+		{name: "principal group", groupType: groupTypePrincipal, mutationName: respCreatePrincipalGroup},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearAtomEnv(t)
+			server, req := recordingServer(t, `{"data":{"`+tc.mutationName+`":{"id":"group-1","name":"Group"}}}`)
+
+			err := runRootCmd(t,
+				"--graphql-url", server.URL,
+				"--token", "test-token",
+				cmdGroups, "create", "domain-1", "Group",
+				"--type", tc.groupType,
+			)
+			if err != nil {
+				t.Fatalf("execute command: %v", err)
+			}
+
+			if !strings.Contains(req.Query, tc.mutationName+"(input: $input)") {
+				t.Errorf("query does not use %s: %s", tc.mutationName, req.Query)
+			}
+			if strings.Contains(req.Query, "createGroup(input: $input)") {
+				t.Errorf("query still uses generic createGroup: %s", req.Query)
+			}
+			input, ok := req.Variables[varInput].(map[string]any)
+			if !ok {
+				t.Fatalf("missing input variables: %#v", req.Variables)
+			}
+			if _, ok := input["groupType"]; ok {
+				t.Errorf("groupType should not be sent to a specialized mutation: %#v", input)
+			}
+		})
+	}
+}
+
+func TestGroupCreateRejectsUnsupportedGroupType(t *testing.T) {
+	clearAtomEnv(t)
+	// No endpoint is configured: the group type has to be rejected before the
+	// command reaches the network.
+	err := runRootCmd(t, "--token", "test-token", cmdGroups, "create", "domain-1", "Group", "--type", "invalid")
+	if err == nil {
+		t.Fatal("expected unsupported group type error")
+	}
+	if !strings.Contains(err.Error(), "expected object or principal") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/graphql_client.go
+++ b/cli/graphql_client.go
@@ -1,0 +1,99 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultAtomGraphQLURL = "http://localhost:8080/graphql"
+
+type graphQLClient struct {
+	endpoint   string
+	token      string
+	httpClient *http.Client
+}
+
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type graphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func newGraphQLClient(endpoint, token string) *graphQLClient {
+	return &graphQLClient{
+		endpoint: endpoint,
+		token:    token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (c *graphQLClient) do(ctx context.Context, query string, variables map[string]any, out any) error {
+	if strings.TrimSpace(c.endpoint) == "" {
+		return errors.New("GraphQL endpoint is required")
+	}
+
+	body, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("GraphQL request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var gqlResp graphQLResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		return err
+	}
+	if len(gqlResp.Errors) > 0 {
+		msgs := make([]string, 0, len(gqlResp.Errors))
+		for _, gqlErr := range gqlResp.Errors {
+			msgs = append(msgs, gqlErr.Message)
+		}
+		return fmt.Errorf("GraphQL error: %s", strings.Join(msgs, "; "))
+	}
+	if out == nil {
+		return nil
+	}
+	if len(gqlResp.Data) == 0 || string(gqlResp.Data) == "null" {
+		return errors.New("GraphQL response did not contain data")
+	}
+	return json.Unmarshal(gqlResp.Data, out)
+}

--- a/cli/graphql_client.go
+++ b/cli/graphql_client.go
@@ -15,7 +15,11 @@ import (
 	"time"
 )
 
-const defaultAtomGraphQLURL = "http://localhost:8080/graphql"
+const (
+	atomGraphQLPath       = "/graphql"
+	defaultAtomGraphQLURL = "http://localhost:8080" + atomGraphQLPath
+	jsonNull              = "null"
+)
 
 type graphQLClient struct {
 	endpoint   string
@@ -28,36 +32,39 @@ type graphQLRequest struct {
 	Variables map[string]any `json:"variables,omitempty"`
 }
 
-type graphQLResponse struct {
-	Data   json.RawMessage `json:"data"`
-	Errors []struct {
-		Message string `json:"message"`
-	} `json:"errors"`
+type graphQLError struct {
+	Message string `json:"message"`
 }
 
-func newGraphQLClient(endpoint, token string) *graphQLClient {
+type graphQLResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphQLError  `json:"errors"`
+}
+
+func newGraphQLClient(endpoint, token string, timeout time.Duration) *graphQLClient {
 	return &graphQLClient{
-		endpoint: endpoint,
-		token:    token,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		endpoint:   strings.TrimSpace(endpoint),
+		token:      strings.TrimSpace(token),
+		httpClient: &http.Client{Timeout: timeout},
 	}
 }
 
-func (c *graphQLClient) do(ctx context.Context, query string, variables map[string]any, out any) error {
-	if strings.TrimSpace(c.endpoint) == "" {
-		return errors.New("GraphQL endpoint is required")
+// do runs query and returns the raw JSON value of the requested top-level
+// response field. A field that is present but null means Atom holds no such
+// object, which is reported as an error so callers never print a bare null.
+func (c *graphQLClient) do(ctx context.Context, query string, variables map[string]any, field string) (json.RawMessage, error) {
+	if c.endpoint == "" {
+		return nil, errors.New("GraphQL endpoint is required")
 	}
 
 	body, err := json.Marshal(graphQLRequest{Query: query, Variables: variables})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.token != "" {
@@ -66,34 +73,44 @@ func (c *graphQLClient) do(ctx context.Context, query string, variables map[stri
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("GraphQL request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return nil, fmt.Errorf("GraphQL request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 
 	var gqlResp graphQLResponse
 	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
-		return err
+		return nil, err
 	}
 	if len(gqlResp.Errors) > 0 {
 		msgs := make([]string, 0, len(gqlResp.Errors))
 		for _, gqlErr := range gqlResp.Errors {
 			msgs = append(msgs, gqlErr.Message)
 		}
-		return fmt.Errorf("GraphQL error: %s", strings.Join(msgs, "; "))
+		return nil, fmt.Errorf("GraphQL error: %s", strings.Join(msgs, "; "))
 	}
-	if out == nil {
-		return nil
+	if len(gqlResp.Data) == 0 || string(gqlResp.Data) == jsonNull {
+		return nil, errors.New("GraphQL response did not contain data")
 	}
-	if len(gqlResp.Data) == 0 || string(gqlResp.Data) == "null" {
-		return errors.New("GraphQL response did not contain data")
+
+	var data map[string]json.RawMessage
+	if err := json.Unmarshal(gqlResp.Data, &data); err != nil {
+		return nil, err
 	}
-	return json.Unmarshal(gqlResp.Data, out)
+	value, ok := data[field]
+	if !ok {
+		return nil, fmt.Errorf("GraphQL response did not contain field %q", field)
+	}
+	if len(value) == 0 || string(value) == jsonNull {
+		return nil, fmt.Errorf("%s not found", field)
+	}
+
+	return value, nil
 }

--- a/cli/graphql_client_test.go
+++ b/cli/graphql_client_test.go
@@ -10,52 +10,100 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
+const testTimeout = 5 * time.Second
+
 func TestGraphQLClientAddsBearerTokenAndDecodesData(t *testing.T) {
+	// The handler runs on its own goroutine, so it only records what it saw and
+	// the assertions happen back on the test goroutine.
+	var (
+		method string
+		authz  string
+		req    graphQLRequest
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.Method, http.MethodPost; got != want {
-			t.Fatalf("unexpected method: got %s want %s", got, want)
-		}
-		if got, want := r.Header.Get("Authorization"), "Bearer test-token"; got != want {
-			t.Fatalf("unexpected authorization header: got %q want %q", got, want)
-		}
-		var req graphQLRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("failed to decode request: %v", err)
-		}
-		if !strings.Contains(req.Query, "tenant") {
-			t.Fatalf("query was not sent: %q", req.Query)
-		}
-		if got, want := req.Variables["id"], "domain-1"; got != want {
-			t.Fatalf("unexpected variable: got %v want %v", got, want)
-		}
+		method = r.Method
+		authz = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"tenant":{"id":"domain-1","name":"Domain"}}}`))
 	}))
 	defer server.Close()
 
-	client := newGraphQLClient(server.URL, "test-token")
-	var out struct {
-		Tenant map[string]any `json:"tenant"`
-	}
-	if err := client.do(context.Background(), "query { tenant { id } }", map[string]any{"id": "domain-1"}, &out); err != nil {
+	client := newGraphQLClient(server.URL, "test-token", testTimeout)
+	value, err := client.do(context.Background(), "query { tenant { id } }", map[string]any{varID: "domain-1"}, respTenant)
+	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	if got, want := out.Tenant["id"], "domain-1"; got != want {
-		t.Fatalf("unexpected tenant id: got %v want %v", got, want)
+
+	if got, want := method, http.MethodPost; got != want {
+		t.Errorf("unexpected method: got %s want %s", got, want)
+	}
+	if got, want := authz, "Bearer test-token"; got != want {
+		t.Errorf("unexpected authorization header: got %q want %q", got, want)
+	}
+	if !strings.Contains(req.Query, respTenant) {
+		t.Errorf("query was not sent: %q", req.Query)
+	}
+	if got, want := req.Variables[varID], "domain-1"; got != want {
+		t.Errorf("unexpected variable: got %v want %v", got, want)
+	}
+
+	var tenant map[string]any
+	if err := json.Unmarshal(value, &tenant); err != nil {
+		t.Fatalf("failed to decode tenant: %v", err)
+	}
+	if got, want := tenant[varID], "domain-1"; got != want {
+		t.Errorf("unexpected tenant id: got %v want %v", got, want)
+	}
+}
+
+func TestGraphQLClientTrimsEndpointAndToken(t *testing.T) {
+	var authz string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authz = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tenant":{"id":"domain-1"}}}`))
+	}))
+	defer server.Close()
+
+	client := newGraphQLClient(" "+server.URL+"\n", " test-token\n", testTimeout)
+	if _, err := client.do(context.Background(), "query { tenant { id } }", nil, respTenant); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if got, want := authz, "Bearer test-token"; got != want {
+		t.Errorf("unexpected authorization header: got %q want %q", got, want)
+	}
+}
+
+func TestGraphQLClientReportsNullField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tenant":null}}`))
+	}))
+	defer server.Close()
+
+	client := newGraphQLClient(server.URL, "", testTimeout)
+	_, err := client.do(context.Background(), "query { tenant { id } }", nil, respTenant)
+	if err == nil {
+		t.Fatal("expected a not found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestGraphQLClientReturnsGraphQLErrors(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"errors":[{"message":"forbidden"},{"message":"invalid input"}]}`))
 	}))
 	defer server.Close()
 
-	client := newGraphQLClient(server.URL, "")
-	err := client.do(context.Background(), "query { tenants { total } }", nil, &struct{}{})
+	client := newGraphQLClient(server.URL, "", testTimeout)
+	_, err := client.do(context.Background(), "query { tenants { total } }", nil, respTenants)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -65,17 +113,24 @@ func TestGraphQLClientReturnsGraphQLErrors(t *testing.T) {
 }
 
 func TestGraphQLClientReturnsHTTPStatusErrors(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 	}))
 	defer server.Close()
 
-	client := newGraphQLClient(server.URL, "")
-	err := client.do(context.Background(), "query { tenants { total } }", nil, &struct{}{})
+	client := newGraphQLClient(server.URL, "", testTimeout)
+	_, err := client.do(context.Background(), "query { tenants { total } }", nil, respTenants)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "status 502") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGraphQLClientRequiresEndpoint(t *testing.T) {
+	client := newGraphQLClient("   ", "", testTimeout)
+	if _, err := client.do(context.Background(), "query { tenants { total } }", nil, respTenants); err == nil {
+		t.Fatal("expected endpoint error")
 	}
 }

--- a/cli/graphql_client_test.go
+++ b/cli/graphql_client_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGraphQLClientAddsBearerTokenAndDecodesData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, http.MethodPost; got != want {
+			t.Fatalf("unexpected method: got %s want %s", got, want)
+		}
+		if got, want := r.Header.Get("Authorization"), "Bearer test-token"; got != want {
+			t.Fatalf("unexpected authorization header: got %q want %q", got, want)
+		}
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if !strings.Contains(req.Query, "tenant") {
+			t.Fatalf("query was not sent: %q", req.Query)
+		}
+		if got, want := req.Variables["id"], "domain-1"; got != want {
+			t.Fatalf("unexpected variable: got %v want %v", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tenant":{"id":"domain-1","name":"Domain"}}}`))
+	}))
+	defer server.Close()
+
+	client := newGraphQLClient(server.URL, "test-token")
+	var out struct {
+		Tenant map[string]any `json:"tenant"`
+	}
+	if err := client.do(context.Background(), "query { tenant { id } }", map[string]any{"id": "domain-1"}, &out); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if got, want := out.Tenant["id"], "domain-1"; got != want {
+		t.Fatalf("unexpected tenant id: got %v want %v", got, want)
+	}
+}
+
+func TestGraphQLClientReturnsGraphQLErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"forbidden"},{"message":"invalid input"}]}`))
+	}))
+	defer server.Close()
+
+	client := newGraphQLClient(server.URL, "")
+	err := client.do(context.Background(), "query { tenants { total } }", nil, &struct{}{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "forbidden; invalid input") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGraphQLClientReturnsHTTPStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client := newGraphQLClient(server.URL, "")
+	err := client.do(context.Background(), "query { tenants { total } }", nil, &struct{}{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/health.go
+++ b/cli/health.go
@@ -11,6 +11,7 @@ func NewHealthCmd() *cobra.Command {
 		Use:   "health <service>",
 		Short: "Health Check",
 		Long: "Magistrala service Health Check\n" +
+			"Supported services: certs, fluxmq\n" +
 			"usage:\n" +
 			"\tmagistrala-cli health <service>",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1,0 +1,107 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+type rootOptions struct {
+	graphQLURL string
+	token      string
+}
+
+// NewRootCmd returns the Atom-backed Magistrala CLI root command.
+func NewRootCmd() *cobra.Command {
+	opts := &rootOptions{
+		graphQLURL: envOrDefault("MG_ATOM_GRAPHQL_URL", defaultAtomGraphQLURL),
+		token:      firstEnv("MG_ATOM_TOKEN", "MAGISTRALA_TOKEN"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "magistrala-cli",
+		Short: "Magistrala command line client",
+		Long:  "Magistrala command line client backed by Atom GraphQL.",
+	}
+	cmd.PersistentFlags().StringVar(&opts.graphQLURL, "graphql-url", opts.graphQLURL, "Atom GraphQL endpoint")
+	cmd.PersistentFlags().StringVar(&opts.token, "token", opts.token, "Atom bearer token")
+
+	cmd.AddCommand(
+		newLoginCmd(opts),
+		newDomainsCmd(opts),
+		newGraphQLClientsCmd(opts),
+		newGraphQLChannelsCmd(opts),
+		newGraphQLGroupsCmd(opts),
+		newAuthzCmd(opts),
+	)
+	return cmd
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func firstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (o *rootOptions) client() *graphQLClient {
+	return newGraphQLClient(o.graphQLURL, o.token)
+}
+
+func (o *rootOptions) authedClient() (*graphQLClient, error) {
+	if o.token == "" {
+		return nil, errors.New("token is required; pass --token or set MG_ATOM_TOKEN")
+	}
+	return o.client(), nil
+}
+
+func writeOutput(cmd *cobra.Command, value any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}
+
+func commonListFlags(cmd *cobra.Command, limit, offset *int) {
+	cmd.Flags().IntVar(limit, "limit", 20, "maximum number of records")
+	cmd.Flags().IntVar(offset, "offset", 0, "number of records to skip")
+}
+
+func parseJSONFlag(raw string) (map[string]any, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var value map[string]any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return nil, fmt.Errorf("invalid JSON value: %w", err)
+	}
+	return value, nil
+}
+
+func optionalString(input string) any {
+	if input == "" {
+		return nil
+	}
+	return input
+}
+
+func optionalObject(input map[string]any) any {
+	if input == nil {
+		return nil
+	}
+	return input
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -4,104 +4,171 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
+	"github.com/absmach/magistrala/pkg/atom"
+	smqsdk "github.com/absmach/magistrala/pkg/sdk"
 	"github.com/spf13/cobra"
+)
+
+const (
+	defCertsSvcURL    = "http://localhost:9010"
+	defHTTPAdapterURL = "http://localhost:9026"
 )
 
 type rootOptions struct {
 	graphQLURL string
 	token      string
+	timeout    time.Duration
 }
 
 // NewRootCmd returns the Atom-backed Magistrala CLI root command.
 func NewRootCmd() *cobra.Command {
+	atomCfg := atom.LoadConfig()
 	opts := &rootOptions{
-		graphQLURL: envOrDefault("MG_ATOM_GRAPHQL_URL", defaultAtomGraphQLURL),
-		token:      firstEnv("MG_ATOM_TOKEN", "MAGISTRALA_TOKEN"),
+		graphQLURL: graphQLURLFromEnv(atomCfg.URL),
+		token:      strings.TrimSpace(atomCfg.Token),
+		timeout:    atomCfg.Timeout,
 	}
+
+	// health is the one command still served by the legacy per-service HTTP
+	// APIs rather than by Atom, so it keeps using the Magistrala SDK.
+	SetSDK(smqsdk.NewSDK(smqsdk.Config{
+		CertsURL:       envOrDefault("MG_CERTS_URL", defCertsSvcURL),
+		HTTPAdapterURL: envOrDefault("MG_HTTP_ADAPTER_URL", defHTTPAdapterURL),
+	}))
 
 	cmd := &cobra.Command{
 		Use:   "magistrala-cli",
 		Short: "Magistrala command line client",
 		Long:  "Magistrala command line client backed by Atom GraphQL.",
+		// devices, gateways and device-types go through pkg/atom.Client, which
+		// can only be built once --graphql-url and --token have been parsed.
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			cfg := atomCfg
+			cfg.URL = atomBaseURL(opts.graphQLURL, atomCfg.URL)
+			cfg.Token = opts.token
+			SetAtomClient(atom.NewClient(cfg))
+		},
 	}
 	cmd.PersistentFlags().StringVar(&opts.graphQLURL, "graphql-url", opts.graphQLURL, "Atom GraphQL endpoint")
 	cmd.PersistentFlags().StringVar(&opts.token, "token", opts.token, "Atom bearer token")
+	cmd.PersistentFlags().BoolVarP(&RawOutput, "raw", "r", RawOutput, "Enables raw output mode for easier parsing of output")
+	cmd.PersistentFlags().Uint64VarP(&Limit, varLimit, "l", Limit, "Limit query parameter")
+	cmd.PersistentFlags().Uint64VarP(&Offset, varOffset, "o", Offset, "Offset query parameter")
+	cmd.PersistentFlags().StringVarP(&Name, varName, "n", Name, "Name query parameter")
 
 	cmd.AddCommand(
+		NewHealthCmd(),
 		newLoginCmd(opts),
 		newDomainsCmd(opts),
 		newGraphQLClientsCmd(opts),
 		newGraphQLChannelsCmd(opts),
 		newGraphQLGroupsCmd(opts),
 		newAuthzCmd(opts),
+		NewDevicesCmd(),
+		NewGatewaysCmd(),
+		NewDeviceTypesCmd(),
 	)
+
 	return cmd
 }
 
-func envOrDefault(key, fallback string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
+// atomBaseURL turns a GraphQL endpoint back into the Atom base URL
+// pkg/atom.Client expects, so --graphql-url configures both clients. An
+// endpoint that does not end in the GraphQL path leaves the base untouched.
+func atomBaseURL(endpoint, fallback string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	base := strings.TrimSuffix(endpoint, atomGraphQLPath)
+	if base != endpoint && base != "" {
+		return base
 	}
+
 	return fallback
 }
 
-func firstEnv(keys ...string) string {
-	for _, key := range keys {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
+// graphQLURLFromEnv resolves the Atom GraphQL endpoint, preferring an explicit
+// ATOM_GRAPHQL_URL over the ATOM_URL base the rest of the repo configures.
+func graphQLURLFromEnv(atomURL string) string {
+	if endpoint := strings.TrimSpace(os.Getenv("ATOM_GRAPHQL_URL")); endpoint != "" {
+		return endpoint
 	}
-	return ""
+	if base := strings.TrimRight(strings.TrimSpace(atomURL), "/"); base != "" {
+		return base + atomGraphQLPath
+	}
+
+	return defaultAtomGraphQLURL
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+
+	return fallback
 }
 
 func (o *rootOptions) client() *graphQLClient {
-	return newGraphQLClient(o.graphQLURL, o.token)
+	return newGraphQLClient(o.graphQLURL, o.token, o.timeout)
 }
 
 func (o *rootOptions) authedClient() (*graphQLClient, error) {
-	if o.token == "" {
-		return nil, errors.New("token is required; pass --token or set MG_ATOM_TOKEN")
+	if strings.TrimSpace(o.token) == "" {
+		return nil, errors.New("token is required; pass --token or set ATOM_ADMIN_TOKEN")
 	}
+
 	return o.client(), nil
 }
 
-func writeOutput(cmd *cobra.Command, value any) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(value)
+// writeOutput re-indents the raw Atom response, which keeps field order and
+// leaves characters such as & and < untouched.
+func writeOutput(cmd *cobra.Command, value json.RawMessage) error {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, value, "", "  "); err != nil {
+		return err
+	}
+	buf.WriteByte('\n')
+	_, err := cmd.OutOrStdout().Write(buf.Bytes())
+
+	return err
 }
 
-func commonListFlags(cmd *cobra.Command, limit, offset *int) {
-	cmd.Flags().IntVar(limit, "limit", 20, "maximum number of records")
-	cmd.Flags().IntVar(offset, "offset", 0, "number of records to skip")
+// listVariables seeds the pagination every list query takes from the shared
+// --limit/--offset flags the rest of the CLI already uses.
+func listVariables() map[string]any {
+	return map[string]any{varLimit: Limit, varOffset: Offset}
 }
 
 func parseJSONFlag(raw string) (map[string]any, error) {
-	if raw == "" {
+	if strings.TrimSpace(raw) == "" {
 		return nil, nil
 	}
 	var value map[string]any
 	if err := json.Unmarshal([]byte(raw), &value); err != nil {
 		return nil, fmt.Errorf("invalid JSON value: %w", err)
 	}
+
 	return value, nil
 }
 
-func optionalString(input string) any {
-	if input == "" {
-		return nil
+// gqlInput builds a GraphQL input object. Empty values are omitted rather than
+// sent as an explicit null, which GraphQL reads as "set this field to null".
+type gqlInput map[string]any
+
+func (in gqlInput) setString(key, value string) {
+	if value != "" {
+		in[key] = value
 	}
-	return input
 }
 
-func optionalObject(input map[string]any) any {
-	if input == nil {
-		return nil
+func (in gqlInput) setObject(key string, value map[string]any) {
+	if value != nil {
+		in[key] = value
 	}
-	return input
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRootCommandContainsAtomBackedCommands(t *testing.T) {
+	t.Setenv("MG_ATOM_TOKEN", "")
+	t.Setenv("MAGISTRALA_TOKEN", "")
+	cmd := NewRootCmd()
+	for _, name := range []string{"login", "domains", "clients", "channels", "groups", "authz"} {
+		if subcmd, _, err := cmd.Find([]string{name}); err != nil || subcmd == nil || subcmd.Name() != name {
+			t.Fatalf("expected command %q to be registered", name)
+		}
+	}
+}
+
+func TestAuthedCommandsRequireToken(t *testing.T) {
+	t.Setenv("MG_ATOM_TOKEN", "")
+	t.Setenv("MAGISTRALA_TOKEN", "")
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"domains", "list"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected token error")
+	}
+	if got, want := err.Error(), "token is required"; len(got) < len(want) || got[:len(want)] != want {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -5,14 +5,26 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
+func clearAtomEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ATOM_URL", "")
+	t.Setenv("ATOM_GRAPHQL_URL", "")
+	t.Setenv("ATOM_SERVICE_TOKEN", "")
+	t.Setenv("ATOM_ADMIN_TOKEN", "")
+}
+
 func TestRootCommandContainsAtomBackedCommands(t *testing.T) {
-	t.Setenv("MG_ATOM_TOKEN", "")
-	t.Setenv("MAGISTRALA_TOKEN", "")
+	clearAtomEnv(t)
 	cmd := NewRootCmd()
-	for _, name := range []string{"login", "domains", "clients", "channels", "groups", "authz"} {
+	for _, name := range []string{
+		"health", "login", cmdDomains, cmdClients, cmdChannels, cmdGroups, "authz",
+		"devices", "gateways", "devicetypes",
+	} {
 		if subcmd, _, err := cmd.Find([]string{name}); err != nil || subcmd == nil || subcmd.Name() != name {
 			t.Fatalf("expected command %q to be registered", name)
 		}
@@ -20,10 +32,9 @@ func TestRootCommandContainsAtomBackedCommands(t *testing.T) {
 }
 
 func TestAuthedCommandsRequireToken(t *testing.T) {
-	t.Setenv("MG_ATOM_TOKEN", "")
-	t.Setenv("MAGISTRALA_TOKEN", "")
+	clearAtomEnv(t)
 	cmd := NewRootCmd()
-	cmd.SetArgs([]string{"domains", "list"})
+	cmd.SetArgs([]string{cmdDomains, "list"})
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 
@@ -31,7 +42,116 @@ func TestAuthedCommandsRequireToken(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected token error")
 	}
-	if got, want := err.Error(), "token is required"; len(got) < len(want) || got[:len(want)] != want {
+	if !strings.HasPrefix(err.Error(), "token is required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGraphQLURLFromEnv(t *testing.T) {
+	cases := []struct {
+		name       string
+		atomURL    string
+		graphQLURL string
+		want       string
+	}{
+		{name: "falls back to the local default", want: defaultAtomGraphQLURL},
+		{name: "derives the endpoint from ATOM_URL", atomURL: "http://atom:8080/", want: "http://atom:8080/graphql"},
+		{name: "trims surrounding whitespace", atomURL: "  http://atom:8080 ", want: "http://atom:8080/graphql"},
+		{name: "prefers an explicit endpoint", atomURL: "http://atom:8080", graphQLURL: " http://gw/gql ", want: "http://gw/gql"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ATOM_GRAPHQL_URL", tc.graphQLURL)
+			if got := graphQLURLFromEnv(tc.atomURL); got != tc.want {
+				t.Fatalf("unexpected endpoint: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGQLInputOmitsEmptyValues(t *testing.T) {
+	input := gqlInput{varName: "Demo"}
+	input.setString(varAlias, "")
+	input.setObject(varAttributes, nil)
+	input.setString(varKind, "device")
+
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal input: %v", err)
+	}
+	if got, want := string(raw), `{"kind":"device","name":"Demo"}`; got != want {
+		t.Fatalf("unexpected input: got %s want %s", got, want)
+	}
+}
+
+func TestWriteOutputDoesNotEscapeHTML(t *testing.T) {
+	cmd := NewRootCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+
+	if err := writeOutput(cmd, json.RawMessage(`{"name":"A & B <lab>"}`)); err != nil {
+		t.Fatalf("failed to write output: %v", err)
+	}
+	if !strings.Contains(out.String(), `"A & B <lab>"`) {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestRootCommandConfiguresAtomClient(t *testing.T) {
+	clearAtomEnv(t)
+	SetAtomClient(nil)
+	t.Cleanup(func() { SetAtomClient(nil) })
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{cmdDomains, "list"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	// The command itself fails on the missing token, but PersistentPreRun has
+	// already run by then, which is what devices/gateways/devicetypes need.
+	_ = cmd.Execute()
+
+	if atomClient == nil {
+		t.Fatal("expected NewRootCmd to configure the Atom client")
+	}
+}
+
+func TestAtomBaseURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		fallback string
+		want     string
+	}{
+		{name: "strips the GraphQL path", endpoint: "http://atom:8080/graphql", fallback: "http://fb", want: "http://atom:8080"},
+		{name: "trims surrounding whitespace", endpoint: " http://atom:8080/graphql ", fallback: "http://fb", want: "http://atom:8080"},
+		{name: "keeps the fallback for a foreign path", endpoint: "http://gw/api", fallback: "http://fb", want: "http://fb"},
+		{name: "keeps the fallback for a bare path", endpoint: "/graphql", fallback: "http://fb", want: "http://fb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := atomBaseURL(tc.endpoint, tc.fallback); got != tc.want {
+				t.Fatalf("unexpected base URL: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListVariablesUseSharedPaginationFlags(t *testing.T) {
+	clearAtomEnv(t)
+	cmd := NewRootCmd()
+	if err := cmd.PersistentFlags().Set(varLimit, "5"); err != nil {
+		t.Fatalf("failed to set limit: %v", err)
+	}
+	if err := cmd.PersistentFlags().Set(varOffset, "2"); err != nil {
+		t.Fatalf("failed to set offset: %v", err)
+	}
+	t.Cleanup(func() { Limit, Offset = 10, 0 })
+
+	variables := listVariables()
+	if got, want := variables[varLimit], uint64(5); got != want {
+		t.Errorf("unexpected limit: got %v want %v", got, want)
+	}
+	if got, want := variables[varOffset], uint64(2); got != want {
+		t.Errorf("unexpected offset: got %v want %v", got, want)
 	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,18 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/absmach/magistrala/cli"
+)
+
+func main() {
+	if err := cli.NewRootCmd().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,15 +4,14 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/absmach/magistrala/cli"
 )
 
 func main() {
+	// Cobra has already reported the error, so only the exit code is left.
 	if err := cli.NewRootCmd().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix because it restores the Magistrala CLI build and replaces the broken legacy HTTP SDK-backed CLI entrypoint with Atom GraphQL-backed commands.

## What does this do?

  - Adds a `cmd/cli` entrypoint so `make cli` builds `build/cli`.
  - Adds an Atom GraphQL client for the CLI.
  - Adds Atom-backed CLI commands for:
  - login
  - domains
  - clients
  - channels
  - groups
  - authz check
  - Updates CLI documentation and root README examples to use the new  GraphQL-backed CLI.
  - Removes outdated CLI documentation examples for removed legacy HTTP management APIs.

## Which issue(s) does this PR fix/relate to?

  - Related Issue #N/A
  - Resolves #N/A

## Have you included tests for your changes?

Yes. Added focused tests for the GraphQL client and root CLI command registration.


Verified locally:

 ```sh
go test ./cli ./cmd/cli
make cli
git diff --check

## Did you document any new/modified feature?

Yes. Updated README.md and cli/README.md with the Atom GraphQL-backed CLI usage.

### Notes

This restores a functional first slice of MG-CLI against Atom GraphQL. It does not migrate every historical legacy HTTP SDK command.
