### PR TITLE
MG-05: Message attribution — device_id from the payload

### DIFF
--- a/pkg/messaging/README.md
+++ b/pkg/messaging/README.md
@@ -40,6 +40,8 @@ A message carries the protocol it was published with (`mqtt`, `http`, `coap`, �
 
 `InternalMetadata` is what avoids this. A connection authenticated as a `service`-role local principal on the mTLS listener may relay the origin protocol, publisher, `created` timestamp and metadata it received rather than having its own stamped on. Any service that republishes messages someone else authored has to use it, and its principal needs a `permissions.publish` entry for the destination.
 
+`Message.DeviceId` is a separate, opt-in identity: "whose data this is" rather than "who sent it". It is set only when a publish is already known to be about exactly one device — a directly-connected device, or a service republishing a value it computed for one specific meter — and is relayed the same way as publisher/protocol. It is never set from a raw gateway batch, which is never provably single-device; a batch's per-record attribution is resolved downstream, from the payload, by `pkg/transformers/senml` and `pkg/transformers/json`.
+
 ### Options
 
 | Option                                 | Description                                                                                       |

--- a/pkg/messaging/fluxmq/publisher.go
+++ b/pkg/messaging/fluxmq/publisher.go
@@ -19,6 +19,7 @@ var _ messaging.Publisher = (*publisher)(nil)
 const (
 	headerExternalID = "external_id"
 	headerProtocol   = "protocol"
+	headerDeviceID   = "device_id"
 	// headerMetadataPrefix sits inside FluxMQ's reserved "_flux." namespace, so
 	// the broker treats message metadata as internal state passed between
 	// first-party services: it is dropped when an untrusted connection sets it
@@ -150,6 +151,11 @@ func messageProperties(msg *messaging.Message) map[string]string {
 	}
 	if clientID := msg.ClientIdentity(); clientID != "" {
 		props["client_id"] = clientID
+	}
+	// Broker-level, single-device only. Never set from payload accumulation —
+	// see pkg/transformers/senml and pkg/transformers/json for that mechanism.
+	if msg.GetDeviceId() != "" {
+		props[headerDeviceID] = msg.GetDeviceId()
 	}
 	if msg.GetCreated() != 0 {
 		props["created"] = strconv.FormatInt(msg.GetCreated(), 10)

--- a/pkg/messaging/fluxmq/pubsub.go
+++ b/pkg/messaging/fluxmq/pubsub.go
@@ -237,6 +237,7 @@ func messageFromDelivery(body []byte, headers map[string]any, ts time.Time, pref
 
 	clientID := stringHeader(headers, "client_id")
 	publisher := stringHeader(headers, headerExternalID)
+	deviceID := stringHeader(headers, headerDeviceID)
 
 	protocol := stringHeader(headers, headerProtocol)
 	if protocol == "" {
@@ -279,6 +280,7 @@ func messageFromDelivery(body []byte, headers map[string]any, ts time.Time, pref
 		Protocol:  protocol,
 		Created:   created,
 		Metadata:  metadata,
+		DeviceId:  deviceID,
 	}, nil
 }
 

--- a/pkg/messaging/fluxmq/pubsub_test.go
+++ b/pkg/messaging/fluxmq/pubsub_test.go
@@ -286,6 +286,39 @@ func TestMetadataPropertyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDeviceIDPropertyRoundTrip(t *testing.T) {
+	want := &messaging.Message{
+		Publisher: "gateway-1",
+		Protocol:  "mqtt",
+		Payload:   []byte("payload"),
+		DeviceId:  "dev-1",
+	}
+
+	properties := messageProperties(want)
+	headers := make(map[string]any, len(properties))
+	for key, value := range properties {
+		headers[key] = value
+	}
+
+	got, err := messageFromDelivery(want.Payload, headers, time.Time{}, "m", "m/domain/c/channel/subtopic")
+	if err != nil {
+		t.Fatalf("reconstruct message: %v", err)
+	}
+	if got.GetDeviceId() != want.GetDeviceId() {
+		t.Fatalf("device ID mismatch: got %q, want %q", got.GetDeviceId(), want.GetDeviceId())
+	}
+}
+
+func TestMessagePropertiesOmitsDeviceIDWhenUnset(t *testing.T) {
+	msg := &messaging.Message{Publisher: "gateway-1", Protocol: "mqtt"}
+
+	got := messageProperties(msg)
+
+	if _, ok := got[headerDeviceID]; ok {
+		t.Fatalf("expected no %q property when DeviceId is unset, got %#v", headerDeviceID, got)
+	}
+}
+
 func TestMessageFromDeliveryZeroTimestampFallsBackToNow(t *testing.T) {
 	before := time.Now().UnixNano()
 	got, err := messageFromDelivery([]byte("raw"), nil, time.Time{}, "m", "m/dom/c/ch")

--- a/pkg/messaging/message.pb.go
+++ b/pkg/messaging/message.pb.go
@@ -36,7 +36,12 @@ type Message struct {
 	Created   int64                  `protobuf:"varint,7,opt,name=created,proto3" json:"created,omitempty"`                  // Unix timestamp in nanoseconds
 	ClientId  string                 `protobuf:"bytes,8,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"` // Transport-level client identifier
 	// Internal metadata propagated between services
-	Metadata      map[string]string `protobuf:"bytes,9,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata map[string]string `protobuf:"bytes,9,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Set only when a publish is already known to be about exactly one
+	// device before it reaches the broker. Never inferred from a raw
+	// gateway batch — see pkg/transformers/senml and pkg/transformers/json
+	// for the per-record mechanism a batch actually uses.
+	DeviceId      string `protobuf:"bytes,10,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -134,11 +139,18 @@ func (x *Message) GetMetadata() map[string]string {
 	return nil
 }
 
+func (x *Message) GetDeviceId() string {
+	if x != nil {
+		return x.DeviceId
+	}
+	return ""
+}
+
 var File_pkg_messaging_message_proto protoreflect.FileDescriptor
 
 const file_pkg_messaging_message_proto_rawDesc = "" +
 	"\n" +
-	"\x1bpkg/messaging/message.proto\x12\tmessaging\"\xdd\x02\n" +
+	"\x1bpkg/messaging/message.proto\x12\tmessaging\"\xfa\x02\n" +
 	"\aMessage\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12\x16\n" +
 	"\x06domain\x18\x02 \x01(\tR\x06domain\x12\x1a\n" +
@@ -148,7 +160,9 @@ const file_pkg_messaging_message_proto_rawDesc = "" +
 	"\apayload\x18\x06 \x01(\fR\apayload\x12\x18\n" +
 	"\acreated\x18\a \x01(\x03R\acreated\x12\x1b\n" +
 	"\tclient_id\x18\b \x01(\tR\bclientId\x12<\n" +
-	"\bmetadata\x18\t \x03(\v2 .messaging.Message.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\t \x03(\v2 .messaging.Message.MetadataEntryR\bmetadata\x12\x1b\n" +
+	"\tdevice_id\x18\n" +
+	" \x01(\tR\bdeviceId\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\rZ\v./messagingb\x06proto3"

--- a/pkg/messaging/message.proto
+++ b/pkg/messaging/message.proto
@@ -18,4 +18,9 @@ message Message {
   string client_id = 8; // Transport-level client identifier
   // Internal metadata propagated between services
   map<string, string> metadata = 9;
+  // Set only when a publish is already known to be about exactly one
+  // device before it reaches the broker. Never inferred from a raw
+  // gateway batch — see pkg/transformers/senml and pkg/transformers/json
+  // for the per-record mechanism a batch actually uses.
+  string device_id = 10;
 }

--- a/pkg/transformers/json/message.go
+++ b/pkg/transformers/json/message.go
@@ -14,6 +14,10 @@ type Message struct {
 	Publisher string  `json:"publisher,omitempty" db:"publisher" bson:"publisher"`
 	Protocol  string  `json:"protocol,omitempty" db:"protocol" bson:"protocol"`
 	Payload   Payload `json:"payload,omitempty" db:"payload" bson:"payload,omitempty"`
+	// The device's serial, verbatim, popped from the reserved "device_id" key
+	// and accumulated forward across a batch the same way senml.Message.DeviceId
+	// accumulates from bn — never looked up.
+	DeviceId string `json:"device_id,omitempty" db:"device_id" bson:"device_id,omitempty"`
 }
 
 // Messages represents a list of JSON messages.

--- a/pkg/transformers/json/transformer.go
+++ b/pkg/transformers/json/transformer.go
@@ -15,7 +15,7 @@ import (
 const sep = "/"
 
 var (
-	keys = [...]string{"publisher", "protocol", "channel", "subtopic"}
+	keys = [...]string{"publisher", "protocol", "channel", "subtopic", "device_id"}
 
 	// ErrTransform represents an error during parsing message.
 	ErrTransform = errors.New("unable to parse JSON object")
@@ -74,6 +74,7 @@ func (ts *transformerService) Transform(msg *messaging.Message) (any, error) {
 
 	switch p := payload.(type) {
 	case map[string]any:
+		ret.DeviceId = popDeviceID(p)
 		ret.Payload = p
 
 		// Apply timestamp transformation rules depending on key/unit pairs
@@ -88,6 +89,10 @@ func (ts *transformerService) Transform(msg *messaging.Message) (any, error) {
 		return Messages{[]Message{ret}, format}, nil
 	case []any:
 		res := []Message{}
+		// device_id accumulates forward across the batch exactly like SenML's
+		// bn (RFC 8428 §4.6) — set on one element, it applies to every
+		// following element until the next one sets a new value.
+		var deviceID string
 		// Make an array of messages from the root array.
 		for _, val := range p {
 			v, ok := val.(map[string]any)
@@ -95,6 +100,11 @@ func (ts *transformerService) Transform(msg *messaging.Message) (any, error) {
 				return nil, errors.Wrap(ErrTransform, errInvalidNestedJSON)
 			}
 			newMsg := ret
+
+			if id := popDeviceID(v); id != "" {
+				deviceID = id
+			}
+			newMsg.DeviceId = deviceID
 
 			// Apply timestamp transformation rules depending on key/unit pairs
 			ts, err := ts.transformTimeField(v)
@@ -112,6 +122,21 @@ func (ts *transformerService) Transform(msg *messaging.Message) (any, error) {
 	default:
 		return nil, errors.Wrap(ErrTransform, errInvalidFormat)
 	}
+}
+
+// popDeviceID extracts the reserved "device_id" key from a decoded record,
+// if present, so it is not also duplicated in the stored Payload. A present
+// but non-string or empty value is still popped but does not count as a
+// device id — this mirrors bn's own "empty does not update the accumulator"
+// rule (see pkg/transformers/senml).
+func popDeviceID(m map[string]any) string {
+	v, ok := m["device_id"]
+	if !ok {
+		return ""
+	}
+	delete(m, "device_id")
+	s, _ := v.(string)
+	return s
 }
 
 // ParseFlat receives flat map that represents complex JSON objects and returns

--- a/pkg/transformers/json/transformer_test.go
+++ b/pkg/transformers/json/transformer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/absmach/magistrala/pkg/messaging"
 	"github.com/absmach/magistrala/pkg/transformers/json"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -253,4 +254,95 @@ func TestTransformJSON(t *testing.T) {
 		assert.Equal(t, tc.json, m, fmt.Sprintf("%s got incorrect json response from Transform()", tc.desc))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
 	}
+}
+
+// TestTransformDeviceID covers MG-05: device_id popped from the reserved
+// "device_id" key, accumulating forward across a batch the same way SenML's
+// bn does (RFC 8428 §4.6).
+func TestTransformDeviceID(t *testing.T) {
+	tr := json.New(nil)
+	newMsg := func(payload string) *messaging.Message {
+		return &messaging.Message{
+			Channel:   "channel-1",
+			Subtopic:  "subtopic-1",
+			Publisher: "publisher-1",
+			Protocol:  "protocol",
+			Payload:   []byte(payload),
+		}
+	}
+
+	t.Run("single object: device_id is popped from Payload and set on the message", func(t *testing.T) {
+		got, err := tr.Transform(newMsg(`{"device_id":"dev-1","temp":21.5}`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 1)
+		assert.Equal(t, "dev-1", msgs.Data[0].DeviceId)
+		assert.NotContains(t, msgs.Data[0].Payload, "device_id")
+		assert.Equal(t, map[string]any{"temp": 21.5}, map[string]any(msgs.Data[0].Payload))
+	})
+
+	t.Run("single object: no device_id leaves DeviceId empty and Payload untouched", func(t *testing.T) {
+		got, err := tr.Transform(newMsg(`{"temp":21.5}`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 1)
+		assert.Empty(t, msgs.Data[0].DeviceId)
+		assert.Equal(t, map[string]any{"temp": 21.5}, map[string]any(msgs.Data[0].Payload))
+	})
+
+	t.Run("array: device_id set once is inherited across every following element", func(t *testing.T) {
+		got, err := tr.Transform(newMsg(`[{"device_id":"dev-1","temp":21.5},{"humidity":55},{"pressure":1013}]`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 3)
+		for _, m := range msgs.Data {
+			assert.Equal(t, "dev-1", m.DeviceId)
+		}
+	})
+
+	t.Run("array: device_id changing mid-array attributes each element to its own device", func(t *testing.T) {
+		// A concentrating gateway's single flush spanning two meters — the
+		// primary scenario this PRD exists for.
+		got, err := tr.Transform(newMsg(`[
+			{"device_id":"dev-1","temp":21.5},
+			{"humidity":55},
+			{"device_id":"dev-2","temp":19.0},
+			{"humidity":60}
+		]`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 4)
+		want := []string{"dev-1", "dev-1", "dev-2", "dev-2"}
+		for i, m := range msgs.Data {
+			assert.Equal(t, want[i], m.DeviceId, "element %d", i)
+		}
+	})
+
+	t.Run("array: an explicit empty device_id does not reset accumulation", func(t *testing.T) {
+		got, err := tr.Transform(newMsg(`[
+			{"device_id":"dev-1","temp":21.5},
+			{"device_id":"","humidity":55},
+			{"pressure":1013}
+		]`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 3)
+		for _, m := range msgs.Data {
+			assert.Equal(t, "dev-1", m.DeviceId)
+		}
+	})
+
+	t.Run("device id is carried verbatim, including unicode", func(t *testing.T) {
+		got, err := tr.Transform(newMsg(`{"device_id":"dév-测试_1","temp":21.5}`))
+		require.NoError(t, err)
+		msgs, ok := got.(json.Messages)
+		require.True(t, ok)
+		require.Len(t, msgs.Data, 1)
+		assert.Equal(t, "dév-测试_1", msgs.Data[0].DeviceId)
+	})
 }

--- a/pkg/transformers/senml/message.go
+++ b/pkg/transformers/senml/message.go
@@ -18,4 +18,7 @@ type Message struct {
 	DataValue   *string  `json:"data_value,omitempty" db:"data_value" bson:"data_value,omitempty"`
 	BoolValue   *bool    `json:"bool_value,omitempty" db:"bool_value" bson:"bool_value,omitempty"`
 	Sum         *float64 `json:"sum,omitempty" db:"sum" bson:"sum,omitempty"`
+	// The device's serial, verbatim, resolved per record from the pack's
+	// accumulated bn (RFC 8428 §4.6) — not a platform UUID, never looked up.
+	DeviceId string `json:"device_id,omitempty" db:"device_id" bson:"device_id,omitempty"`
 }

--- a/pkg/transformers/senml/transformer.go
+++ b/pkg/transformers/senml/transformer.go
@@ -51,6 +51,21 @@ func (t transformer) Transform(msg *messaging.Message) (any, error) {
 		return nil, errors.Wrap(errDecode, err)
 	}
 
+	// Accumulate bn forward across the raw pack (RFC 8428 §4.6), before
+	// Normalize folds it into Name and discards it. Stashed in the otherwise
+	// unused Link field so it survives Normalize's internal sort — Swap moves
+	// whole records, so the accumulated value travels with the record it
+	// belongs to regardless of how Time ties are broken. Link is never
+	// mapped to the output Message, so this does not change any existing
+	// behaviour.
+	var deviceID string
+	for i := range raw.Records {
+		if raw.Records[i].BaseName != "" {
+			deviceID = raw.Records[i].BaseName
+		}
+		raw.Records[i].Link = deviceID
+	}
+
 	normalized, err := senml.Normalize(raw)
 	if err != nil {
 		return nil, errors.Wrap(errNormalize, err)
@@ -87,6 +102,7 @@ func (t transformer) Transform(msg *messaging.Message) (any, error) {
 			DataValue:   v.DataValue,
 			StringValue: v.StringValue,
 			Sum:         v.Sum,
+			DeviceId:    v.Link,
 		}
 	}
 

--- a/pkg/transformers/senml/transformer_test.go
+++ b/pkg/transformers/senml/transformer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/absmach/magistrala/pkg/transformers/senml"
 	mgsenml "github.com/absmach/senml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransformJSON(t *testing.T) {
@@ -48,6 +49,7 @@ func TestTransformJSON(t *testing.T) {
 			UpdateTime: 150,
 			Value:      &val,
 			Sum:        &sum,
+			DeviceId:   "base-name",
 		},
 	}
 
@@ -120,6 +122,7 @@ func TestTransformCBOR(t *testing.T) {
 			UpdateTime: 150,
 			Value:      &val,
 			Sum:        &sum,
+			DeviceId:   "base-name",
 		},
 	}
 
@@ -148,4 +151,106 @@ func TestTransformCBOR(t *testing.T) {
 		assert.Equal(t, tc.msgs, msgs, fmt.Sprintf("%s expected %v, got %v", tc.desc, tc.msgs, msgs))
 		assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s expected %s, got %s", tc.desc, tc.err, err))
 	}
+}
+
+// TestTransformDeviceIDAccumulation covers MG-05: device_id resolved per
+// record from the pack's accumulated bn (RFC 8428 §4.6), not per message.
+func TestTransformDeviceIDAccumulation(t *testing.T) {
+	tr := senml.New(senml.JSON)
+
+	t.Run("no bn anywhere leaves DeviceId empty", func(t *testing.T) {
+		payload := []byte(`[
+			{"n":"temp","t":1,"v":21.5},
+			{"n":"humidity","t":2,"v":55}
+		]`)
+		msg := &messaging.Message{Channel: "c", Publisher: "p", Payload: payload}
+
+		got, err := tr.Transform(msg)
+		require.NoError(t, err)
+		msgs, ok := got.([]senml.Message)
+		require.True(t, ok)
+		require.Len(t, msgs, 2)
+		for _, m := range msgs {
+			assert.Empty(t, m.DeviceId)
+		}
+	})
+
+	t.Run("bn set once is inherited across every following record", func(t *testing.T) {
+		payload := []byte(`[
+			{"bn":"dev-1","n":"temp","t":1,"v":21.5},
+			{"n":"humidity","t":2,"v":55},
+			{"n":"pressure","t":3,"v":1013}
+		]`)
+		msg := &messaging.Message{Channel: "c", Publisher: "p", Payload: payload}
+
+		got, err := tr.Transform(msg)
+		require.NoError(t, err)
+		msgs, ok := got.([]senml.Message)
+		require.True(t, ok)
+		require.Len(t, msgs, 3)
+		for _, m := range msgs {
+			assert.Equal(t, "dev-1", m.DeviceId)
+		}
+	})
+
+	t.Run("bn changing mid-pack attributes each group to its own device", func(t *testing.T) {
+		// A concentrating gateway's single flush spanning two meters — the
+		// primary scenario this PRD exists for.
+		payload := []byte(`[
+			{"bn":"dev-1","n":"temp","t":1,"v":21.5},
+			{"n":"humidity","t":2,"v":55},
+			{"bn":"dev-2","n":"temp","t":3,"v":19.0},
+			{"n":"humidity","t":4,"v":60}
+		]`)
+		msg := &messaging.Message{Channel: "c", Publisher: "p", Payload: payload}
+
+		got, err := tr.Transform(msg)
+		require.NoError(t, err)
+		msgs, ok := got.([]senml.Message)
+		require.True(t, ok)
+		require.Len(t, msgs, 4)
+
+		// Keyed by Name (unique per record here) rather than slice position:
+		// Normalize sorts by Time, and ties are not guaranteed stable.
+		byName := make(map[string]string, len(msgs))
+		for _, m := range msgs {
+			byName[m.Name] = m.DeviceId
+		}
+		assert.Equal(t, map[string]string{
+			"dev-1temp":     "dev-1",
+			"dev-1humidity": "dev-1",
+			"dev-2temp":     "dev-2",
+			"dev-2humidity": "dev-2",
+		}, byName)
+	})
+
+	t.Run("an explicit empty bn does not reset accumulation", func(t *testing.T) {
+		payload := []byte(`[
+			{"bn":"dev-1","n":"temp","t":1,"v":21.5},
+			{"bn":"","n":"humidity","t":2,"v":55},
+			{"n":"pressure","t":3,"v":1013}
+		]`)
+		msg := &messaging.Message{Channel: "c", Publisher: "p", Payload: payload}
+
+		got, err := tr.Transform(msg)
+		require.NoError(t, err)
+		msgs, ok := got.([]senml.Message)
+		require.True(t, ok)
+		require.Len(t, msgs, 3)
+		for _, m := range msgs {
+			assert.Equal(t, "dev-1", m.DeviceId)
+		}
+	})
+
+	t.Run("device id is carried verbatim", func(t *testing.T) {
+		payload := []byte(`[{"bn":"DEV.7-A:07_x","n":"temp","t":1,"v":21.5}]`)
+		msg := &messaging.Message{Channel: "c", Publisher: "p", Payload: payload}
+
+		got, err := tr.Transform(msg)
+		require.NoError(t, err)
+		msgs, ok := got.([]senml.Message)
+		require.True(t, ok)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "DEV.7-A:07_x", msgs[0].DeviceId)
+	})
 }


### PR DESCRIPTION
## Summary

Implements [MG-05](edge/prd/MG-05-topic-device-segment.md) — the first PRD in **phase 2** (message attribution), stacked against the new `edge-ph2` integration branch per [spec §8 A15](edge/architecture.md#8-decision-record).

`device_id` is resolved **per record, from the payload** — not from the topic. An earlier draft of this PRD put it in a topic segment; that was reversed because a concentrating gateway's single publish routinely carries readings for several different meters at once, and a topic names exactly one identity per publish.

- **SenML**: `device_id` accumulates forward from `bn` (base name) per [RFC 8428 §4.6](https://datatracker.ietf.org/doc/html/rfc8428#section-4.6) — set on one record, it applies to every following record until the next one sets a new `bn`. Implemented as a pass over the raw pack before `senml.Normalize`, carried through `Normalize`'s internal time-sort via the otherwise-unused `Link` field (which `Swap` moves together with the rest of each record, so the value survives regardless of how time ties are broken — and `Link` is never mapped to any output field, so this changes no existing behaviour).
- **JSON**: a new reserved `device_id` key, given the same accumulating semantics deliberately modelled on `bn` even though JSON has no native base-field concept — Magistrala's own convention, chosen because a gateway's JSON flush is the same batch shape as a SenML pack.
- **Broker-level `messaging.Message.DeviceId`** (new proto field 10): opt-in, single-device only, for a publish already known to be about exactly one device before it reaches the broker (a directly-connected device, or a service republishing a value it computed for one specific meter). Never inferred from a raw gateway batch. Relayed through FluxMQ properties the same way `publisher`/`protocol` already are.

## Scope

- `pkg/messaging/message.proto` / `message.pb.go` — `device_id = 10`, regenerated with protoc v35.1 (CI's pinned version, so `scripts/ci.sh`'s `cmp` check against a fresh regen stays green) and protoc-gen-go v1.36.11.
- `pkg/messaging/fluxmq/publisher.go`, `pubsub.go` — opt-in `device_id` header, round-tripped through `messageProperties`/`messageFromDelivery`.
- `pkg/transformers/senml/{message,transformer}.go` — `DeviceId` field + `bn` accumulation pass.
- `pkg/transformers/json/{message,transformer}.go` — `DeviceId` field + reserved-key extraction with accumulation, added to the existing reserved-keys list.
- `pkg/messaging/README.md` — documents the new field alongside the existing publisher/protocol relay section.

**Out of scope** (per the PRD): no topic grammar changes anywhere — `C5` (reserving a `d` segment) is withdrawn, not deferred. No resolution/lookup — `device_id` is carried verbatim, never checked against Atom. Persistence and query filters are MG-06.

## Test plan

- Table-driven tests for both transformers: single device, multiple devices in one pack/array (the core gateway-batching scenario), no device, `bn`/`device_id` set once and inherited, changed mid-pack, explicit-empty-does-not-reset, and verbatim carry (SenML constrained to RFC 8428's Name charset; JSON including unicode).
- Existing SenML/JSON transformer fixtures updated where they already had `bn` set (they now correctly report `DeviceId` — not a regression, the accumulation pass now surfaces a value that was previously silently discarded).
- FluxMQ round-trip test for the broker-level field, plus a test asserting it's omitted when unset.
- Verified: `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), `gofmt -l` (clean), full `go test ./...` — all green, no regressions anywhere in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)