### PR TITLE
MG-02: Device Type (Atom Profile) client API

### DIFF
--- a/auth/pat.go
+++ b/auth/pat.go
@@ -77,29 +77,31 @@ type EntityType uint32
 // never become load-bearing by accident later. 2 (former ClientsType) is
 // retired, not reused, so no future constant silently inherits old meaning.
 const (
-	GroupsType    EntityType = 0
-	ChannelsType  EntityType = 1
-	BootstrapType EntityType = 3
-	DashboardType EntityType = 4
-	MessagesType  EntityType = 5
-	DomainsType   EntityType = 6
-	UsersType     EntityType = 7
-	RulesType     EntityType = 8
-	ReportsType   EntityType = 9
-	DevicesType   EntityType = 10
+	GroupsType      EntityType = 0
+	ChannelsType    EntityType = 1
+	BootstrapType   EntityType = 3
+	DashboardType   EntityType = 4
+	MessagesType    EntityType = 5
+	DomainsType     EntityType = 6
+	UsersType       EntityType = 7
+	RulesType       EntityType = 8
+	ReportsType     EntityType = 9
+	DevicesType     EntityType = 10
+	DeviceTypesType EntityType = 11
 )
 
 const (
-	GroupsScopeStr   = "groups"
-	ChannelsScopeStr = "channels"
-	DevicesScopeStr  = "devices"
-	BootstrapStr     = "bootstrap"
-	DashboardsStr    = "dashboards"
-	MessagesStr      = "messages"
-	DomainsStr       = "domains"
-	UsersStr         = "users"
-	RulesScopeStr    = "rules"
-	ReportsScopeStr  = "reports"
+	GroupsScopeStr      = "groups"
+	ChannelsScopeStr    = "channels"
+	DevicesScopeStr     = "devices"
+	DeviceTypesScopeStr = "device_types"
+	BootstrapStr        = "bootstrap"
+	DashboardsStr       = "dashboards"
+	MessagesStr         = "messages"
+	DomainsStr          = "domains"
+	UsersStr            = "users"
+	RulesScopeStr       = "rules"
+	ReportsScopeStr     = "reports"
 )
 
 func (et EntityType) String() string {
@@ -110,6 +112,8 @@ func (et EntityType) String() string {
 		return ChannelsScopeStr
 	case DevicesType:
 		return DevicesScopeStr
+	case DeviceTypesType:
+		return DeviceTypesScopeStr
 	case BootstrapType:
 		return BootstrapStr
 	case DashboardType:
@@ -137,6 +141,8 @@ func ParseEntityType(et string) (EntityType, error) {
 		return ChannelsType, nil
 	case DevicesScopeStr:
 		return DevicesType, nil
+	case DeviceTypesScopeStr:
+		return DeviceTypesType, nil
 	case BootstrapStr:
 		return BootstrapType, nil
 	case DashboardsStr:
@@ -179,7 +185,7 @@ func (et *EntityType) UnmarshalText(data []byte) (err error) {
 
 func IsValidOperationForEntity(entityType EntityType, operation string) bool {
 	switch entityType {
-	case DevicesType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
+	case DevicesType, DeviceTypesType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
 		return true
 	case DashboardType:
 		return operation == OpDashboardShare || operation == OpDashboardUnshare

--- a/auth/pat_test.go
+++ b/auth/pat_test.go
@@ -32,6 +32,11 @@ func TestEntityTypeString(t *testing.T) {
 			expected: "devices",
 		},
 		{
+			desc:     "Device types entity type",
+			et:       auth.DeviceTypesType,
+			expected: "device_types",
+		},
+		{
 			desc:     "Bootstrap entity type",
 			et:       auth.BootstrapType,
 			expected: "bootstrap",
@@ -94,6 +99,12 @@ func TestParseEntityType(t *testing.T) {
 			desc:     "Parse devices",
 			et:       "devices",
 			expected: auth.DevicesType,
+			err:      false,
+		},
+		{
+			desc:     "Parse device types",
+			et:       "device_types",
+			expected: auth.DeviceTypesType,
 			err:      false,
 		},
 		{
@@ -164,6 +175,12 @@ func TestEntityTypeMarshalJSON(t *testing.T) {
 			desc:     "Marshal devices",
 			et:       auth.DevicesType,
 			expected: []byte(`"devices"`),
+			err:      nil,
+		},
+		{
+			desc:     "Marshal device types",
+			et:       auth.DeviceTypesType,
+			expected: []byte(`"device_types"`),
 			err:      nil,
 		},
 		{
@@ -334,5 +351,62 @@ func TestEntityTypeUnmarshalText(t *testing.T) {
 				assert.Equal(t, tc.expected, et, "UnmarshalText() = %v, expected %v", et, tc.expected)
 			}
 		})
+	}
+}
+
+// TestEntityTypeRoundTrip pins every declared EntityType against all four of
+// its representations at once. String(), ParseEntityType, JSON and text are
+// written separately, so a new variant added to one and forgotten in another
+// only shows up here.
+func TestEntityTypeRoundTrip(t *testing.T) {
+	cases := []struct {
+		et   auth.EntityType
+		name string
+	}{
+		{auth.GroupsType, "groups"},
+		{auth.ChannelsType, "channels"},
+		{auth.BootstrapType, "bootstrap"},
+		{auth.DashboardType, "dashboards"},
+		{auth.MessagesType, "messages"},
+		{auth.DomainsType, "domains"},
+		{auth.UsersType, "users"},
+		{auth.RulesType, "rules"},
+		{auth.ReportsType, "reports"},
+		{auth.DevicesType, "devices"},
+		{auth.DeviceTypesType, "device_types"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.name, tc.et.String())
+
+			parsed, err := auth.ParseEntityType(tc.name)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.et, parsed)
+
+			marshalled, err := tc.et.MarshalJSON()
+			assert.NoError(t, err)
+			assert.Equal(t, []byte(`"`+tc.name+`"`), marshalled)
+
+			var fromJSON auth.EntityType
+			assert.NoError(t, fromJSON.UnmarshalJSON(marshalled))
+			assert.Equal(t, tc.et, fromJSON)
+
+			text, err := tc.et.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, []byte(tc.name), text)
+
+			var fromText auth.EntityType
+			assert.NoError(t, fromText.UnmarshalText(text))
+			assert.Equal(t, tc.et, fromText)
+		})
+	}
+}
+
+// TestDeviceTypesOperationsAreValid mirrors devices: device types accept any
+// operation, unlike dashboards and messages which accept a fixed pair.
+func TestDeviceTypesOperationsAreValid(t *testing.T) {
+	for _, op := range []string{"view", "update", "create_version", "list_versions"} {
+		assert.True(t, auth.IsValidOperationForEntity(auth.DeviceTypesType, op), "operation %s must be valid for device_types", op)
 	}
 }

--- a/cli/atom_fake_test.go
+++ b/cli/atom_fake_test.go
@@ -32,6 +32,12 @@ type fakeAtom struct {
 	getCount    map[string]int
 	mutateAtGet map[string]int
 	mutateAttrs map[string]atom.Attributes
+
+	deviceTypes        map[string]atom.DeviceType
+	typeVersions       map[string][]atom.DeviceTypeVersion
+	typeSeq            int
+	versionSeq         int
+	updateEntityGQLErr string
 }
 
 // mutateOnNthGet swaps id's attributes in after its nth GetEntity call,
@@ -46,9 +52,36 @@ func (fa *fakeAtom) mutateOnNthGet(id string, n int, attrs atom.Attributes) {
 	fa.mutateAttrs[id] = attrs
 }
 
+// seedDeviceType registers a device type, and seedDeviceTypeVersion one of its
+// versions. They are methods rather than newFakeAtom arguments so the entity
+// seeding signature the device and gateway tests use stays unchanged.
+func (fa *fakeAtom) seedDeviceType(deviceTypes ...atom.DeviceType) {
+	for _, dt := range deviceTypes {
+		fa.deviceTypes[dt.ID] = dt
+	}
+}
+
+func (fa *fakeAtom) seedDeviceTypeVersion(versions ...atom.DeviceTypeVersion) {
+	for _, v := range versions {
+		fa.typeVersions[v.DeviceTypeID] = append(fa.typeVersions[v.DeviceTypeID], v)
+	}
+}
+
+// failEntityUpdate makes the next UpdateEntity answer with a GraphQL error,
+// which is how Atom reports a device type schema rejection.
+func (fa *fakeAtom) failEntityUpdate(message string) {
+	fa.updateEntityGQLErr = message
+}
+
 func newFakeAtom(t *testing.T, seed ...atom.Entity) *fakeAtom {
 	t.Helper()
-	fa := &fakeAtom{t: t, entities: map[string]atom.Entity{}, getCount: map[string]int{}}
+	fa := &fakeAtom{
+		t:            t,
+		entities:     map[string]atom.Entity{},
+		getCount:     map[string]int{},
+		deviceTypes:  map[string]atom.DeviceType{},
+		typeVersions: map[string][]atom.DeviceTypeVersion{},
+	}
 	for _, e := range seed {
 		fa.entities[e.ID] = e
 	}
@@ -66,6 +99,8 @@ func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
 	fa.requests = append(fa.requests, req)
 	w.Header().Set("Content-Type", "application/json")
 
+	// CreateDeviceTypeVersion is matched before CreateDeviceType, whose name is
+	// a prefix of it.
 	switch {
 	case strings.Contains(req.Query, "mutation CreateEntity"):
 		fa.handleCreate(w, req)
@@ -77,9 +112,154 @@ func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
 		fa.handleGet(w, req)
 	case strings.Contains(req.Query, "query Entities("):
 		fa.handleList(w, req)
+	case strings.Contains(req.Query, "mutation CreateDeviceTypeVersion"):
+		fa.handleCreateDeviceTypeVersion(w, req)
+	case strings.Contains(req.Query, "mutation CreateDeviceType"):
+		fa.handleCreateDeviceType(w, req)
+	case strings.Contains(req.Query, "mutation UpdateDeviceType"):
+		fa.handleUpdateDeviceType(w, req)
+	case strings.Contains(req.Query, "query DeviceTypeVersions("):
+		fa.handleListDeviceTypeVersions(w, req)
+	case strings.Contains(req.Query, "query DeviceTypes("):
+		fa.handleListDeviceTypes(w, req)
+	case strings.Contains(req.Query, "query DeviceType("):
+		fa.handleGetDeviceType(w, req)
 	default:
 		fa.t.Fatalf("unexpected graphql query: %s", req.Query)
 	}
+}
+
+func (fa *fakeAtom) handleCreateDeviceType(w http.ResponseWriter, req gqlRequest) {
+	input, _ := req.Variables["input"].(map[string]any)
+	fa.typeSeq++
+	dt := atom.DeviceType{
+		ID:          fmt.Sprintf("device-type-%d", fa.typeSeq),
+		TenantID:    strVal(input["tenantId"]),
+		Key:         strVal(input["key"]),
+		Name:        strVal(input["displayName"]),
+		Description: strVal(input["description"]),
+		Status:      "active",
+	}
+	if status := strVal(input["status"]); status != "" {
+		dt.Status = status
+	}
+	fa.deviceTypes[dt.ID] = dt
+	writeGQLData(fa.t, w, map[string]any{"createProfile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleGetDeviceType(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	dt, ok := fa.deviceTypes[id]
+	if !ok {
+		writeGQLError(fa.t, w, "device type not found")
+		return
+	}
+	writeGQLData(fa.t, w, map[string]any{"profile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleListDeviceTypes(w http.ResponseWriter, req gqlRequest) {
+	tenantID := strVal(req.Variables["tenantId"])
+	status := strVal(req.Variables["status"])
+
+	items := []map[string]any{}
+	for _, dt := range fa.deviceTypes {
+		if tenantID != "" && dt.TenantID != tenantID {
+			continue
+		}
+		if status != "" && dt.Status != status {
+			continue
+		}
+		items = append(items, deviceTypeJSON(dt))
+	}
+	writeGQLData(fa.t, w, map[string]any{"profiles": map[string]any{"items": items, "total": len(items)}})
+}
+
+func (fa *fakeAtom) handleUpdateDeviceType(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	dt, ok := fa.deviceTypes[id]
+	if !ok {
+		writeGQLError(fa.t, w, "device type not found")
+		return
+	}
+	input, _ := req.Variables["input"].(map[string]any)
+	if name := strVal(input["displayName"]); name != "" {
+		dt.Name = name
+	}
+	if description := strVal(input["description"]); description != "" {
+		dt.Description = description
+	}
+	if status := strVal(input["status"]); status != "" {
+		dt.Status = status
+	}
+	fa.deviceTypes[id] = dt
+	writeGQLData(fa.t, w, map[string]any{"updateProfile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleCreateDeviceTypeVersion(w http.ResponseWriter, req gqlRequest) {
+	deviceTypeID := strVal(req.Variables["profileId"])
+	input, _ := req.Variables["input"].(map[string]any)
+	fa.versionSeq++
+
+	version := atom.DeviceTypeVersion{
+		ID:           fmt.Sprintf("device-type-version-%d", fa.versionSeq),
+		DeviceTypeID: deviceTypeID,
+		Version:      intVal(input["version"]),
+		Status:       "active",
+		JSONSchema:   mapVal(input["jsonSchema"]),
+		UISchema:     mapVal(input["uiSchema"]),
+	}
+	if status := strVal(input["status"]); status != "" {
+		version.Status = status
+	}
+	fa.typeVersions[deviceTypeID] = append(fa.typeVersions[deviceTypeID], version)
+	writeGQLData(fa.t, w, map[string]any{"createProfileVersion": deviceTypeVersionJSON(version)})
+}
+
+func (fa *fakeAtom) handleListDeviceTypeVersions(w http.ResponseWriter, req gqlRequest) {
+	deviceTypeID := strVal(req.Variables["profileId"])
+	items := []map[string]any{}
+	for _, version := range fa.typeVersions[deviceTypeID] {
+		items = append(items, deviceTypeVersionJSON(version))
+	}
+	writeGQLData(fa.t, w, map[string]any{"profileVersions": items})
+}
+
+func deviceTypeJSON(dt atom.DeviceType) map[string]any {
+	return map[string]any{
+		"id":          dt.ID,
+		"tenant_id":   dt.TenantID,
+		"key":         dt.Key,
+		"name":        dt.Name,
+		"description": dt.Description,
+		"status":      dt.Status,
+	}
+}
+
+func deviceTypeVersionJSON(v atom.DeviceTypeVersion) map[string]any {
+	return map[string]any{
+		"id":             v.ID,
+		"device_type_id": v.DeviceTypeID,
+		"version":        v.Version,
+		"json_schema":    v.JSONSchema,
+		"ui_schema":      v.UISchema,
+		"status":         v.Status,
+	}
+}
+
+func intVal(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}
+
+func mapVal(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
 }
 
 func (fa *fakeAtom) handleCreate(w http.ResponseWriter, req gqlRequest) {
@@ -98,6 +278,12 @@ func (fa *fakeAtom) handleCreate(w http.ResponseWriter, req gqlRequest) {
 }
 
 func (fa *fakeAtom) handleUpdate(w http.ResponseWriter, req gqlRequest) {
+	if message := fa.updateEntityGQLErr; message != "" {
+		fa.updateEntityGQLErr = ""
+		writeGQLError(fa.t, w, message)
+		return
+	}
+
 	id, _ := req.Variables["id"].(string)
 	e, ok := fa.entities[id]
 	if !ok {
@@ -110,6 +296,12 @@ func (fa *fakeAtom) handleUpdate(w http.ResponseWriter, req gqlRequest) {
 	}
 	if status := strVal(input["status"]); status != "" {
 		e.Status = status
+	}
+	if profileID := strVal(input["profileId"]); profileID != "" {
+		e.DeviceTypeID = profileID
+	}
+	if versionID := strVal(input["profileVersionId"]); versionID != "" {
+		e.DeviceTypeVersionID = versionID
 	}
 	if attrs, ok := input["attributes"].(map[string]any); ok {
 		e.Attributes = atom.Attributes(attrs)
@@ -185,12 +377,14 @@ func entityJSON(e atom.Entity) map[string]any {
 		attrs = map[string]any{}
 	}
 	return map[string]any{
-		"id":         e.ID,
-		"kind":       e.Kind,
-		"name":       e.Name,
-		"tenant_id":  e.TenantID,
-		"status":     e.Status,
-		"attributes": attrs,
+		"id":                     e.ID,
+		"kind":                   e.Kind,
+		"name":                   e.Name,
+		"tenant_id":              e.TenantID,
+		"device_type_id":         e.DeviceTypeID,
+		"device_type_version_id": e.DeviceTypeVersionID,
+		"status":                 e.Status,
+		"attributes":             attrs,
 	}
 }
 

--- a/cli/devicetypes.go
+++ b/cli/devicetypes.go
@@ -1,0 +1,313 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/spf13/cobra"
+)
+
+// Operations unique to device types. The shared ones (create, get, update,
+// all) come from channels.go's block.
+const (
+	deviceTypeVersions      = "versions"
+	deviceTypeCreateVersion = "create-version"
+	deviceTypeActiveVersion = "active-version"
+	deviceTypeBind          = "bind"
+)
+
+const (
+	usageDeviceTypeCreate        = "cli devicetypes create <JSON_device_type> <domain_id>"
+	usageDeviceTypeGet           = "cli devicetypes <device_type_id|all> get <domain_id>"
+	usageDeviceTypeUpdate        = "cli devicetypes <device_type_id> update <JSON_string>"
+	usageDeviceTypeVersions      = "cli devicetypes <device_type_id> versions"
+	usageDeviceTypeCreateVersion = "cli devicetypes <device_type_id> create-version <JSON_version>"
+	usageDeviceTypeActiveVersion = "cli devicetypes <device_type_id> active-version"
+	usageDeviceTypeBind          = "cli devicetypes <device_type_id> bind <device_id> [version_id]"
+)
+
+// NewDeviceTypesCmd wraps pkg/atom's device type API. There is deliberately no
+// delete operation: Atom has no deleteProfile mutation, so a device type is
+// retired by setting its status, not removed.
+func NewDeviceTypesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "devicetypes <device_type_id|all|create> [operation] [args...]",
+		Short: "Device types management",
+		Long: `Format:
+  devicetypes create <JSON_device_type> <domain_id>
+  devicetypes <device_type_id|all> <operation> [args...]
+
+Operations (require device_type_id/all): get, update, versions, create-version,
+active-version, bind
+
+Listing is always domain-scoped. Atom's device type filter is "this tenant" or
+"no filter at all", and no filter at all crosses tenants, so "all get" takes a
+domain_id.
+
+There is no delete: status carries retirement instead, and its three values
+(active, deprecated, disabled) do not reduce to an enable/disable pair, so it
+is set through update:
+  devicetypes <device_type_id> update '{"status":"deprecated"}'
+
+A version is immutable once created and its status is fixed at creation —
+create it with "status":"draft" to stage one without making it bindable.
+
+"bind" is the checked way to attach a device to a type: it refuses a type or
+version that is not active, which writing device_type_id through
+"devices <device_id> update" does not.
+
+Examples:
+  devicetypes create '{"key":"thermostat","name":"Thermostat"}' <domain_id>
+  devicetypes all get <domain_id>
+  devicetypes <device_type_id> get
+  devicetypes <device_type_id> update '{"name":"Thermostat","status":"deprecated"}'
+  devicetypes <device_type_id> versions
+  devicetypes <device_type_id> create-version '{"capabilities":{"measurements":[{"name":"temperature","type":"number","unit":"Cel"}]}}'
+  devicetypes <device_type_id> active-version
+  devicetypes <device_type_id> bind <device_id> <version_id>`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+
+			if args[0] == create {
+				handleDeviceTypeCreate(cmd, args[1:])
+				return
+			}
+
+			if len(args) < 2 {
+				logUsageCmd(*cmd, "devicetypes <device_type_id|all> <get|update|versions|create-version|active-version|bind> [args...]")
+				return
+			}
+
+			deviceTypeID := args[0]
+			operation := args[1]
+			opArgs := args[2:]
+
+			switch operation {
+			case get:
+				handleDeviceTypeGet(cmd, deviceTypeID, opArgs)
+			case update:
+				handleDeviceTypeUpdate(cmd, deviceTypeID, opArgs)
+			case deviceTypeVersions:
+				handleDeviceTypeVersions(cmd, deviceTypeID, opArgs)
+			case deviceTypeCreateVersion:
+				handleDeviceTypeCreateVersion(cmd, deviceTypeID, opArgs)
+			case deviceTypeActiveVersion:
+				handleDeviceTypeActiveVersion(cmd, deviceTypeID, opArgs)
+			case deviceTypeBind:
+				handleDeviceTypeBind(cmd, deviceTypeID, opArgs)
+			default:
+				logErrorCmd(*cmd, fmt.Errorf("unknown operation: %s", operation))
+			}
+		},
+	}
+
+	return cmd
+}
+
+func handleDeviceTypeCreate(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		logUsageCmd(*cmd, usageDeviceTypeCreate)
+		return
+	}
+
+	var deviceType atom.DeviceType
+	if err := json.Unmarshal([]byte(args[0]), &deviceType); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+	deviceType.TenantID = args[1]
+
+	created, err := atomClient.CreateDeviceType(cmd.Context(), deviceType)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleDeviceTypeGet's "all" branch needs the domain argument that a single
+// lookup does not: ListDeviceTypes refuses a tenant-less listing, since Atom
+// would answer it with every tenant's types.
+func handleDeviceTypeGet(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if deviceTypeID == all {
+		if len(args) != 1 || args[0] == "" {
+			logUsageCmd(*cmd, usageDeviceTypeGet)
+			return
+		}
+
+		q := atom.DeviceTypeQuery{
+			TenantID: args[0],
+			Status:   Status,
+			Limit:    Limit,
+			Offset:   Offset,
+		}
+		l, err := atomClient.ListDeviceTypes(cmd.Context(), q)
+		if err != nil {
+			logErrorCmd(*cmd, err)
+			return
+		}
+
+		logJSONCmd(*cmd, l)
+		return
+	}
+
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeGet)
+		return
+	}
+
+	dt, err := atomClient.GetDeviceType(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, dt)
+}
+
+func handleDeviceTypeUpdate(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageDeviceTypeUpdate)
+		return
+	}
+
+	var deviceType atom.DeviceType
+	if err := json.Unmarshal([]byte(args[0]), &deviceType); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	updated, err := atomClient.UpdateDeviceType(cmd.Context(), deviceTypeID, deviceType)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, updated)
+}
+
+func handleDeviceTypeVersions(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeVersions)
+		return
+	}
+
+	l, err := atomClient.ListDeviceTypeVersions(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, l)
+}
+
+// handleDeviceTypeCreateVersion takes a whole version rather than a bare
+// capability document so the CLI can also stage a draft and pin a version
+// number — both are fixed at creation, with no mutation to change them after.
+func handleDeviceTypeCreateVersion(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageDeviceTypeCreateVersion)
+		return
+	}
+
+	var version atom.DeviceTypeVersion
+	if err := json.Unmarshal([]byte(args[0]), &version); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	created, err := atomClient.CreateDeviceTypeVersion(cmd.Context(), deviceTypeID, version)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleDeviceTypeActiveVersion reports the version a bind picks when none is
+// named, which is otherwise only visible by reading the whole version list.
+func handleDeviceTypeActiveVersion(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeActiveVersion)
+		return
+	}
+
+	version, err := atomClient.ActiveDeviceTypeVersion(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, version)
+}
+
+// handleDeviceTypeBind lives here rather than under "devices" because binding
+// is a device type act — pkg/atom keeps BindDeviceType in device_types.go for
+// the same reason, and the type and version status checks it performs are what
+// separate it from an ordinary device update.
+func handleDeviceTypeBind(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) < 1 || len(args) > 2 {
+		logUsageCmd(*cmd, usageDeviceTypeBind)
+		return
+	}
+
+	versionID := ""
+	if len(args) == 2 {
+		versionID = args[1]
+	}
+
+	device, err := atomClient.BindDeviceType(cmd.Context(), args[0], deviceTypeID, versionID)
+	if err != nil {
+		logDeviceTypeErrorCmd(cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, device)
+}
+
+// logDeviceTypeErrorCmd prints err, expanding a device type schema rejection
+// into one line per violation. SchemaValidationError's own message lists
+// "field: message" pairs but drops the constraint and the expected value,
+// which is the part that says what to write instead.
+//
+// Only bind can raise one: it writes the device through UpdateEntity, and Atom
+// validates the attributes already on the device — against the version bound
+// before this call, not the one being bound.
+func logDeviceTypeErrorCmd(cmd *cobra.Command, err error) {
+	schemaErr, ok := atom.AsSchemaValidationError(err)
+	if !ok {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("attributes rejected by the device type schema:")
+	for _, violation := range schemaErr.Violations {
+		field := violation.Field
+		if field == "" {
+			field = "<unidentified field>"
+		}
+		b.WriteString("\n  " + field)
+		if violation.Constraint != "" {
+			b.WriteString(" (" + violation.Constraint + ")")
+		}
+		b.WriteString(": " + violation.Message)
+		if violation.Expected != "" {
+			b.WriteString("; expected " + violation.Expected)
+		}
+	}
+
+	logErrorCmd(*cmd, errors.New(b.String()))
+}

--- a/cli/devicetypes_test.go
+++ b/cli/devicetypes_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceTypesCreateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	deviceTypeJSON := `{"key":"thermostat","name":"Thermostat","description":"wall unit"}`
+	out := executeCommand(t, rootCmd, createCmd, deviceTypeJSON, "domain-1")
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "thermostat", got.Key)
+	assert.Equal(t, "Thermostat", got.Name)
+	assert.Equal(t, "domain-1", got.TenantID)
+
+	// Atom stores device types as Profiles narrowed by object_kind/kind; a
+	// type created without that narrowing would not come back from a listing.
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "entity", input["objectKind"])
+	assert.Equal(t, "device", input["kind"])
+	assert.Equal(t, "domain-1", input["tenantId"])
+}
+
+func TestDeviceTypesGetCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Name: "Thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", getCmd)
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device-type-1", got.ID)
+	assert.Equal(t, "thermostat", got.Key)
+}
+
+func TestDeviceTypesGetAllCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(
+		atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"},
+		atom.DeviceType{ID: "device-type-2", TenantID: "domain-1", Key: "valve", Status: "active"},
+		atom.DeviceType{ID: "device-type-3", TenantID: "domain-2", Key: "meter", Status: "active"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd, "domain-1")
+
+	var got atom.DeviceTypeList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+}
+
+// TestDeviceTypesGetAllRequiresDomain pins the trap: Atom answers a
+// tenant-less device type listing with every tenant's types, so the CLI must
+// refuse rather than pass the query through.
+func TestDeviceTypesGetAllRequiresDomain(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd)
+
+	assert.Contains(t, out, "usage")
+	assert.Empty(t, fa.requests, "no listing may reach Atom without a domain")
+}
+
+func TestDeviceTypesUpdateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Name: "Thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", updateCmd, `{"name":"Thermostat mk2","status":"deprecated"}`)
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "Thermostat mk2", got.Name)
+	// Retirement runs through update: Atom has no delete for device types.
+	assert.Equal(t, "deprecated", got.Status)
+}
+
+func TestDeviceTypesCreateVersionCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	capabilities := `{"capabilities":{"measurements":[{"name":"temperature","type":"number","unit":"Cel","access":"rw","required":true}],"commands":[{"name":"reboot"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, capabilities)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, 1, got.Version, "first version numbers itself")
+	assert.Equal(t, "active", got.Status)
+
+	// The capability document round-trips through the stored schemas.
+	require.Len(t, got.Capabilities.Measurements, 1)
+	assert.Equal(t, "temperature", got.Capabilities.Measurements[0].Name)
+	assert.Equal(t, "Cel", got.Capabilities.Measurements[0].Unit)
+	require.Len(t, got.Capabilities.Commands, 1)
+	assert.Equal(t, "reboot", got.Capabilities.Commands[0].Name)
+
+	properties, _ := got.JSONSchema["properties"].(map[string]any)
+	assert.Contains(t, properties, "temperature")
+}
+
+// TestDeviceTypesCreateVersionDraftCmd covers the reason the argument is a
+// whole version rather than a bare capability document: a version's status is
+// fixed at creation, so staging a draft is only possible here.
+func TestDeviceTypesCreateVersionDraftCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	body := `{"status":"draft","capabilities":{"measurements":[{"name":"humidity","type":"number"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, body)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "draft", got.Status)
+}
+
+func TestDeviceTypesCreateVersionRejectsBadCapabilityCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	body := `{"capabilities":{"measurements":[{"name":"temperature","type":"tesseract"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, body)
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "unsupported value type")
+	assert.Empty(t, fa.requests, "an unrenderable capability document never reaches Atom")
+}
+
+func TestDeviceTypesVersionsCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(
+		atom.DeviceTypeVersion{ID: "version-2", DeviceTypeID: "device-type-1", Version: 2, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "deprecated"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", versionsCmd)
+
+	var got []atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, 1, got[0].Version, "versions come back oldest first")
+	assert.Equal(t, 2, got[1].Version)
+}
+
+func TestDeviceTypesActiveVersionCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(
+		atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-2", DeviceTypeID: "device-type-1", Version: 2, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-3", DeviceTypeID: "device-type-1", Version: 3, Status: "draft"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", activeVersionCmd)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	// The draft is higher-numbered but not bindable.
+	assert.Equal(t, "version-2", got.ID)
+}
+
+func TestDeviceTypesBindCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1", "version-1")
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device-type-1", got.DeviceTypeID)
+	assert.Equal(t, "version-1", got.DeviceTypeVersionID)
+}
+
+// TestDeviceTypesBindRejectsDeprecatedVersion pins what bind buys over an
+// ordinary device update: Atom binds a caller-named version whatever its
+// status, so deprecating one would not stop new bindings without this check.
+func TestDeviceTypesBindRejectsDeprecatedVersion(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "deprecated"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1", "version-1")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "version is not active")
+
+	device := fa.entities["device-1"]
+	assert.Empty(t, device.DeviceTypeID, "a refused bind must not write the device")
+}
+
+func TestDeviceTypesBindRejectsDeprecatedType(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "deprecated"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "device type is not active")
+}
+
+// TestDeviceTypesBindSurfacesSchemaViolations checks that a schema rejection
+// reaches the operator with the field and the constraint intact, rather than
+// as the validator's raw sentence.
+func TestDeviceTypesBindSurfacesSchemaViolations(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.failEntityUpdate("attributes failed profile schema validation: 'temperature' is a required property; Additional properties are not allowed ('colour' was unexpected)")
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1")
+
+	assert.Contains(t, out, "rejected by the device type schema")
+	assert.Contains(t, out, "temperature (required)")
+	assert.Contains(t, out, "colour (additionalProperties)")
+}
+
+func TestDeviceTypesCmdUsageOnMissingArgs(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd)
+
+	assert.Contains(t, out, "usage")
+}
+
+func TestDeviceTypesCmdUnknownOperation(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", deleteCmd)
+
+	assert.Contains(t, out, "unknown operation: delete")
+}

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -16,13 +16,17 @@ import (
 // get, update, delete, enable, disable) — can't reference those directly
 // from this external test package.
 const (
-	createCmd  = "create"
-	getCmd     = "get"
-	updateCmd  = "update"
-	deleteCmd  = "delete"
-	enableCmd  = "enable"
-	disableCmd = "disable"
-	allCmd     = "all"
+	createCmd        = "create"
+	getCmd           = "get"
+	updateCmd        = "update"
+	deleteCmd        = "delete"
+	enableCmd        = "enable"
+	disableCmd       = "disable"
+	allCmd           = "all"
+	versionsCmd      = "versions"
+	createVersionCmd = "create-version"
+	activeVersionCmd = "active-version"
+	bindCmd          = "bind"
 )
 
 func executeCommand(t *testing.T, root *cobra.Command, args ...string) string {

--- a/docker/permission.yaml
+++ b/docker/permission.yaml
@@ -32,6 +32,22 @@ devices:
     - remove_members: remove_role_users_permission
     - remove_all_members: remove_role_users_permission
 
+# Device types carry no delete: Atom has no deleteProfile mutation, so a type
+# is retired by setting its status through update, never removed. Versions are
+# immutable once created, so creating one is the only version write — and it
+# gets its own permission because publishing a version changes what every
+# future device of the type validates against, which is a larger act than
+# renaming the type. No roles_operations: device types have no role surface,
+# matching the alarm block.
+device_types:
+  operations:
+    - create: create_permission
+    - view: read_permission
+    - list: read_permission
+    - update: update_permission
+    - create_version: create_version_permission
+    - list_versions: read_permission
+
 channels:
   operations:
     - view: read_permission

--- a/pkg/atom/capability.go
+++ b/pkg/atom/capability.go
@@ -1,0 +1,358 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// capabilityDeclarationKey is where BuildCapabilitySchema stores the capability
+// document verbatim. It lives in ui_schema rather than json_schema because Atom
+// compiles json_schema with a JSON Schema validator on every entity write,
+// while ui_schema is never compiled — so the declaration cannot affect what
+// Atom accepts, whatever it contains.
+const capabilityDeclarationKey = "x-magistrala-device-type"
+
+// capabilityOrderKey records declaration order, which json_schema's properties
+// object cannot preserve.
+const capabilityOrderKey = "ui:order"
+
+// Value types a measurement or command parameter may take. These are the JSON
+// Schema names; normalizeValueType also accepts the shorthand a declaration is
+// likely to be written with.
+const (
+	ValueTypeNumber  = "number"
+	ValueTypeInteger = "integer"
+	ValueTypeString  = "string"
+	ValueTypeBoolean = "boolean"
+)
+
+// Measurement access. Access is advisory: it is rendered as JSON Schema's
+// readOnly annotation, which validators record but do not enforce.
+const (
+	MeasurementAccessRead      = "r"
+	MeasurementAccessReadWrite = "rw"
+)
+
+// BuildCapabilitySchema renders a capability document to the json_schema and
+// ui_schema a device type version stores.
+//
+// json_schema constrains a device's *attributes*, which is what Atom validates
+// on entity write. It does not constrain telemetry — messages never reach Atom.
+//
+// additionalProperties is deliberately left open. A Magistrala device carries
+// housekeeping attributes no device type declares (source, tags, metadata,
+// gateways, timestamps — see EntityFromFields), so closing the schema would
+// reject every device write.
+func BuildCapabilitySchema(doc CapabilityDocument) (jsonSchema, uiSchema map[string]any, err error) {
+	normalized, err := normalizeCapabilityDocument(doc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	properties := make(map[string]any, len(normalized.Measurements))
+	required := make([]string, 0, len(normalized.Measurements))
+	order := make([]string, 0, len(normalized.Measurements))
+
+	for _, measurement := range normalized.Measurements {
+		property := map[string]any{"type": measurement.Type}
+		if measurement.Unit != "" {
+			property["unit"] = measurement.Unit
+		}
+		if measurement.Access == MeasurementAccessRead {
+			property["readOnly"] = true
+		}
+		if measurement.Min != nil {
+			property["minimum"] = *measurement.Min
+		}
+		if measurement.Max != nil {
+			property["maximum"] = *measurement.Max
+		}
+		if len(measurement.Enum) > 0 {
+			options := make([]any, len(measurement.Enum))
+			for i, option := range measurement.Enum {
+				options[i] = option
+			}
+			property["enum"] = options
+		}
+		properties[measurement.Name] = property
+		order = append(order, measurement.Name)
+		if measurement.Required {
+			required = append(required, measurement.Name)
+		}
+	}
+
+	jsonSchema = map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		jsonSchema["required"] = required
+	}
+
+	declaration, err := jsonValue(normalized)
+	if err != nil {
+		return nil, nil, err
+	}
+	uiSchema = map[string]any{capabilityDeclarationKey: declaration}
+	if len(order) > 0 {
+		uiSchema[capabilityOrderKey] = order
+	}
+
+	return jsonSchema, uiSchema, nil
+}
+
+// ParseCapabilityDocument reads a capability document back out of a stored
+// device type version, so callers never hand-parse JSON Schema.
+//
+// It prefers the declaration BuildCapabilitySchema stashed in ui_schema, which
+// round-trips exactly. Failing that — a version whose schema was written by
+// hand — it reconstructs what it can from json_schema's properties. That
+// fallback recovers measurements only: commands have no json_schema
+// representation, since a command is not device state.
+func ParseCapabilityDocument(jsonSchema, uiSchema map[string]any) (CapabilityDocument, error) {
+	if declaration, ok := uiSchema[capabilityDeclarationKey]; ok {
+		raw, err := json.Marshal(declaration)
+		if err != nil {
+			return CapabilityDocument{}, fmt.Errorf("atom: encode device type declaration: %w", err)
+		}
+		var doc CapabilityDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return CapabilityDocument{}, fmt.Errorf("atom: decode device type declaration: %w", err)
+		}
+		return normalizeCapabilityDocument(doc)
+	}
+	return capabilityDocumentFromSchema(jsonSchema)
+}
+
+// capabilityDocumentFromSchema reconstructs measurements from a hand-written
+// json_schema. Properties whose type the capability model cannot express
+// (objects, arrays, unions) are skipped rather than failing the whole read —
+// an advanced schema stays usable, it just does not round-trip in full.
+func capabilityDocumentFromSchema(jsonSchema map[string]any) (CapabilityDocument, error) {
+	properties, _ := jsonSchema["properties"].(map[string]any)
+	if len(properties) == 0 {
+		return CapabilityDocument{}, nil
+	}
+
+	required := map[string]bool{}
+	for _, name := range jsonSlice(jsonSchema["required"]) {
+		if name, ok := name.(string); ok {
+			required[name] = true
+		}
+	}
+
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var doc CapabilityDocument
+	for _, name := range names {
+		property, ok := properties[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		declared, _ := property["type"].(string)
+		valueType, err := normalizeValueType(declared)
+		if err != nil {
+			continue
+		}
+
+		measurement := Measurement{
+			Name:     name,
+			Type:     valueType,
+			Access:   MeasurementAccessReadWrite,
+			Required: required[name],
+		}
+		if unit, ok := property["unit"].(string); ok {
+			measurement.Unit = unit
+		}
+		if readOnly, ok := property["readOnly"].(bool); ok && readOnly {
+			measurement.Access = MeasurementAccessRead
+		}
+		if min, ok := floatValue(property["minimum"]); ok {
+			measurement.Min = &min
+		}
+		if max, ok := floatValue(property["maximum"]); ok {
+			measurement.Max = &max
+		}
+		for _, option := range jsonSlice(property["enum"]) {
+			if option, ok := option.(string); ok {
+				measurement.Enum = append(measurement.Enum, option)
+			}
+		}
+		doc.Measurements = append(doc.Measurements, measurement)
+	}
+
+	return normalizeCapabilityDocument(doc)
+}
+
+// normalizeCapabilityDocument fills in defaults and rejects declarations that
+// cannot render to a schema. It is idempotent, so a document survives any
+// number of build/parse cycles unchanged.
+func normalizeCapabilityDocument(doc CapabilityDocument) (CapabilityDocument, error) {
+	var out CapabilityDocument
+
+	seen := make(map[string]struct{}, len(doc.Measurements))
+	for _, measurement := range doc.Measurements {
+		name := strings.TrimSpace(measurement.Name)
+		if name == "" {
+			return CapabilityDocument{}, errors.New("atom: device type measurement has no name")
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return CapabilityDocument{}, fmt.Errorf("atom: duplicate device type measurement %q", name)
+		}
+		seen[name] = struct{}{}
+
+		declared := strings.TrimSpace(measurement.Type)
+		if declared == "" {
+			declared = ValueTypeNumber
+		}
+		valueType, err := normalizeValueType(declared)
+		if err != nil {
+			return CapabilityDocument{}, fmt.Errorf("atom: measurement %q: %w", name, err)
+		}
+		access, err := normalizeAccess(measurement.Access)
+		if err != nil {
+			return CapabilityDocument{}, fmt.Errorf("atom: measurement %q: %w", name, err)
+		}
+		if measurement.Min != nil && measurement.Max != nil && *measurement.Min > *measurement.Max {
+			return CapabilityDocument{}, fmt.Errorf("atom: measurement %q has min above max", name)
+		}
+
+		out.Measurements = append(out.Measurements, Measurement{
+			Name:     name,
+			Unit:     strings.TrimSpace(measurement.Unit),
+			Access:   access,
+			Type:     valueType,
+			Required: measurement.Required,
+			Min:      copyFloat(measurement.Min),
+			Max:      copyFloat(measurement.Max),
+			Enum:     cloneStrings(measurement.Enum),
+		})
+	}
+
+	seen = make(map[string]struct{}, len(doc.Commands))
+	for _, command := range doc.Commands {
+		name := strings.TrimSpace(command.Name)
+		if name == "" {
+			return CapabilityDocument{}, errors.New("atom: device type command has no name")
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return CapabilityDocument{}, fmt.Errorf("atom: duplicate device type command %q", name)
+		}
+		seen[name] = struct{}{}
+
+		var params map[string]string
+		if len(command.Params) > 0 {
+			params = make(map[string]string, len(command.Params))
+			for param, declared := range command.Params {
+				param = strings.TrimSpace(param)
+				if param == "" {
+					return CapabilityDocument{}, fmt.Errorf("atom: command %q has an unnamed parameter", name)
+				}
+				valueType, err := normalizeValueType(declared)
+				if err != nil {
+					return CapabilityDocument{}, fmt.Errorf("atom: command %q parameter %q: %w", name, param, err)
+				}
+				params[param] = valueType
+			}
+		}
+
+		out.Commands = append(out.Commands, Command{
+			Name:        name,
+			Description: strings.TrimSpace(command.Description),
+			Params:      params,
+		})
+	}
+
+	return out, nil
+}
+
+func normalizeValueType(valueType string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(valueType)) {
+	case ValueTypeNumber, "float", "double":
+		return ValueTypeNumber, nil
+	case ValueTypeInteger, "int":
+		return ValueTypeInteger, nil
+	case ValueTypeString, "text":
+		return ValueTypeString, nil
+	case ValueTypeBoolean, "bool":
+		return ValueTypeBoolean, nil
+	default:
+		return "", fmt.Errorf("unsupported value type %q", valueType)
+	}
+}
+
+func normalizeAccess(access string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(access)) {
+	case "", MeasurementAccessRead:
+		return MeasurementAccessRead, nil
+	case MeasurementAccessReadWrite:
+		return MeasurementAccessReadWrite, nil
+	default:
+		return "", fmt.Errorf("unsupported access %q, want %q or %q", access, MeasurementAccessRead, MeasurementAccessReadWrite)
+	}
+}
+
+// jsonValue converts a value to the plain map/slice/scalar form it will have
+// after a round trip through Atom, so what is stored matches what is read back.
+func jsonValue(v any) (map[string]any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("atom: encode device type declaration: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("atom: decode device type declaration: %w", err)
+	}
+	return out, nil
+}
+
+func jsonSlice(v any) []any {
+	switch v := v.(type) {
+	case []any:
+		return v
+	case []string:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = item
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func floatValue(v any) (float64, bool) {
+	switch v := v.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func copyFloat(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	out := *v
+	return &out
+}

--- a/pkg/atom/capability.go
+++ b/pkg/atom/capability.go
@@ -226,6 +226,9 @@ func normalizeCapabilityDocument(doc CapabilityDocument) (CapabilityDocument, er
 		if measurement.Min != nil && measurement.Max != nil && *measurement.Min > *measurement.Max {
 			return CapabilityDocument{}, fmt.Errorf("atom: measurement %q has min above max", name)
 		}
+		if len(measurement.Enum) > 0 && valueType != ValueTypeString {
+			return CapabilityDocument{}, fmt.Errorf("atom: measurement %q has enum but type %q, want %q", name, valueType, ValueTypeString)
+		}
 
 		out.Measurements = append(out.Measurements, Measurement{
 			Name:     name,

--- a/pkg/atom/capability_test.go
+++ b/pkg/atom/capability_test.go
@@ -1,0 +1,362 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func floatPtr(v float64) *float64 { return &v }
+
+// storedRoundTrip mimics what a schema goes through on the way to Atom and
+// back: marshalled to JSON, stored as JSONB, decoded into map[string]any. A
+// declaration that only survives in memory would still be broken in practice.
+func storedRoundTrip(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	if schema == nil {
+		return nil
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	return out
+}
+
+func buildAndParse(t *testing.T, doc CapabilityDocument) CapabilityDocument {
+	t.Helper()
+	jsonSchema, uiSchema, err := BuildCapabilitySchema(doc)
+	if err != nil {
+		t.Fatalf("build capability schema: %v", err)
+	}
+	parsed, err := ParseCapabilityDocument(storedRoundTrip(t, jsonSchema), storedRoundTrip(t, uiSchema))
+	if err != nil {
+		t.Fatalf("parse capability document: %v", err)
+	}
+	return parsed
+}
+
+func TestCapabilityDocumentRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  CapabilityDocument
+		want CapabilityDocument
+	}{
+		{
+			name: "watermeter",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "volume", Unit: "m3", Access: MeasurementAccessRead, Required: true},
+					{Name: "battery", Unit: "%", Access: MeasurementAccessRead, Min: floatPtr(0), Max: floatPtr(100)},
+				},
+				Commands: []Command{
+					{Name: "set_interval", Params: map[string]string{"seconds": "int"}},
+				},
+			},
+			want: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "volume", Unit: "m3", Access: MeasurementAccessRead, Type: ValueTypeNumber, Required: true},
+					{Name: "battery", Unit: "%", Access: MeasurementAccessRead, Type: ValueTypeNumber, Min: floatPtr(0), Max: floatPtr(100)},
+				},
+				Commands: []Command{
+					{Name: "set_interval", Params: map[string]string{"seconds": ValueTypeInteger}},
+				},
+			},
+		},
+		{
+			name: "no commands",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{{Name: "temperature", Unit: "Cel"}},
+			},
+			want: CapabilityDocument{
+				Measurements: []Measurement{{Name: "temperature", Unit: "Cel", Access: MeasurementAccessRead, Type: ValueTypeNumber}},
+			},
+		},
+		{
+			name: "no units",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{{Name: "pulse_count", Type: "int"}},
+			},
+			want: CapabilityDocument{
+				Measurements: []Measurement{{Name: "pulse_count", Access: MeasurementAccessRead, Type: ValueTypeInteger}},
+			},
+		},
+		{
+			name: "rw access",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "setpoint", Unit: "Cel", Access: MeasurementAccessReadWrite, Min: floatPtr(5), Max: floatPtr(30)},
+				},
+			},
+			want: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "setpoint", Unit: "Cel", Access: MeasurementAccessReadWrite, Type: ValueTypeNumber, Min: floatPtr(5), Max: floatPtr(30)},
+				},
+			},
+		},
+		{
+			name: "commands without params",
+			doc: CapabilityDocument{
+				Commands: []Command{{Name: "reboot", Description: "power cycle the modem"}},
+			},
+			want: CapabilityDocument{
+				Commands: []Command{{Name: "reboot", Description: "power cycle the modem"}},
+			},
+		},
+		{
+			name: "empty declaration",
+			doc:  CapabilityDocument{},
+			want: CapabilityDocument{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildAndParse(t, tc.doc)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("round trip changed the declaration:\n got: %+v\nwant: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The capability model is easy to freeze around the watermeter example alone.
+// These are the shapes the PRD calls out as likely to break it.
+func TestCapabilityDocumentRoundTripsRealisticDeviceTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  CapabilityDocument
+	}{
+		{
+			name: "multi-channel energy meter",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "l1_voltage", Unit: "V", Type: ValueTypeNumber},
+					{Name: "l2_voltage", Unit: "V", Type: ValueTypeNumber},
+					{Name: "l3_voltage", Unit: "V", Type: ValueTypeNumber},
+					{Name: "total_energy", Unit: "kWh", Type: ValueTypeNumber, Required: true},
+				},
+				Commands: []Command{{Name: "reset_counters"}},
+			},
+		},
+		{
+			name: "smart valve with enumerated state",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "position", Type: ValueTypeString, Access: MeasurementAccessReadWrite, Enum: []string{"open", "closed", "partial"}, Required: true},
+					{Name: "opening", Unit: "%", Min: floatPtr(0), Max: floatPtr(100), Access: MeasurementAccessReadWrite},
+				},
+				Commands: []Command{
+					{Name: "set_position", Params: map[string]string{"position": "string", "ramp_seconds": "int"}},
+				},
+			},
+		},
+		{
+			name: "lorawan concentrator that also meters",
+			doc: CapabilityDocument{
+				Measurements: []Measurement{
+					{Name: "uplink_count", Type: ValueTypeInteger},
+					{Name: "radio_enabled", Type: ValueTypeBoolean, Access: MeasurementAccessReadWrite},
+					{Name: "firmware", Type: ValueTypeString},
+					{Name: "volume", Unit: "m3"},
+				},
+				Commands: []Command{
+					{Name: "restart_radio"},
+					{Name: "set_region", Params: map[string]string{"region": "string"}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first := buildAndParse(t, tc.doc)
+			// Normalization must be idempotent, or a device type would drift
+			// every time it is read and written back.
+			second := buildAndParse(t, first)
+			if !reflect.DeepEqual(first, second) {
+				t.Fatalf("re-rendering a parsed declaration changed it:\nfirst: %+v\nsecond: %+v", first, second)
+			}
+			if len(first.Measurements) != len(tc.doc.Measurements) {
+				t.Fatalf("expected %d measurements, got %d", len(tc.doc.Measurements), len(first.Measurements))
+			}
+			if len(first.Commands) != len(tc.doc.Commands) {
+				t.Fatalf("expected %d commands, got %d", len(tc.doc.Commands), len(first.Commands))
+			}
+		})
+	}
+}
+
+func TestBuildCapabilitySchemaRendersConstraints(t *testing.T) {
+	jsonSchema, _, err := BuildCapabilitySchema(CapabilityDocument{
+		Measurements: []Measurement{
+			{Name: "volume", Unit: "m3", Required: true},
+			{Name: "interval", Type: "int", Access: MeasurementAccessReadWrite, Min: floatPtr(30), Max: floatPtr(86400)},
+			{Name: "mode", Type: ValueTypeString, Enum: []string{"normal", "burst"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build capability schema: %v", err)
+	}
+
+	properties, ok := jsonSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties object, got %T", jsonSchema["properties"])
+	}
+
+	volume, _ := properties["volume"].(map[string]any)
+	if volume["type"] != ValueTypeNumber || volume["unit"] != "m3" || volume["readOnly"] != true {
+		t.Fatalf("unexpected volume property: %+v", volume)
+	}
+
+	interval, _ := properties["interval"].(map[string]any)
+	if interval["type"] != ValueTypeInteger || interval["minimum"] != float64(30) || interval["maximum"] != float64(86400) {
+		t.Fatalf("unexpected interval property: %+v", interval)
+	}
+	if _, readOnly := interval["readOnly"]; readOnly {
+		t.Fatalf("rw measurement must not be marked readOnly: %+v", interval)
+	}
+
+	mode, _ := properties["mode"].(map[string]any)
+	if !reflect.DeepEqual(mode["enum"], []any{"normal", "burst"}) {
+		t.Fatalf("unexpected mode enum: %+v", mode["enum"])
+	}
+
+	if !reflect.DeepEqual(jsonSchema["required"], []string{"volume"}) {
+		t.Fatalf("unexpected required list: %+v", jsonSchema["required"])
+	}
+}
+
+// A device carries housekeeping attributes no device type declares. Closing
+// the schema would reject every Magistrala device write.
+func TestBuildCapabilitySchemaLeavesAdditionalPropertiesOpen(t *testing.T) {
+	jsonSchema, _, err := BuildCapabilitySchema(CapabilityDocument{
+		Measurements: []Measurement{{Name: "volume", Unit: "m3"}},
+	})
+	if err != nil {
+		t.Fatalf("build capability schema: %v", err)
+	}
+	if _, closed := jsonSchema["additionalProperties"]; closed {
+		t.Fatalf("device type schemas must stay open to housekeeping attributes: %+v", jsonSchema)
+	}
+}
+
+// The declaration belongs in ui_schema: Atom compiles json_schema on every
+// entity write, so a custom keyword there is a validator's problem.
+func TestBuildCapabilitySchemaKeepsDeclarationOutOfJSONSchema(t *testing.T) {
+	jsonSchema, uiSchema, err := BuildCapabilitySchema(CapabilityDocument{
+		Measurements: []Measurement{{Name: "volume", Unit: "m3"}},
+		Commands:     []Command{{Name: "reboot"}},
+	})
+	if err != nil {
+		t.Fatalf("build capability schema: %v", err)
+	}
+	if _, found := jsonSchema[capabilityDeclarationKey]; found {
+		t.Fatalf("declaration must not appear in json_schema: %+v", jsonSchema)
+	}
+	if _, found := uiSchema[capabilityDeclarationKey]; !found {
+		t.Fatalf("declaration must be stored in ui_schema: %+v", uiSchema)
+	}
+	if !reflect.DeepEqual(uiSchema[capabilityOrderKey], []string{"volume"}) {
+		t.Fatalf("ui_schema must record declaration order: %+v", uiSchema[capabilityOrderKey])
+	}
+}
+
+func TestBuildCapabilitySchemaRejectsUnusableDeclarations(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  CapabilityDocument
+	}{
+		{"measurement without a name", CapabilityDocument{Measurements: []Measurement{{Unit: "m3"}}}},
+		{"duplicate measurements", CapabilityDocument{Measurements: []Measurement{{Name: "volume"}, {Name: "volume"}}}},
+		{"unsupported measurement type", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Type: "geometry"}}}},
+		{"unsupported access", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Access: "w"}}}},
+		{"min above max", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Min: floatPtr(10), Max: floatPtr(1)}}}},
+		{"command without a name", CapabilityDocument{Commands: []Command{{Description: "no name"}}}},
+		{"duplicate commands", CapabilityDocument{Commands: []Command{{Name: "reboot"}, {Name: "reboot"}}}},
+		{"parameter without a type", CapabilityDocument{Commands: []Command{{Name: "set", Params: map[string]string{"seconds": ""}}}}},
+		{"unsupported parameter type", CapabilityDocument{Commands: []Command{{Name: "set", Params: map[string]string{"at": "timestamp"}}}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := BuildCapabilitySchema(tc.doc); err == nil {
+				t.Fatal("expected an error, got none")
+			}
+		})
+	}
+}
+
+// A version whose schema was written by hand has no declaration to read, so
+// the measurements are reconstructed from the schema itself.
+func TestParseCapabilityDocumentFallsBackToJSONSchema(t *testing.T) {
+	got, err := ParseCapabilityDocument(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"volume":   map[string]any{"type": "number", "unit": "m3", "readOnly": true},
+			"interval": map[string]any{"type": "integer", "minimum": float64(30), "maximum": float64(600)},
+			"mode":     map[string]any{"type": "string", "enum": []any{"normal", "burst"}},
+		},
+		"required": []any{"volume"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("parse capability document: %v", err)
+	}
+
+	want := CapabilityDocument{Measurements: []Measurement{
+		{Name: "interval", Type: ValueTypeInteger, Access: MeasurementAccessReadWrite, Min: floatPtr(30), Max: floatPtr(600)},
+		{Name: "mode", Type: ValueTypeString, Access: MeasurementAccessReadWrite, Enum: []string{"normal", "burst"}},
+		{Name: "volume", Unit: "m3", Type: ValueTypeNumber, Access: MeasurementAccessRead, Required: true},
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected reconstruction:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// An advanced schema stays readable even where the capability model cannot
+// describe it — the unmodelled properties are skipped, not fatal.
+func TestParseCapabilityDocumentSkipsUnmodelledProperties(t *testing.T) {
+	got, err := ParseCapabilityDocument(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"volume":   map[string]any{"type": "number"},
+			"channels": map[string]any{"type": "array"},
+			"location": map[string]any{"type": "object"},
+			"untyped":  map[string]any{},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("parse capability document: %v", err)
+	}
+	if len(got.Measurements) != 1 || got.Measurements[0].Name != "volume" {
+		t.Fatalf("expected only the modellable property, got: %+v", got.Measurements)
+	}
+}
+
+func TestParseCapabilityDocumentPrefersStoredDeclaration(t *testing.T) {
+	doc := CapabilityDocument{
+		Measurements: []Measurement{{Name: "volume", Unit: "m3", Access: MeasurementAccessRead}},
+		Commands:     []Command{{Name: "set_interval", Params: map[string]string{"seconds": "int"}}},
+	}
+	_, uiSchema, err := BuildCapabilitySchema(doc)
+	if err != nil {
+		t.Fatalf("build capability schema: %v", err)
+	}
+
+	// Commands have no json_schema representation, so recovering them proves
+	// the declaration was read rather than the schema reverse-engineered.
+	got, err := ParseCapabilityDocument(nil, storedRoundTrip(t, uiSchema))
+	if err != nil {
+		t.Fatalf("parse capability document: %v", err)
+	}
+	if len(got.Commands) != 1 || got.Commands[0].Name != "set_interval" {
+		t.Fatalf("expected the stored declaration's commands, got: %+v", got.Commands)
+	}
+}

--- a/pkg/atom/capability_test.go
+++ b/pkg/atom/capability_test.go
@@ -279,6 +279,7 @@ func TestBuildCapabilitySchemaRejectsUnusableDeclarations(t *testing.T) {
 		{"unsupported measurement type", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Type: "geometry"}}}},
 		{"unsupported access", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Access: "w"}}}},
 		{"min above max", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Min: floatPtr(10), Max: floatPtr(1)}}}},
+		{"non-string enum", CapabilityDocument{Measurements: []Measurement{{Name: "volume", Type: ValueTypeInteger, Enum: []string{"1", "2"}}}}},
 		{"command without a name", CapabilityDocument{Commands: []Command{{Description: "no name"}}}},
 		{"duplicate commands", CapabilityDocument{Commands: []Command{{Name: "reboot"}, {Name: "reboot"}}}},
 		{"parameter without a type", CapabilityDocument{Commands: []Command{{Name: "set", Params: map[string]string{"seconds": ""}}}}},

--- a/pkg/atom/client.go
+++ b/pkg/atom/client.go
@@ -117,14 +117,21 @@ func (c *Client) UpsertEntity(ctx context.Context, entity Entity) error {
 	return err
 }
 
+// entityFields is the entity selection every entity query shares, so a new
+// field cannot reach one caller and not another.
+const entityFields = `id kind name tenant_id: tenantId device_type_id: profileId device_type_version_id: profileVersionId status attributes created_at: createdAt updated_at: updatedAt`
+
 func (c *Client) CreateEntity(ctx context.Context, entity Entity) (Entity, error) {
 	var out struct {
 		CreateEntity Entity `json:"createEntity"`
 	}
 	err := c.graphQL(ctx, `mutation CreateEntity($input: CreateEntityInput!) {
-		createEntity(input: $input) { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+		createEntity(input: $input) { `+entityFields+` }
 	}`, map[string]any{atomInputKeyInput: entityCreateInput(entity)}, &out)
-	return out.CreateEntity, err
+	if err != nil {
+		return Entity{}, translateSchemaError(err, entity.Attributes)
+	}
+	return out.CreateEntity, nil
 }
 
 func (c *Client) GetEntity(ctx context.Context, id string) (Entity, error) {
@@ -132,7 +139,7 @@ func (c *Client) GetEntity(ctx context.Context, id string) (Entity, error) {
 		Entity Entity `json:"entity"`
 	}
 	err := c.graphQL(ctx, `query Entity($id: ID!) {
-		entity(id: $id) { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+		entity(id: $id) { `+entityFields+` }
 	}`, map[string]any{"id": id}, &out)
 	return out.Entity, err
 }
@@ -142,9 +149,12 @@ func (c *Client) UpdateEntity(ctx context.Context, id string, entity Entity) (En
 		UpdateEntity Entity `json:"updateEntity"`
 	}
 	err := c.graphQL(ctx, `mutation UpdateEntity($id: ID!, $input: UpdateEntityInput!) {
-		updateEntity(id: $id, input: $input) { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+		updateEntity(id: $id, input: $input) { `+entityFields+` }
 	}`, map[string]any{"id": id, atomInputKeyInput: entityUpdateInput(entity)}, &out)
-	return out.UpdateEntity, err
+	if err != nil {
+		return Entity{}, translateSchemaError(err, entity.Attributes)
+	}
+	return out.UpdateEntity, nil
 }
 
 // CreateObjectGroup creates a group of devices/channels. Atom keeps object
@@ -241,7 +251,7 @@ func (c *Client) GroupMembers(ctx context.Context, groupID string) ([]Entity, er
 		err := c.graphQL(ctx, `query GroupMembers($parentGroupId: ID!, $limit: Int, $offset: Int) {
 			entities(parentGroupId: $parentGroupId, limit: $limit, offset: $offset) {
 				total
-				items { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+				items { `+entityFields+` }
 			}
 		}`, map[string]any{
 			atomInputKeyParentGroupID: groupID,
@@ -798,10 +808,10 @@ func (c *Client) ListEntities(ctx context.Context, q Query) (EntityList, error) 
 	var out struct {
 		Entities EntityList `json:"entities"`
 	}
-	err := c.graphQL(ctx, `query Entities($q: String, $kind: EntityKind, $tenantId: ID, $status: EntityStatus, $attributesContains: JSON, $limit: Int, $offset: Int) {
-		entities(q: $q, kind: $kind, tenantId: $tenantId, status: $status, attributesContains: $attributesContains, limit: $limit, offset: $offset) {
+	err := c.graphQL(ctx, `query Entities($q: String, $kind: EntityKind, $tenantId: ID, $profileId: ID, $status: EntityStatus, $attributesContains: JSON, $limit: Int, $offset: Int) {
+		entities(q: $q, kind: $kind, tenantId: $tenantId, profileId: $profileId, status: $status, attributesContains: $attributesContains, limit: $limit, offset: $offset) {
 			total
-			items { id kind name tenant_id: tenantId status attributes created_at: createdAt updated_at: updatedAt }
+			items { `+entityFields+` }
 		}
 	}`, objectQueryVariables(q), &out)
 	return out.Entities, err
@@ -942,6 +952,8 @@ func entityCreateInput(entity Entity) map[string]any {
 	setIfNotEmpty(input, "id", entity.ID)
 	setIfNotEmpty(input, atomInputKeyKind, entity.Kind)
 	setIfNotEmpty(input, "tenantId", entity.TenantID)
+	setIfNotEmpty(input, atomInputKeyProfileID, entity.DeviceTypeID)
+	setIfNotEmpty(input, atomInputKeyProfileVersionID, entity.DeviceTypeVersionID)
 	if entity.Attributes != nil {
 		input["attributes"] = entity.Attributes
 	} else {
@@ -950,10 +962,15 @@ func entityCreateInput(entity Entity) map[string]any {
 	return input
 }
 
+// entityUpdateInput omits the device type binding when unset, which is what
+// keeps an update from disturbing it: Atom coalesces a missing binding to the
+// stored one.
 func entityUpdateInput(entity Entity) map[string]any {
 	input := map[string]any{}
 	setIfNotEmpty(input, atomInputKeyName, entity.Name)
 	setIfNotEmpty(input, atomAttributeStatus, entity.Status)
+	setIfNotEmpty(input, atomInputKeyProfileID, entity.DeviceTypeID)
+	setIfNotEmpty(input, atomInputKeyProfileVersionID, entity.DeviceTypeVersionID)
 	if entity.Attributes != nil {
 		input["attributes"] = entity.Attributes
 	}
@@ -1100,6 +1117,7 @@ func objectQueryVariables(q Query) map[string]any {
 	setIfNotEmpty(vars, "q", q.Q)
 	setIfNotEmpty(vars, atomInputKeyKind, q.Kind)
 	setIfNotEmpty(vars, "tenantId", q.TenantID)
+	setIfNotEmpty(vars, atomInputKeyProfileID, q.DeviceTypeID)
 	setIfNotEmpty(vars, atomAttributeStatus, q.Status)
 	if q.AttributesContains != nil {
 		vars["attributesContains"] = q.AttributesContains
@@ -1218,12 +1236,14 @@ func (e Error) Error() string {
 	return fmt.Sprintf("atom request failed with status %d: %s", e.StatusCode, e.Message)
 }
 
+// IsConflict and IsNotFound unwrap, so they still answer for an error a
+// richer type wraps — SchemaValidationError, say.
 func IsConflict(err error) bool {
-	ae, ok := err.(Error)
-	return ok && ae.StatusCode == http.StatusConflict
+	var ae Error
+	return errors.As(err, &ae) && ae.StatusCode == http.StatusConflict
 }
 
 func IsNotFound(err error) bool {
-	ae, ok := err.(Error)
-	return ok && ae.StatusCode == http.StatusNotFound
+	var ae Error
+	return errors.As(err, &ae) && ae.StatusCode == http.StatusNotFound
 }

--- a/pkg/atom/constants.go
+++ b/pkg/atom/constants.go
@@ -61,17 +61,35 @@ const (
 const atomDecisionAllow = "allow"
 
 const (
-	atomInputKeyAction        = "action"
-	atomInputKeyCredentialID  = "credentialId"
-	atomInputKeyEntityID      = "entityId"
-	atomInputKeyInput         = "input"
-	atomInputKeyKind          = "kind"
-	atomInputKeyName          = "name"
-	atomInputKeyObjectGroupID = "objectGroupId"
-	atomInputKeyObjectKind    = "objectKind"
-	atomInputKeyParentGroupID = "parentGroupId"
-	atomInputKeyParentID      = "parentId"
-	atomInputKeySubjectID     = "subjectId"
+	atomInputKeyAction           = "action"
+	atomInputKeyCredentialID     = "credentialId"
+	atomInputKeyEntityID         = "entityId"
+	atomInputKeyInput            = "input"
+	atomInputKeyKind             = "kind"
+	atomInputKeyName             = "name"
+	atomInputKeyObjectGroupID    = "objectGroupId"
+	atomInputKeyObjectKind       = "objectKind"
+	atomInputKeyParentGroupID    = "parentGroupId"
+	atomInputKeyParentID         = "parentId"
+	atomInputKeySubjectID        = "subjectId"
+	atomInputKeyProfileID        = "profileId"
+	atomInputKeyProfileVersionID = "profileVersionId"
+)
+
+// Device type status. A deprecated or disabled device type accepts no new
+// bindings; devices already bound to it are unaffected.
+const (
+	DeviceTypeStatusActive     = "active"
+	DeviceTypeStatusDeprecated = "deprecated"
+	DeviceTypeStatusDisabled   = "disabled"
+)
+
+// Device type version status. Only an active version can be bound to.
+const (
+	DeviceTypeVersionStatusDraft      = "draft"
+	DeviceTypeVersionStatusActive     = "active"
+	DeviceTypeVersionStatusDeprecated = "deprecated"
+	DeviceTypeVersionStatusDisabled   = "disabled"
 )
 
 const (

--- a/pkg/atom/device_types.go
+++ b/pkg/atom/device_types.go
@@ -1,0 +1,329 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+)
+
+// ErrDeviceTypeVersionNotBindable means a bind named a version that is not
+// active. Atom only rejects this when it picks the version itself; when the
+// caller names one explicitly it binds without checking status, so this client
+// checks instead.
+var ErrDeviceTypeVersionNotBindable = errors.New("atom: device type version is not active")
+
+// ErrDeviceTypeNotBindable means a bind named a device type that is not
+// active. Atom enforces this too; checking here turns it into a typed error.
+var ErrDeviceTypeNotBindable = errors.New("atom: device type is not active")
+
+// Atom's Profile carries these for every device type. object_kind narrows it
+// to entity profiles and kind to devices, which is also what makes a gateway
+// type an ordinary device type rather than a separate catalogue.
+const (
+	deviceTypeObjectKind = atomObjectKindEntity
+	deviceTypeKind       = atomKindDevice
+)
+
+// Atom names this concept "profile" on the wire. Aliases map it back to Device
+// Type so nothing above this file has to know.
+const (
+	deviceTypeFields        = `id tenant_id: tenantId key name: displayName description status created_at: createdAt updated_at: updatedAt`
+	deviceTypeVersionFields = `id device_type_id: profileId version json_schema: jsonSchema ui_schema: uiSchema status created_at: createdAt`
+)
+
+// CreateDeviceType registers a device type. It creates the type only — add a
+// capability document with CreateDeviceTypeVersion, which is a separate call
+// because Atom has no deleteProfile mutation, so a combined create could not
+// roll back a half-built type.
+//
+// TenantID is required. Atom also supports tenant-less global types, but its
+// profiles query cannot ask for "this tenant plus global" — passing no tenant
+// returns every tenant's types — so Magistrala does not expose global types
+// and always scopes to a tenant.
+func (c *Client) CreateDeviceType(ctx context.Context, deviceType DeviceType) (DeviceType, error) {
+	if deviceType.TenantID == "" {
+		return DeviceType{}, Error{StatusCode: http.StatusBadRequest, Message: "device type requires a tenant"}
+	}
+	if deviceType.Key == "" {
+		return DeviceType{}, Error{StatusCode: http.StatusBadRequest, Message: "device type requires a key"}
+	}
+
+	var out struct {
+		CreateProfile DeviceType `json:"createProfile"`
+	}
+	err := c.graphQL(ctx, `mutation CreateDeviceType($input: CreateProfileInput!) {
+		createProfile(input: $input) { `+deviceTypeFields+` }
+	}`, map[string]any{atomInputKeyInput: deviceTypeCreateInput(deviceType)}, &out)
+	return out.CreateProfile, err
+}
+
+func (c *Client) GetDeviceType(ctx context.Context, id string) (DeviceType, error) {
+	var out struct {
+		Profile DeviceType `json:"profile"`
+	}
+	err := c.graphQL(ctx, `query DeviceType($id: ID!) {
+		profile(id: $id) { `+deviceTypeFields+` }
+	}`, map[string]any{"id": id}, &out)
+	return out.Profile, err
+}
+
+// ListDeviceTypes lists a tenant's device types. Global (tenant-less) types
+// are not returned: Atom's filter is "this tenant" or "no filter at all", and
+// no filter at all crosses tenants.
+func (c *Client) ListDeviceTypes(ctx context.Context, q DeviceTypeQuery) (DeviceTypeList, error) {
+	if q.TenantID == "" {
+		return DeviceTypeList{}, Error{StatusCode: http.StatusBadRequest, Message: "listing device types requires a tenant"}
+	}
+
+	var out struct {
+		Profiles DeviceTypeList `json:"profiles"`
+	}
+	err := c.graphQL(ctx, `query DeviceTypes($objectKind: String, $kind: String, $tenantId: ID, $status: String, $limit: Int, $offset: Int) {
+		profiles(objectKind: $objectKind, kind: $kind, tenantId: $tenantId, status: $status, limit: $limit, offset: $offset) {
+			total
+			items { `+deviceTypeFields+` }
+		}
+	}`, deviceTypeQueryVariables(q), &out)
+	return out.Profiles, err
+}
+
+// UpdateDeviceType changes a device type's name, description or status. Key,
+// tenant and kind are fixed at creation.
+//
+// Setting Status to anything but active is how a whole device type is retired:
+// Atom refuses new bindings to a non-active type and leaves bound devices
+// alone.
+func (c *Client) UpdateDeviceType(ctx context.Context, id string, deviceType DeviceType) (DeviceType, error) {
+	var out struct {
+		UpdateProfile DeviceType `json:"updateProfile"`
+	}
+	err := c.graphQL(ctx, `mutation UpdateDeviceType($id: ID!, $input: UpdateProfileInput!) {
+		updateProfile(id: $id, input: $input) { `+deviceTypeFields+` }
+	}`, map[string]any{"id": id, atomInputKeyInput: deviceTypeUpdateInput(deviceType)}, &out)
+	return out.UpdateProfile, err
+}
+
+// CreateDeviceTypeVersion adds a version to a device type. It never mutates an
+// existing version, so devices bound to earlier versions keep validating
+// against exactly what they were created against.
+//
+// Version numbers off Version, or the next unused number when it is zero.
+// Deriving it costs a read, and two concurrent creates can still collide — the
+// unique constraint turns that into a conflict rather than a silent overwrite.
+//
+// JSONSchema and UISchema are rendered from Capabilities unless the caller
+// supplies JSONSchema directly, which is the escape hatch for schemas the
+// capability model cannot express.
+//
+// Status defaults to active. Atom has no mutation to change it afterwards, so
+// a version's status is decided here and only here: publish as
+// DeviceTypeVersionStatusDraft to stage a version without making it bindable.
+func (c *Client) CreateDeviceTypeVersion(ctx context.Context, deviceTypeID string, version DeviceTypeVersion) (DeviceTypeVersion, error) {
+	if deviceTypeID == "" {
+		return DeviceTypeVersion{}, Error{StatusCode: http.StatusBadRequest, Message: "device type version requires a device type"}
+	}
+
+	if version.JSONSchema == nil {
+		jsonSchema, uiSchema, err := BuildCapabilitySchema(version.Capabilities)
+		if err != nil {
+			return DeviceTypeVersion{}, err
+		}
+		version.JSONSchema = jsonSchema
+		if version.UISchema == nil {
+			version.UISchema = uiSchema
+		}
+	}
+
+	if version.Version == 0 {
+		next, err := c.nextDeviceTypeVersion(ctx, deviceTypeID)
+		if err != nil {
+			return DeviceTypeVersion{}, err
+		}
+		version.Version = next
+	}
+
+	var out struct {
+		CreateProfileVersion DeviceTypeVersion `json:"createProfileVersion"`
+	}
+	err := c.graphQL(ctx, `mutation CreateDeviceTypeVersion($profileId: ID!, $input: CreateProfileVersionInput!) {
+		createProfileVersion(profileId: $profileId, input: $input) { `+deviceTypeVersionFields+` }
+	}`, map[string]any{
+		atomInputKeyProfileID: deviceTypeID,
+		atomInputKeyInput:     deviceTypeVersionCreateInput(version),
+	}, &out)
+	if err != nil {
+		return DeviceTypeVersion{}, err
+	}
+	return withCapabilities(out.CreateProfileVersion)
+}
+
+// ListDeviceTypeVersions returns every version of a device type, oldest first.
+func (c *Client) ListDeviceTypeVersions(ctx context.Context, deviceTypeID string) ([]DeviceTypeVersion, error) {
+	var out struct {
+		ProfileVersions []DeviceTypeVersion `json:"profileVersions"`
+	}
+	err := c.graphQL(ctx, `query DeviceTypeVersions($profileId: ID!) {
+		profileVersions(profileId: $profileId) { `+deviceTypeVersionFields+` }
+	}`, map[string]any{atomInputKeyProfileID: deviceTypeID}, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := out.ProfileVersions
+	sort.Slice(versions, func(i, j int) bool { return versions[i].Version < versions[j].Version })
+	for i, version := range versions {
+		parsed, err := withCapabilities(version)
+		if err != nil {
+			return nil, err
+		}
+		versions[i] = parsed
+	}
+	return versions, nil
+}
+
+// ActiveDeviceTypeVersion returns the version Atom binds a device to when none
+// is named: the highest-numbered active one. It returns a not-found error when
+// the type has no active version, which is also what Atom does on bind.
+func (c *Client) ActiveDeviceTypeVersion(ctx context.Context, deviceTypeID string) (DeviceTypeVersion, error) {
+	versions, err := c.ListDeviceTypeVersions(ctx, deviceTypeID)
+	if err != nil {
+		return DeviceTypeVersion{}, err
+	}
+	for i := len(versions) - 1; i >= 0; i-- {
+		if versions[i].Status == DeviceTypeVersionStatusActive {
+			return versions[i], nil
+		}
+	}
+	return DeviceTypeVersion{}, Error{
+		StatusCode: http.StatusNotFound,
+		Message:    "device type " + deviceTypeID + " has no active version",
+	}
+}
+
+// BindDeviceType binds an existing device to a device type, optionally to a
+// named version. An empty versionID leaves the choice to Atom, which takes the
+// highest-numbered active version.
+//
+// The type and version are checked before the write because Atom only checks
+// them itself when it chooses the version — a caller-named version is bound
+// whatever its status. Without this check, deprecating a version would not
+// stop new bindings to it.
+//
+// Binding validates attributes against the *previously* bound version, not the
+// new one: Atom's update path looks up the schema by the entity's current
+// binding. The first write after a bind is what the new schema sees.
+func (c *Client) BindDeviceType(ctx context.Context, deviceID, deviceTypeID, versionID string) (Entity, error) {
+	if deviceID == "" || deviceTypeID == "" {
+		return Entity{}, Error{StatusCode: http.StatusBadRequest, Message: "binding a device type requires a device and a device type"}
+	}
+
+	deviceType, err := c.GetDeviceType(ctx, deviceTypeID)
+	if err != nil {
+		return Entity{}, err
+	}
+	if deviceType.Status != DeviceTypeStatusActive {
+		return Entity{}, ErrDeviceTypeNotBindable
+	}
+
+	if versionID != "" {
+		versions, err := c.ListDeviceTypeVersions(ctx, deviceTypeID)
+		if err != nil {
+			return Entity{}, err
+		}
+		bindable := false
+		for _, version := range versions {
+			if version.ID != versionID {
+				continue
+			}
+			bindable = version.Status == DeviceTypeVersionStatusActive
+			break
+		}
+		if !bindable {
+			return Entity{}, ErrDeviceTypeVersionNotBindable
+		}
+	}
+
+	return c.UpdateEntity(ctx, deviceID, Entity{
+		DeviceTypeID:        deviceTypeID,
+		DeviceTypeVersionID: versionID,
+	})
+}
+
+// nextDeviceTypeVersion is one past the highest existing version number.
+func (c *Client) nextDeviceTypeVersion(ctx context.Context, deviceTypeID string) (int, error) {
+	versions, err := c.ListDeviceTypeVersions(ctx, deviceTypeID)
+	if err != nil {
+		return 0, err
+	}
+	next := 1
+	for _, version := range versions {
+		if version.Version >= next {
+			next = version.Version + 1
+		}
+	}
+	return next, nil
+}
+
+// withCapabilities fills in the declaration a stored version encodes, so
+// callers never read json_schema themselves.
+func withCapabilities(version DeviceTypeVersion) (DeviceTypeVersion, error) {
+	capabilities, err := ParseCapabilityDocument(version.JSONSchema, version.UISchema)
+	if err != nil {
+		return DeviceTypeVersion{}, err
+	}
+	version.Capabilities = capabilities
+	return version, nil
+}
+
+func deviceTypeCreateInput(deviceType DeviceType) map[string]any {
+	input := map[string]any{
+		atomInputKeyObjectKind: deviceTypeObjectKind,
+		atomInputKeyKind:       deviceTypeKind,
+		"key":                  deviceType.Key,
+		"displayName":          deviceType.Name,
+	}
+	setIfNotEmpty(input, "tenantId", deviceType.TenantID)
+	setIfNotEmpty(input, "description", deviceType.Description)
+	setIfNotEmpty(input, atomAttributeStatus, deviceType.Status)
+	return input
+}
+
+func deviceTypeUpdateInput(deviceType DeviceType) map[string]any {
+	input := map[string]any{}
+	setIfNotEmpty(input, "displayName", deviceType.Name)
+	setIfNotEmpty(input, "description", deviceType.Description)
+	setIfNotEmpty(input, atomAttributeStatus, deviceType.Status)
+	return input
+}
+
+func deviceTypeVersionCreateInput(version DeviceTypeVersion) map[string]any {
+	input := map[string]any{"version": version.Version}
+	if version.JSONSchema != nil {
+		input["jsonSchema"] = version.JSONSchema
+	}
+	if version.UISchema != nil {
+		input["uiSchema"] = version.UISchema
+	}
+	setIfNotEmpty(input, atomAttributeStatus, version.Status)
+	return input
+}
+
+func deviceTypeQueryVariables(q DeviceTypeQuery) map[string]any {
+	vars := map[string]any{
+		atomInputKeyObjectKind: deviceTypeObjectKind,
+		atomInputKeyKind:       deviceTypeKind,
+	}
+	setIfNotEmpty(vars, "tenantId", q.TenantID)
+	setIfNotEmpty(vars, atomAttributeStatus, q.Status)
+	if q.Limit > 0 {
+		vars["limit"] = int(q.Limit)
+	}
+	if q.Offset > 0 {
+		vars["offset"] = int(q.Offset)
+	}
+	return vars
+}

--- a/pkg/atom/device_types_test.go
+++ b/pkg/atom/device_types_test.go
@@ -1,0 +1,1008 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAtomDeviceTypes stands in for the slice of Atom device types depend on:
+// profile and profile-version storage, and the entity write path that
+// validates attributes against a bound version.
+//
+// It reproduces Atom's resolution rules rather than a convenient
+// approximation, because the rules are what these tests are about:
+//
+//   - a device type must be active to accept a new binding
+//     (src/identity/repo.rs, resolve_entity_profile)
+//   - with no version named, the highest-numbered *active* version is chosen
+//   - with a version named, Atom binds it without checking its status — the
+//     gap BindDeviceType closes on the client side
+//   - an update validates against the entity's already-bound version, not
+//     against a version supplied in the same call
+//   - a missing binding on update coalesces to the stored one
+type fakeAtomDeviceTypes struct {
+	t           *testing.T
+	deviceTypes map[string]*fakeDeviceType
+	versions    map[string]*fakeDeviceTypeVersion
+	entities    map[string]*fakeEntity
+	listQueries []map[string]any
+	sequence    int
+}
+
+type fakeDeviceType struct {
+	ID          string
+	TenantID    string
+	ObjectKind  string
+	Kind        string
+	Key         string
+	Name        string
+	Description string
+	Status      string
+}
+
+type fakeDeviceTypeVersion struct {
+	ID           string
+	DeviceTypeID string
+	Version      int
+	JSONSchema   map[string]any
+	UISchema     map[string]any
+	Status       string
+}
+
+type fakeEntity struct {
+	ID                  string
+	Kind                string
+	Name                string
+	TenantID            string
+	DeviceTypeID        string
+	DeviceTypeVersionID string
+	Status              string
+	Attributes          map[string]any
+}
+
+func newFakeAtomDeviceTypes(t *testing.T) (*fakeAtomDeviceTypes, *Client) {
+	t.Helper()
+	fa := &fakeAtomDeviceTypes{
+		t:           t,
+		deviceTypes: map[string]*fakeDeviceType{},
+		versions:    map[string]*fakeDeviceTypeVersion{},
+		entities:    map[string]*fakeEntity{},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fa.handle))
+	t.Cleanup(srv.Close)
+	return fa, NewClient(Config{URL: srv.URL, Timeout: time.Second})
+}
+
+func (fa *fakeAtomDeviceTypes) id(prefix string) string {
+	fa.sequence++
+	return fmt.Sprintf("%s-%d", prefix, fa.sequence)
+}
+
+func (fa *fakeAtomDeviceTypes) handle(w http.ResponseWriter, r *http.Request) {
+	payload := decodePayload(fa.t, r)
+	switch {
+	case strings.Contains(payload.Query, "mutation CreateDeviceTypeVersion"):
+		fa.createVersion(w, payload)
+	case strings.Contains(payload.Query, "query DeviceTypeVersions("):
+		fa.listVersions(w, payload)
+	case strings.Contains(payload.Query, "mutation CreateDeviceType"):
+		fa.createDeviceType(w, payload)
+	case strings.Contains(payload.Query, "mutation UpdateDeviceType"):
+		fa.updateDeviceType(w, payload)
+	case strings.Contains(payload.Query, "query DeviceTypes("):
+		fa.listDeviceTypes(w, payload)
+	case strings.Contains(payload.Query, "query DeviceType("):
+		fa.getDeviceType(w, payload)
+	case strings.Contains(payload.Query, "mutation CreateEntity"):
+		fa.createEntity(w, payload)
+	case strings.Contains(payload.Query, "mutation UpdateEntity"):
+		fa.updateEntity(w, payload)
+	case strings.Contains(payload.Query, "query Entities("):
+		fa.listEntities(w, payload)
+	case strings.Contains(payload.Query, "query Entity("):
+		fa.getEntity(w, payload)
+	default:
+		fa.t.Fatalf("unexpected GraphQL payload: %s", payload.Query)
+	}
+}
+
+func (fa *fakeAtomDeviceTypes) fail(w http.ResponseWriter, format string, args ...any) {
+	_ = writeJSON(w, map[string]any{
+		"errors": []map[string]string{{"message": fmt.Sprintf(format, args...)}},
+	})
+}
+
+func (fa *fakeAtomDeviceTypes) createDeviceType(w http.ResponseWriter, payload gqlPayload) {
+	input, _ := payload.Variables["input"].(map[string]any)
+	deviceType := &fakeDeviceType{
+		ID:          fa.id("dt"),
+		TenantID:    stringField(input, "tenantId"),
+		ObjectKind:  stringField(input, "objectKind"),
+		Kind:        stringField(input, "kind"),
+		Key:         stringField(input, "key"),
+		Name:        stringField(input, "displayName"),
+		Description: stringField(input, "description"),
+		Status:      stringField(input, "status"),
+	}
+	if deviceType.Status == "" {
+		deviceType.Status = DeviceTypeStatusActive
+	}
+	for _, existing := range fa.deviceTypes {
+		if existing.TenantID == deviceType.TenantID && existing.Key == deviceType.Key {
+			fa.fail(w, "already exists")
+			return
+		}
+	}
+	fa.deviceTypes[deviceType.ID] = deviceType
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"createProfile": deviceTypeJSON(deviceType)}})
+}
+
+func (fa *fakeAtomDeviceTypes) getDeviceType(w http.ResponseWriter, payload gqlPayload) {
+	id, _ := payload.Variables["id"].(string)
+	deviceType, ok := fa.deviceTypes[id]
+	if !ok {
+		fa.fail(w, "profile %s not found", id)
+		return
+	}
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"profile": deviceTypeJSON(deviceType)}})
+}
+
+func (fa *fakeAtomDeviceTypes) listDeviceTypes(w http.ResponseWriter, payload gqlPayload) {
+	fa.listQueries = append(fa.listQueries, payload.Variables)
+
+	tenantID, hasTenant := payload.Variables["tenantId"].(string)
+	objectKind, _ := payload.Variables["objectKind"].(string)
+	kind, _ := payload.Variables["kind"].(string)
+	status, _ := payload.Variables["status"].(string)
+
+	var items []map[string]any
+	for _, deviceType := range fa.deviceTypes {
+		// Atom filters on tenant only when one is given; no tenant means every
+		// tenant's types, which is why this client always sends one.
+		if hasTenant && deviceType.TenantID != tenantID {
+			continue
+		}
+		if objectKind != "" && deviceType.ObjectKind != objectKind {
+			continue
+		}
+		if kind != "" && deviceType.Kind != kind {
+			continue
+		}
+		if status != "" && deviceType.Status != status {
+			continue
+		}
+		items = append(items, deviceTypeJSON(deviceType))
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i]["key"].(string) < items[j]["key"].(string) })
+
+	_ = writeJSON(w, map[string]any{
+		"data": map[string]any{"profiles": map[string]any{"items": items, "total": len(items)}},
+	})
+}
+
+func (fa *fakeAtomDeviceTypes) updateDeviceType(w http.ResponseWriter, payload gqlPayload) {
+	id, _ := payload.Variables["id"].(string)
+	deviceType, ok := fa.deviceTypes[id]
+	if !ok {
+		fa.fail(w, "profile %s not found", id)
+		return
+	}
+	input, _ := payload.Variables["input"].(map[string]any)
+	if name := stringField(input, "displayName"); name != "" {
+		deviceType.Name = name
+	}
+	if description := stringField(input, "description"); description != "" {
+		deviceType.Description = description
+	}
+	if status := stringField(input, "status"); status != "" {
+		deviceType.Status = status
+	}
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"updateProfile": deviceTypeJSON(deviceType)}})
+}
+
+func (fa *fakeAtomDeviceTypes) createVersion(w http.ResponseWriter, payload gqlPayload) {
+	deviceTypeID, _ := payload.Variables["profileId"].(string)
+	if _, ok := fa.deviceTypes[deviceTypeID]; !ok {
+		fa.fail(w, "profile %s not found", deviceTypeID)
+		return
+	}
+	input, _ := payload.Variables["input"].(map[string]any)
+	number := 0
+	if raw, ok := input["version"].(float64); ok {
+		number = int(raw)
+	}
+	for _, existing := range fa.versions {
+		if existing.DeviceTypeID == deviceTypeID && existing.Version == number {
+			fa.fail(w, "already exists")
+			return
+		}
+	}
+
+	version := &fakeDeviceTypeVersion{
+		ID:           fa.id("dtv"),
+		DeviceTypeID: deviceTypeID,
+		Version:      number,
+		Status:       stringField(input, "status"),
+	}
+	version.JSONSchema, _ = input["jsonSchema"].(map[string]any)
+	version.UISchema, _ = input["uiSchema"].(map[string]any)
+	if version.Status == "" {
+		version.Status = DeviceTypeVersionStatusActive
+	}
+	fa.versions[version.ID] = version
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"createProfileVersion": versionJSON(version)}})
+}
+
+func (fa *fakeAtomDeviceTypes) listVersions(w http.ResponseWriter, payload gqlPayload) {
+	deviceTypeID, _ := payload.Variables["profileId"].(string)
+	var items []map[string]any
+	for _, version := range fa.versionsOf(deviceTypeID) {
+		items = append(items, versionJSON(version))
+	}
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"profileVersions": items}})
+}
+
+// versionsOf returns a device type's versions, newest last.
+func (fa *fakeAtomDeviceTypes) versionsOf(deviceTypeID string) []*fakeDeviceTypeVersion {
+	var versions []*fakeDeviceTypeVersion
+	for _, version := range fa.versions {
+		if version.DeviceTypeID == deviceTypeID {
+			versions = append(versions, version)
+		}
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i].Version < versions[j].Version })
+	return versions
+}
+
+// resolveBinding mirrors Atom's resolve_entity_profile.
+func (fa *fakeAtomDeviceTypes) resolveBinding(deviceTypeID, versionID string) (*fakeDeviceTypeVersion, error) {
+	deviceType, ok := fa.deviceTypes[deviceTypeID]
+	if !ok {
+		return nil, fmt.Errorf("profile %s not found", deviceTypeID)
+	}
+	if deviceType.Status != DeviceTypeStatusActive {
+		return nil, fmt.Errorf("profile %s is not active", deviceTypeID)
+	}
+
+	if versionID != "" {
+		version, ok := fa.versions[versionID]
+		if !ok {
+			return nil, fmt.Errorf("profile version %s not found", versionID)
+		}
+		if version.DeviceTypeID != deviceTypeID {
+			return nil, fmt.Errorf("profile_version_id %s does not belong to profile_id %s", versionID, deviceTypeID)
+		}
+		// Deliberately no status check: this is what Atom does.
+		return version, nil
+	}
+
+	versions := fa.versionsOf(deviceTypeID)
+	for i := len(versions) - 1; i >= 0; i-- {
+		if versions[i].Status == DeviceTypeVersionStatusActive {
+			return versions[i], nil
+		}
+	}
+	return nil, fmt.Errorf("profile %s has no active version", deviceTypeID)
+}
+
+func (fa *fakeAtomDeviceTypes) createEntity(w http.ResponseWriter, payload gqlPayload) {
+	input, _ := payload.Variables["input"].(map[string]any)
+	entity := &fakeEntity{
+		ID:       stringField(input, "id"),
+		Kind:     stringField(input, "kind"),
+		Name:     stringField(input, "name"),
+		TenantID: stringField(input, "tenantId"),
+		Status:   atomStatusActive,
+	}
+	if entity.ID == "" {
+		entity.ID = fa.id("device")
+	}
+	entity.Attributes, _ = input["attributes"].(map[string]any)
+	if entity.Attributes == nil {
+		entity.Attributes = map[string]any{}
+	}
+
+	if deviceTypeID := stringField(input, "profileId"); deviceTypeID != "" {
+		version, err := fa.resolveBinding(deviceTypeID, stringField(input, "profileVersionId"))
+		if err != nil {
+			fa.fail(w, "%s", err.Error())
+			return
+		}
+		if messages := validateAgainstSchema(version.JSONSchema, entity.Attributes); len(messages) > 0 {
+			fa.fail(w, "%s%s", atomSchemaValidationPrefix, strings.Join(messages, "; "))
+			return
+		}
+		entity.DeviceTypeID = deviceTypeID
+		entity.DeviceTypeVersionID = version.ID
+		entity.Kind = atomKindDevice
+	}
+
+	fa.entities[entity.ID] = entity
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"createEntity": deviceTypeEntityJSON(entity)}})
+}
+
+func (fa *fakeAtomDeviceTypes) updateEntity(w http.ResponseWriter, payload gqlPayload) {
+	id, _ := payload.Variables["id"].(string)
+	entity, ok := fa.entities[id]
+	if !ok {
+		fa.fail(w, "entity %s not found", id)
+		return
+	}
+	input, _ := payload.Variables["input"].(map[string]any)
+
+	// Atom validates against the version already bound, looked up by the
+	// entity's stored profile_version_id — not against a binding supplied in
+	// the same call.
+	if attributes, ok := input["attributes"].(map[string]any); ok {
+		if version, bound := fa.versions[entity.DeviceTypeVersionID]; bound {
+			if messages := validateAgainstSchema(version.JSONSchema, attributes); len(messages) > 0 {
+				fa.fail(w, "%s%s", atomSchemaValidationPrefix, strings.Join(messages, "; "))
+				return
+			}
+		}
+		entity.Attributes = attributes
+	}
+	if name := stringField(input, "name"); name != "" {
+		entity.Name = name
+	}
+	if status := stringField(input, "status"); status != "" {
+		entity.Status = status
+	}
+	// COALESCE: an absent binding keeps the stored one.
+	if deviceTypeID := stringField(input, "profileId"); deviceTypeID != "" {
+		version, err := fa.resolveBinding(deviceTypeID, stringField(input, "profileVersionId"))
+		if err != nil {
+			fa.fail(w, "%s", err.Error())
+			return
+		}
+		entity.DeviceTypeID = deviceTypeID
+		entity.DeviceTypeVersionID = version.ID
+	}
+
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"updateEntity": deviceTypeEntityJSON(entity)}})
+}
+
+func (fa *fakeAtomDeviceTypes) getEntity(w http.ResponseWriter, payload gqlPayload) {
+	id, _ := payload.Variables["id"].(string)
+	entity, ok := fa.entities[id]
+	if !ok {
+		fa.fail(w, "entity %s not found", id)
+		return
+	}
+	_ = writeJSON(w, map[string]any{"data": map[string]any{"entity": deviceTypeEntityJSON(entity)}})
+}
+
+func (fa *fakeAtomDeviceTypes) listEntities(w http.ResponseWriter, payload gqlPayload) {
+	deviceTypeID, _ := payload.Variables["profileId"].(string)
+	kind, _ := payload.Variables["kind"].(string)
+
+	var items []map[string]any
+	for _, entity := range fa.entities {
+		if deviceTypeID != "" && entity.DeviceTypeID != deviceTypeID {
+			continue
+		}
+		if kind != "" && entity.Kind != kind {
+			continue
+		}
+		items = append(items, deviceTypeEntityJSON(entity))
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i]["id"].(string) < items[j]["id"].(string) })
+
+	_ = writeJSON(w, map[string]any{
+		"data": map[string]any{"entities": map[string]any{"items": items, "total": len(items)}},
+	})
+}
+
+func deviceTypeJSON(deviceType *fakeDeviceType) map[string]any {
+	return map[string]any{
+		"id":          deviceType.ID,
+		"tenant_id":   deviceType.TenantID,
+		"key":         deviceType.Key,
+		"name":        deviceType.Name,
+		"description": deviceType.Description,
+		"status":      deviceType.Status,
+	}
+}
+
+func versionJSON(version *fakeDeviceTypeVersion) map[string]any {
+	return map[string]any{
+		"id":             version.ID,
+		"device_type_id": version.DeviceTypeID,
+		"version":        version.Version,
+		"json_schema":    version.JSONSchema,
+		"ui_schema":      version.UISchema,
+		"status":         version.Status,
+	}
+}
+
+func deviceTypeEntityJSON(entity *fakeEntity) map[string]any {
+	return map[string]any{
+		"id":                     entity.ID,
+		"kind":                   entity.Kind,
+		"name":                   entity.Name,
+		"tenant_id":              entity.TenantID,
+		"device_type_id":         entity.DeviceTypeID,
+		"device_type_version_id": entity.DeviceTypeVersionID,
+		"status":                 entity.Status,
+		"attributes":             entity.Attributes,
+	}
+}
+
+func stringField(input map[string]any, key string) string {
+	value, _ := input[key].(string)
+	return value
+}
+
+// validateAgainstSchema is a small JSON Schema validator covering the keywords
+// BuildCapabilitySchema emits, worded exactly as the jsonschema crate words
+// them so the client's error translation is exercised against real input.
+func validateAgainstSchema(schema, attributes map[string]any) []string {
+	if len(schema) == 0 {
+		return nil
+	}
+	var messages []string
+
+	for _, name := range jsonSlice(schema["required"]) {
+		name, ok := name.(string)
+		if !ok {
+			continue
+		}
+		if _, present := attributes[name]; !present {
+			messages = append(messages, fmt.Sprintf("%q is a required property", name))
+		}
+	}
+
+	properties, _ := schema["properties"].(map[string]any)
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		property, _ := properties[name].(map[string]any)
+		value, present := attributes[name]
+		if !present || property == nil {
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		instance := string(encoded)
+
+		declared, _ := property["type"].(string)
+		if !matchesType(declared, value) {
+			messages = append(messages, fmt.Sprintf("%s is not of type %q", instance, declared))
+			continue
+		}
+		number, isNumber := floatValue(value)
+		if isNumber {
+			if min, ok := floatValue(property["minimum"]); ok && number < min {
+				messages = append(messages, fmt.Sprintf("%s is less than the minimum of %s", instance, formatLimit(min)))
+			}
+			if max, ok := floatValue(property["maximum"]); ok && number > max {
+				messages = append(messages, fmt.Sprintf("%s is greater than the maximum of %s", instance, formatLimit(max)))
+			}
+		}
+		if options := jsonSlice(property["enum"]); len(options) > 0 {
+			allowed := false
+			for _, option := range options {
+				if option == value {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				encodedOptions, _ := json.Marshal(options)
+				messages = append(messages, fmt.Sprintf("%s is not one of %s", instance, encodedOptions))
+			}
+		}
+	}
+
+	return messages
+}
+
+func matchesType(declared string, value any) bool {
+	switch declared {
+	case ValueTypeNumber:
+		_, ok := floatValue(value)
+		return ok
+	case ValueTypeInteger:
+		number, ok := floatValue(value)
+		return ok && number == float64(int64(number))
+	case ValueTypeString:
+		_, ok := value.(string)
+		return ok
+	case ValueTypeBoolean:
+		_, ok := value.(bool)
+		return ok
+	default:
+		return true
+	}
+}
+
+func formatLimit(v float64) string {
+	encoded, _ := json.Marshal(v)
+	return string(encoded)
+}
+
+// watermeter is the running example: a type that reports volume and battery
+// and accepts a reporting-interval command.
+func watermeter() CapabilityDocument {
+	return CapabilityDocument{
+		Measurements: []Measurement{
+			{Name: "volume", Unit: "m3", Access: MeasurementAccessRead, Required: true},
+			{Name: "battery", Unit: "%", Access: MeasurementAccessRead, Min: floatPtr(0), Max: floatPtr(100)},
+		},
+		Commands: []Command{
+			{Name: "set_interval", Params: map[string]string{"seconds": "int"}},
+		},
+	}
+}
+
+func createWatermeterType(t *testing.T, client *Client) (DeviceType, DeviceTypeVersion) {
+	t.Helper()
+	ctx := context.Background()
+
+	deviceType, err := client.CreateDeviceType(ctx, DeviceType{
+		TenantID:    testTenantID,
+		Key:         "watermeter",
+		Name:        "Watermeter",
+		Description: "Volumetric water meter",
+	})
+	if err != nil {
+		t.Fatalf("create device type: %v", err)
+	}
+	version, err := client.CreateDeviceTypeVersion(ctx, deviceType.ID, DeviceTypeVersion{Capabilities: watermeter()})
+	if err != nil {
+		t.Fatalf("create device type version: %v", err)
+	}
+	return deviceType, version
+}
+
+// Acceptance criterion 1.
+func TestDeviceTypeCapabilityDocumentSurvivesAtom(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, created := createWatermeterType(t, client)
+	if created.Version != 1 {
+		t.Fatalf("first version must be 1, got %d", created.Version)
+	}
+
+	versions, err := client.ListDeviceTypeVersions(ctx, deviceType.ID)
+	if err != nil {
+		t.Fatalf("list device type versions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected one version, got %d", len(versions))
+	}
+
+	got := versions[0].Capabilities
+	if len(got.Measurements) != 2 || len(got.Commands) != 1 {
+		t.Fatalf("declaration did not survive the round trip: %+v", got)
+	}
+	if got.Measurements[0].Name != "volume" || got.Measurements[0].Unit != "m3" {
+		t.Fatalf("unexpected first measurement: %+v", got.Measurements[0])
+	}
+	if got.Commands[0].Params["seconds"] != ValueTypeInteger {
+		t.Fatalf("unexpected command params: %+v", got.Commands[0].Params)
+	}
+}
+
+// Acceptance criterion 2.
+func TestDeviceBoundToDeviceTypeAcceptsConformingAttributes(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, version := createWatermeterType(t, client)
+
+	device, err := client.CreateEntity(ctx, Entity{
+		Kind:         atomKindDevice,
+		Name:         "meter-1",
+		TenantID:     testTenantID,
+		DeviceTypeID: deviceType.ID,
+		Attributes:   Attributes{"volume": 12.5, "battery": 90, "source": "magistrala"},
+	})
+	if err != nil {
+		t.Fatalf("create bound device: %v", err)
+	}
+	if device.DeviceTypeID != deviceType.ID {
+		t.Fatalf("device is not bound to the type: %+v", device)
+	}
+	if device.DeviceTypeVersionID != version.ID {
+		t.Fatalf("expected a bind to the active version %s, got %s", version.ID, device.DeviceTypeVersionID)
+	}
+}
+
+// Acceptance criterion 3: every violation shape names its field.
+func TestDeviceBoundToDeviceTypeRejectsViolatingAttributes(t *testing.T) {
+	cases := []struct {
+		name       string
+		attributes Attributes
+		wantField  string
+		constraint string
+	}{
+		{
+			name:       "wrong type",
+			attributes: Attributes{"volume": "quite a lot"},
+			wantField:  "volume",
+			constraint: "type",
+		},
+		{
+			name:       "missing required",
+			attributes: Attributes{"battery": 90},
+			wantField:  "volume",
+			constraint: "required",
+		},
+		{
+			name:       "out of range",
+			attributes: Attributes{"volume": 12.5, "battery": 140},
+			wantField:  "battery",
+			constraint: "maximum",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, client := newFakeAtomDeviceTypes(t)
+			deviceType, _ := createWatermeterType(t, client)
+
+			_, err := client.CreateEntity(context.Background(), Entity{
+				Kind:         atomKindDevice,
+				Name:         "meter-1",
+				TenantID:     testTenantID,
+				DeviceTypeID: deviceType.ID,
+				Attributes:   tc.attributes,
+			})
+			if err == nil {
+				t.Fatal("expected the write to be rejected")
+			}
+
+			schemaErr, ok := AsSchemaValidationError(err)
+			if !ok {
+				t.Fatalf("expected a typed schema error, got %T: %v", err, err)
+			}
+			if len(schemaErr.Violations) != 1 {
+				t.Fatalf("expected one violation, got %+v", schemaErr.Violations)
+			}
+			if got := schemaErr.Violations[0].Field; got != tc.wantField {
+				t.Fatalf("expected the error to name %q, got %q", tc.wantField, got)
+			}
+			if got := schemaErr.Violations[0].Constraint; got != tc.constraint {
+				t.Fatalf("expected constraint %q, got %q", tc.constraint, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantField) {
+				t.Fatalf("error text must name the field, got %q", err.Error())
+			}
+		})
+	}
+}
+
+// Acceptance criterion 4, as decided: Magistrala scopes device types to a
+// tenant and does not expose Atom's global ones, because Atom's only
+// alternative to "this tenant" is "every tenant".
+func TestListDeviceTypesIsAlwaysScopedToATenant(t *testing.T) {
+	fa, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	createWatermeterType(t, client)
+	fa.deviceTypes["global"] = &fakeDeviceType{
+		ID: "global", ObjectKind: atomObjectKindEntity, Kind: atomKindDevice,
+		Key: "global-sensor", Name: "Global sensor", Status: DeviceTypeStatusActive,
+	}
+	fa.deviceTypes["other-tenant"] = &fakeDeviceType{
+		ID: "other-tenant", TenantID: "tenant-2", ObjectKind: atomObjectKindEntity, Kind: atomKindDevice,
+		Key: "someone-elses", Name: "Someone else's", Status: DeviceTypeStatusActive,
+	}
+
+	list, err := client.ListDeviceTypes(ctx, DeviceTypeQuery{TenantID: testTenantID})
+	if err != nil {
+		t.Fatalf("list device types: %v", err)
+	}
+	if list.Total != 1 || len(list.Items) != 1 || list.Items[0].Key != "watermeter" {
+		t.Fatalf("expected only the tenant's own device types, got: %+v", list)
+	}
+
+	if len(fa.listQueries) != 1 {
+		t.Fatalf("expected one list query, got %d", len(fa.listQueries))
+	}
+	query := fa.listQueries[0]
+	if query["tenantId"] != testTenantID {
+		t.Fatalf("every listing must carry a tenant, got: %+v", query)
+	}
+	if query["objectKind"] != atomObjectKindEntity || query["kind"] != atomKindDevice {
+		t.Fatalf("listing must be narrowed to device types, got: %+v", query)
+	}
+
+	if _, err := client.ListDeviceTypes(ctx, DeviceTypeQuery{}); err == nil {
+		t.Fatal("expected a tenant-less listing to be refused")
+	}
+}
+
+// Acceptance criterion 5.
+func TestListEntitiesByDeviceTypeReturnsExactlyTheBoundDevices(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	watermeterType, _ := createWatermeterType(t, client)
+
+	probeType, err := client.CreateDeviceType(ctx, DeviceType{
+		TenantID: testTenantID, Key: "probe", Name: "Temperature probe",
+	})
+	if err != nil {
+		t.Fatalf("create device type: %v", err)
+	}
+	if _, err := client.CreateDeviceTypeVersion(ctx, probeType.ID, DeviceTypeVersion{
+		Capabilities: CapabilityDocument{Measurements: []Measurement{{Name: "temperature", Unit: "Cel"}}},
+	}); err != nil {
+		t.Fatalf("create device type version: %v", err)
+	}
+
+	bound := map[string]bool{}
+	for _, name := range []string{"meter-1", "meter-2"} {
+		device, err := client.CreateEntity(ctx, Entity{
+			Kind: atomKindDevice, Name: name, TenantID: testTenantID,
+			DeviceTypeID: watermeterType.ID,
+			Attributes:   Attributes{"volume": 1.0},
+		})
+		if err != nil {
+			t.Fatalf("create bound device: %v", err)
+		}
+		bound[device.ID] = true
+	}
+	if _, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "probe-1", TenantID: testTenantID,
+		DeviceTypeID: probeType.ID, Attributes: Attributes{"temperature": 21.0},
+	}); err != nil {
+		t.Fatalf("create bound device: %v", err)
+	}
+	if _, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "untyped-1", TenantID: testTenantID,
+	}); err != nil {
+		t.Fatalf("create untyped device: %v", err)
+	}
+
+	list, err := client.ListEntities(ctx, Query{DeviceTypeID: watermeterType.ID})
+	if err != nil {
+		t.Fatalf("list entities by device type: %v", err)
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("expected exactly the two bound devices, got: %+v", list.Items)
+	}
+	for _, item := range list.Items {
+		if !bound[item.ID] {
+			t.Fatalf("unexpected device in the listing: %+v", item)
+		}
+	}
+}
+
+// Acceptance criterion 6.
+func TestNewVersionLeavesDevicesOnTheOldVersionWorking(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, first := createWatermeterType(t, client)
+
+	device, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-1", TenantID: testTenantID,
+		DeviceTypeID: deviceType.ID,
+		Attributes:   Attributes{"volume": 12.5},
+	})
+	if err != nil {
+		t.Fatalf("create bound device: %v", err)
+	}
+
+	// Version 2 tightens the declaration: serial becomes mandatory.
+	second, err := client.CreateDeviceTypeVersion(ctx, deviceType.ID, DeviceTypeVersion{
+		Capabilities: CapabilityDocument{Measurements: []Measurement{
+			{Name: "volume", Unit: "m3", Required: true},
+			{Name: "serial", Type: ValueTypeString, Required: true},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create device type version: %v", err)
+	}
+	if second.Version != 2 {
+		t.Fatalf("expected version 2, got %d", second.Version)
+	}
+
+	// The deployed device is still on version 1 and still writable without the
+	// field version 2 added.
+	updated, err := client.UpdateEntity(ctx, device.ID, Entity{Attributes: Attributes{"volume": 13.5}})
+	if err != nil {
+		t.Fatalf("device on version 1 must keep working: %v", err)
+	}
+	if updated.DeviceTypeVersionID != first.ID {
+		t.Fatalf("device must stay on version 1, got %s", updated.DeviceTypeVersionID)
+	}
+
+	// New devices land on version 2, which does enforce the new field.
+	if _, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-2", TenantID: testTenantID,
+		DeviceTypeID: deviceType.ID, Attributes: Attributes{"volume": 1.0},
+	}); err == nil {
+		t.Fatal("expected version 2 to reject a device missing its new required field")
+	}
+}
+
+// Acceptance criterion 7, at the device type level — the only deprecation Atom
+// enforces server-side.
+func TestDeprecatedDeviceTypeBlocksNewBindingsAndLeavesExistingIntact(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, _ := createWatermeterType(t, client)
+	device, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-1", TenantID: testTenantID,
+		DeviceTypeID: deviceType.ID, Attributes: Attributes{"volume": 12.5},
+	})
+	if err != nil {
+		t.Fatalf("create bound device: %v", err)
+	}
+
+	if _, err := client.UpdateDeviceType(ctx, deviceType.ID, DeviceType{Status: DeviceTypeStatusDeprecated}); err != nil {
+		t.Fatalf("deprecate device type: %v", err)
+	}
+
+	if _, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-2", TenantID: testTenantID,
+		DeviceTypeID: deviceType.ID, Attributes: Attributes{"volume": 1.0},
+	}); err == nil {
+		t.Fatal("expected a deprecated device type to refuse new bindings")
+	}
+
+	existing, err := client.GetEntity(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("existing device must remain readable: %v", err)
+	}
+	if existing.DeviceTypeID != deviceType.ID {
+		t.Fatalf("existing binding must be untouched, got: %+v", existing)
+	}
+	if _, err := client.UpdateEntity(ctx, device.ID, Entity{Attributes: Attributes{"volume": 14.0}}); err != nil {
+		t.Fatalf("existing device must remain writable: %v", err)
+	}
+}
+
+// Acceptance criterion 7, at the version level. Atom binds a caller-named
+// version whatever its status, so without this check a non-active version
+// would still accept new devices.
+func TestBindDeviceTypeRefusesNonActiveVersion(t *testing.T) {
+	fa, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, first := createWatermeterType(t, client)
+	staged, err := client.CreateDeviceTypeVersion(ctx, deviceType.ID, DeviceTypeVersion{
+		Status:       DeviceTypeVersionStatusDeprecated,
+		Capabilities: watermeter(),
+	})
+	if err != nil {
+		t.Fatalf("create device type version: %v", err)
+	}
+
+	device, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-1", TenantID: testTenantID,
+		Attributes: Attributes{"volume": 12.5},
+	})
+	if err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	if _, err := client.BindDeviceType(ctx, device.ID, deviceType.ID, staged.ID); !errors.Is(err, ErrDeviceTypeVersionNotBindable) {
+		t.Fatalf("expected ErrDeviceTypeVersionNotBindable, got %v", err)
+	}
+	if fa.entities[device.ID].DeviceTypeID != "" {
+		t.Fatalf("a refused bind must not write: %+v", fa.entities[device.ID])
+	}
+
+	bound, err := client.BindDeviceType(ctx, device.ID, deviceType.ID, first.ID)
+	if err != nil {
+		t.Fatalf("binding to the active version must succeed: %v", err)
+	}
+	if bound.DeviceTypeVersionID != first.ID {
+		t.Fatalf("expected a bind to version 1, got %s", bound.DeviceTypeVersionID)
+	}
+}
+
+func TestBindDeviceTypeRefusesNonActiveDeviceType(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, version := createWatermeterType(t, client)
+	device, err := client.CreateEntity(ctx, Entity{Kind: atomKindDevice, Name: "meter-1", TenantID: testTenantID})
+	if err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+	if _, err := client.UpdateDeviceType(ctx, deviceType.ID, DeviceType{Status: DeviceTypeStatusDisabled}); err != nil {
+		t.Fatalf("disable device type: %v", err)
+	}
+
+	if _, err := client.BindDeviceType(ctx, device.ID, deviceType.ID, version.ID); !errors.Is(err, ErrDeviceTypeNotBindable) {
+		t.Fatalf("expected ErrDeviceTypeNotBindable, got %v", err)
+	}
+}
+
+func TestActiveDeviceTypeVersionPicksTheHighestActive(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, first := createWatermeterType(t, client)
+
+	// A staged draft must not become the binding target.
+	if _, err := client.CreateDeviceTypeVersion(ctx, deviceType.ID, DeviceTypeVersion{
+		Status: DeviceTypeVersionStatusDraft, Capabilities: watermeter(),
+	}); err != nil {
+		t.Fatalf("create draft version: %v", err)
+	}
+
+	active, err := client.ActiveDeviceTypeVersion(ctx, deviceType.ID)
+	if err != nil {
+		t.Fatalf("active device type version: %v", err)
+	}
+	if active.ID != first.ID {
+		t.Fatalf("expected version 1 to remain active, got %+v", active)
+	}
+
+	third, err := client.CreateDeviceTypeVersion(ctx, deviceType.ID, DeviceTypeVersion{Capabilities: watermeter()})
+	if err != nil {
+		t.Fatalf("create device type version: %v", err)
+	}
+	if third.Version != 3 {
+		t.Fatalf("expected version 3, got %d", third.Version)
+	}
+
+	active, err = client.ActiveDeviceTypeVersion(ctx, deviceType.ID)
+	if err != nil {
+		t.Fatalf("active device type version: %v", err)
+	}
+	if active.ID != third.ID {
+		t.Fatalf("expected the newest active version, got %+v", active)
+	}
+}
+
+func TestCreateDeviceTypeRequiresTenantAndKey(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDeviceType(ctx, DeviceType{Key: "watermeter", Name: "Watermeter"}); err == nil {
+		t.Fatal("expected a tenant-less device type to be refused")
+	}
+	if _, err := client.CreateDeviceType(ctx, DeviceType{TenantID: testTenantID, Name: "Watermeter"}); err == nil {
+		t.Fatal("expected a keyless device type to be refused")
+	}
+}
+
+// Binding is schema validation, not default-value injection: it must not
+// invent attributes the caller did not write.
+func TestBindingDoesNotPopulateAttributes(t *testing.T) {
+	_, client := newFakeAtomDeviceTypes(t)
+	ctx := context.Background()
+
+	deviceType, _ := createWatermeterType(t, client)
+	device, err := client.CreateEntity(ctx, Entity{
+		Kind: atomKindDevice, Name: "meter-1", TenantID: testTenantID,
+		DeviceTypeID: deviceType.ID,
+		Attributes:   Attributes{"volume": 12.5},
+	})
+	if err != nil {
+		t.Fatalf("create bound device: %v", err)
+	}
+	if _, invented := device.Attributes["battery"]; invented {
+		t.Fatalf("binding must not populate declared-but-unwritten attributes: %+v", device.Attributes)
+	}
+	if len(device.Attributes) != 1 {
+		t.Fatalf("expected only the attributes written, got: %+v", device.Attributes)
+	}
+}

--- a/pkg/atom/schema_error.go
+++ b/pkg/atom/schema_error.go
@@ -1,0 +1,257 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// atomSchemaValidationPrefix is what Atom puts in front of the validator's own
+// output when a device's attributes fail its device type schema
+// (src/schema.rs). Everything after it is the raw jsonschema crate messages,
+// joined with "; ".
+const atomSchemaValidationPrefix = "attributes failed profile schema validation: "
+
+// SchemaViolation is one field-level reason a device's attributes were
+// rejected.
+//
+// Field is best effort. The validator names the property directly for missing
+// and unexpected properties, but for every other failure it reports only the
+// offending *value* — so the field is recovered by matching that value against
+// the attributes that were submitted, and is left empty when that is ambiguous.
+type SchemaViolation struct {
+	Field      string `json:"field,omitempty"`
+	Constraint string `json:"constraint,omitempty"`
+	Expected   string `json:"expected,omitempty"`
+	Message    string `json:"message"`
+}
+
+func (v SchemaViolation) String() string {
+	if v.Field == "" {
+		return v.Message
+	}
+	return v.Field + ": " + v.Message
+}
+
+// SchemaValidationError is a device type schema rejection, translated from the
+// validator output Atom returns verbatim. Untranslated, an operator creating a
+// device sees a bare validator string with no indication of which attribute
+// was wrong.
+//
+// It wraps the underlying atom Error, so IsConflict, IsNotFound and errors.As
+// on Error keep working.
+type SchemaValidationError struct {
+	Violations []SchemaViolation
+	err        error
+}
+
+func (e *SchemaValidationError) Error() string {
+	parts := make([]string, 0, len(e.Violations))
+	for _, violation := range e.Violations {
+		parts = append(parts, violation.String())
+	}
+	if len(parts) == 0 {
+		return "atom: attributes rejected by the device type schema"
+	}
+	return "atom: attributes rejected by the device type schema: " + strings.Join(parts, "; ")
+}
+
+func (e *SchemaValidationError) Unwrap() error { return e.err }
+
+// Fields lists the attributes the violations name, in order and without
+// duplicates.
+func (e *SchemaValidationError) Fields() []string {
+	var fields []string
+	seen := map[string]struct{}{}
+	for _, violation := range e.Violations {
+		if violation.Field == "" {
+			continue
+		}
+		if _, duplicate := seen[violation.Field]; duplicate {
+			continue
+		}
+		seen[violation.Field] = struct{}{}
+		fields = append(fields, violation.Field)
+	}
+	return fields
+}
+
+// AsSchemaValidationError reports whether err is a device type schema
+// rejection, and if so returns it.
+func AsSchemaValidationError(err error) (*SchemaValidationError, bool) {
+	var schemaErr *SchemaValidationError
+	if errors.As(err, &schemaErr) {
+		return schemaErr, true
+	}
+	return nil, false
+}
+
+// violationPattern maps one jsonschema crate message shape to a constraint.
+// The crate's Display output never includes the instance path, so patterns
+// either capture the property name directly (field) or the offending value
+// (instance), which is then matched back to an attribute.
+type violationPattern struct {
+	constraint string
+	re         *regexp.Regexp
+	field      int
+	instance   int
+	expected   int
+}
+
+// Ordered longest-match-first: "is not of types" must be tried before "is not
+// of type", which would otherwise match it and capture nonsense.
+var violationPatterns = []violationPattern{
+	{constraint: "required", re: regexp.MustCompile(`^(.+) is a required property$`), field: 1},
+	{constraint: "additionalProperties", re: regexp.MustCompile(`^Additional properties are not allowed \((.+) (?:was|were) unexpected\)$`), field: 1},
+	{constraint: "unevaluatedProperties", re: regexp.MustCompile(`^Unevaluated properties are not allowed \((.+) (?:was|were) unexpected\)$`), field: 1},
+	{constraint: "type", re: regexp.MustCompile(`^(.+) is not of types (.+)$`), instance: 1, expected: 2},
+	{constraint: "type", re: regexp.MustCompile(`^(.+) is not of type (.+)$`), instance: 1, expected: 2},
+	{constraint: "exclusiveMaximum", re: regexp.MustCompile(`^(.+) is greater than or equal to the maximum of (.+)$`), instance: 1, expected: 2},
+	{constraint: "exclusiveMinimum", re: regexp.MustCompile(`^(.+) is less than or equal to the minimum of (.+)$`), instance: 1, expected: 2},
+	{constraint: "maximum", re: regexp.MustCompile(`^(.+) is greater than the maximum of (.+)$`), instance: 1, expected: 2},
+	{constraint: "minimum", re: regexp.MustCompile(`^(.+) is less than the minimum of (.+)$`), instance: 1, expected: 2},
+	{constraint: "maxLength", re: regexp.MustCompile(`^(.+) is longer than (\d+) characters?$`), instance: 1, expected: 2},
+	{constraint: "minLength", re: regexp.MustCompile(`^(.+) is shorter than (\d+) characters?$`), instance: 1, expected: 2},
+	{constraint: "maxItems", re: regexp.MustCompile(`^(.+) has more than (\d+) items?$`), instance: 1, expected: 2},
+	{constraint: "minItems", re: regexp.MustCompile(`^(.+) has less than (\d+) items?$`), instance: 1, expected: 2},
+	{constraint: "enum", re: regexp.MustCompile(`^(.+) is not one of (.+)$`), instance: 1, expected: 2},
+	{constraint: "pattern", re: regexp.MustCompile(`^(.+) does not match (".+")$`), instance: 1, expected: 2},
+	{constraint: "multipleOf", re: regexp.MustCompile(`^(.+) is not a multiple of (.+)$`), instance: 1, expected: 2},
+	{constraint: "uniqueItems", re: regexp.MustCompile(`^(.+) has non-unique elements$`), instance: 1},
+}
+
+// translateSchemaError turns Atom's schema rejection into a
+// SchemaValidationError naming the offending fields. Anything else is returned
+// unchanged, so no other error path behaves differently.
+func translateSchemaError(err error, attributes Attributes) error {
+	if err == nil {
+		return nil
+	}
+	var atomErr Error
+	if !errors.As(err, &atomErr) {
+		return err
+	}
+	index := strings.Index(atomErr.Message, atomSchemaValidationPrefix)
+	if index < 0 {
+		return err
+	}
+
+	detail := atomErr.Message[index+len(atomSchemaValidationPrefix):]
+	// The validator's own messages never contain "; " — lists inside them are
+	// comma separated — so this splits exactly on Atom's join.
+	messages := strings.Split(detail, "; ")
+
+	violations := make([]SchemaViolation, 0, len(messages))
+	for _, message := range messages {
+		message = strings.TrimSpace(message)
+		if message == "" {
+			continue
+		}
+		violations = append(violations, parseViolations(message, attributes)...)
+	}
+	if len(violations) == 0 {
+		return err
+	}
+
+	return &SchemaValidationError{Violations: violations, err: err}
+}
+
+func parseViolations(message string, attributes Attributes) []SchemaViolation {
+	for _, pattern := range violationPatterns {
+		match := pattern.re.FindStringSubmatch(message)
+		if match == nil {
+			continue
+		}
+
+		expected := ""
+		if pattern.expected > 0 {
+			expected = unquote(match[pattern.expected])
+		}
+
+		// One message can name several unexpected properties; each is its own
+		// violation so a caller can report them per field.
+		if pattern.field > 0 {
+			names := strings.Split(match[pattern.field], ", ")
+			violations := make([]SchemaViolation, 0, len(names))
+			for _, name := range names {
+				violations = append(violations, SchemaViolation{
+					Field:      unquote(name),
+					Constraint: pattern.constraint,
+					Expected:   expected,
+					Message:    message,
+				})
+			}
+			return violations
+		}
+
+		violation := SchemaViolation{Constraint: pattern.constraint, Expected: expected, Message: message}
+		if pattern.instance > 0 {
+			violation.Field = fieldForInstance(attributes, match[pattern.instance])
+		}
+		return []SchemaViolation{violation}
+	}
+
+	return []SchemaViolation{{Message: message}}
+}
+
+// fieldForInstance finds which submitted attribute held the value the
+// validator rejected. It answers only when exactly one attribute matches:
+// naming the wrong field is worse than naming none.
+func fieldForInstance(attributes Attributes, instance string) string {
+	if len(attributes) == 0 {
+		return ""
+	}
+	wantNumber, wantIsNumber := parseFloat(instance)
+
+	var field string
+	matches := 0
+	for name, value := range attributes {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		if string(encoded) != instance {
+			// Rust renders a whole-numbered float as "5.0" where Go encodes it
+			// as "5", so numbers are also compared by value.
+			gotNumber, gotIsNumber := parseFloat(string(encoded))
+			if !wantIsNumber || !gotIsNumber || gotNumber != wantNumber {
+				continue
+			}
+		}
+		field = name
+		matches++
+	}
+	if matches == 1 {
+		return field
+	}
+	return ""
+}
+
+func parseFloat(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(s, 64)
+	return f, err == nil
+}
+
+// unquote strips the quoting the validator puts around a single token. A
+// capture holding several quoted tokens — a list of accepted types, say — is
+// left exactly as it came, since it is not one name.
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return s
+	}
+	switch {
+	case s[0] == '\'' && s[len(s)-1] == '\'':
+		return s[1 : len(s)-1]
+	case s[0] == '"' && s[len(s)-1] == '"':
+		if unquoted, err := strconv.Unquote(s); err == nil {
+			return unquoted
+		}
+	}
+	return s
+}

--- a/pkg/atom/schema_error_test.go
+++ b/pkg/atom/schema_error_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// atomSchemaError builds the error Atom returns for a schema rejection: the
+// validator's own messages, joined, behind Atom's prefix.
+func atomSchemaError(messages ...string) error {
+	return Error{
+		StatusCode: http.StatusBadRequest,
+		Message:    atomSchemaValidationPrefix + strings.Join(messages, "; "),
+	}
+}
+
+func TestTranslateSchemaErrorNamesTheOffendingField(t *testing.T) {
+	cases := []struct {
+		name       string
+		message    string
+		attributes Attributes
+		want       SchemaViolation
+	}{
+		{
+			name:    "missing required property",
+			message: `"volume" is a required property`,
+			want:    SchemaViolation{Field: "volume", Constraint: "required"},
+		},
+		{
+			name:       "wrong type",
+			message:    `"many" is not of type "number"`,
+			attributes: Attributes{"volume": "many", "battery": 80},
+			want:       SchemaViolation{Field: "volume", Constraint: "type", Expected: "number"},
+		},
+		{
+			name:       "out of range above maximum",
+			message:    `120 is greater than the maximum of 100`,
+			attributes: Attributes{"battery": 120, "volume": 3.5},
+			want:       SchemaViolation{Field: "battery", Constraint: "maximum", Expected: "100"},
+		},
+		{
+			name:       "out of range below minimum",
+			message:    `5 is less than the minimum of 30`,
+			attributes: Attributes{"interval": 5},
+			want:       SchemaViolation{Field: "interval", Constraint: "minimum", Expected: "30"},
+		},
+		{
+			name:       "not one of the declared states",
+			message:    `"sideways" is not one of ["open","closed"]`,
+			attributes: Attributes{"position": "sideways"},
+			want:       SchemaViolation{Field: "position", Constraint: "enum", Expected: `["open","closed"]`},
+		},
+		{
+			name:       "exclusive maximum",
+			message:    `100 is greater than or equal to the maximum of 100`,
+			attributes: Attributes{"duty": 100},
+			want:       SchemaViolation{Field: "duty", Constraint: "exclusiveMaximum", Expected: "100"},
+		},
+		{
+			name:       "string too long",
+			message:    `"abcdefghijk" is longer than 8 characters`,
+			attributes: Attributes{"firmware": "abcdefghijk"},
+			want:       SchemaViolation{Field: "firmware", Constraint: "maxLength", Expected: "8"},
+		},
+		{
+			name:    "unexpected property",
+			message: `Additional properties are not allowed ('flow' was unexpected)`,
+			want:    SchemaViolation{Field: "flow", Constraint: "additionalProperties"},
+		},
+		{
+			name:       "multiple type names",
+			message:    `true is not of types "integer", "number"`,
+			attributes: Attributes{"volume": true},
+			want:       SchemaViolation{Field: "volume", Constraint: "type", Expected: `"integer", "number"`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := translateSchemaError(atomSchemaError(tc.message), tc.attributes)
+
+			schemaErr, ok := AsSchemaValidationError(err)
+			if !ok {
+				t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+			}
+			if len(schemaErr.Violations) != 1 {
+				t.Fatalf("expected one violation, got %+v", schemaErr.Violations)
+			}
+
+			got := schemaErr.Violations[0]
+			if got.Message != tc.message {
+				t.Fatalf("violation must keep Atom's own message, got %q", got.Message)
+			}
+			got.Message = ""
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unexpected violation:\n got: %+v\nwant: %+v", got, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want.Field) {
+				t.Fatalf("error text must name the field, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestTranslateSchemaErrorSplitsEveryViolation(t *testing.T) {
+	err := translateSchemaError(atomSchemaError(
+		`"volume" is a required property`,
+		`"warm" is not of type "number"`,
+		`150 is greater than the maximum of 100`,
+	), Attributes{"setpoint": "warm", "battery": 150})
+
+	schemaErr, ok := AsSchemaValidationError(err)
+	if !ok {
+		t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+	}
+	if got, want := len(schemaErr.Violations), 3; got != want {
+		t.Fatalf("expected %d violations, got %d: %+v", want, got, schemaErr.Violations)
+	}
+	if got, want := schemaErr.Fields(), []string{"volume", "setpoint", "battery"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected fields: got %+v, want %+v", got, want)
+	}
+}
+
+func TestTranslateSchemaErrorReportsEveryUnexpectedProperty(t *testing.T) {
+	err := translateSchemaError(atomSchemaError(
+		`Additional properties are not allowed ('flow', 'pressure' were unexpected)`,
+	), nil)
+
+	schemaErr, ok := AsSchemaValidationError(err)
+	if !ok {
+		t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+	}
+	if got, want := schemaErr.Fields(), []string{"flow", "pressure"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected fields: got %+v, want %+v", got, want)
+	}
+}
+
+// Naming the wrong attribute is worse than naming none, so an ambiguous value
+// yields a violation with no field rather than a guess.
+func TestTranslateSchemaErrorLeavesAmbiguousFieldUnnamed(t *testing.T) {
+	err := translateSchemaError(
+		atomSchemaError(`"warm" is not of type "number"`),
+		Attributes{"setpoint": "warm", "fallback": "warm"},
+	)
+
+	schemaErr, ok := AsSchemaValidationError(err)
+	if !ok {
+		t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+	}
+	if got := schemaErr.Violations[0].Field; got != "" {
+		t.Fatalf("expected no field for an ambiguous value, got %q", got)
+	}
+	if got := schemaErr.Violations[0].Constraint; got != "type" {
+		t.Fatalf("constraint must survive even without a field, got %q", got)
+	}
+}
+
+// Rust renders a whole float as 5.0 where Go encodes it as 5.
+func TestTranslateSchemaErrorMatchesNumbersByValue(t *testing.T) {
+	err := translateSchemaError(
+		atomSchemaError(`5.0 is less than the minimum of 30`),
+		Attributes{"interval": float64(5)},
+	)
+
+	schemaErr, ok := AsSchemaValidationError(err)
+	if !ok {
+		t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+	}
+	if got := schemaErr.Violations[0].Field; got != "interval" {
+		t.Fatalf("expected the numeric attribute to be matched, got %q", got)
+	}
+}
+
+// An unrecognised validator message still becomes a typed error carrying the
+// original text, rather than being dropped back to a raw GraphQL error.
+func TestTranslateSchemaErrorKeepsUnrecognisedMessages(t *testing.T) {
+	err := translateSchemaError(atomSchemaError(`something the validator invented`), nil)
+
+	schemaErr, ok := AsSchemaValidationError(err)
+	if !ok {
+		t.Fatalf("expected a schema validation error, got %T: %v", err, err)
+	}
+	if got := schemaErr.Violations[0].Message; got != "something the validator invented" {
+		t.Fatalf("unexpected message: %q", got)
+	}
+}
+
+func TestTranslateSchemaErrorLeavesOtherErrorsAlone(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"not found", Error{StatusCode: http.StatusNotFound, Message: "entity not found"}},
+		{"conflict", Error{StatusCode: http.StatusConflict, Message: "already exists"}},
+		{"non atom error", errors.New("dial tcp: connection refused")},
+		{"nil", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateSchemaError(tc.err, nil)
+			if !errors.Is(got, tc.err) {
+				t.Fatalf("expected the original error back, got %v", got)
+			}
+			if _, isSchema := AsSchemaValidationError(got); isSchema {
+				t.Fatal("must not be reported as a schema violation")
+			}
+		})
+	}
+}
+
+// The translated error wraps Atom's, so status-based checks keep working.
+func TestSchemaValidationErrorWrapsAtomError(t *testing.T) {
+	err := translateSchemaError(atomSchemaError(`"volume" is a required property`), nil)
+
+	var atomErr Error
+	if !errors.As(err, &atomErr) {
+		t.Fatalf("expected the atom error to remain reachable, got %T", err)
+	}
+	if atomErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", atomErr.StatusCode)
+	}
+	if IsNotFound(err) || IsConflict(err) {
+		t.Fatal("a schema rejection is neither a conflict nor a not-found")
+	}
+}

--- a/pkg/atom/types.go
+++ b/pkg/atom/types.go
@@ -21,14 +21,120 @@ type Tenant struct {
 }
 
 type Entity struct {
-	ID         string     `json:"id,omitempty"`
-	Kind       string     `json:"kind"`
-	Name       string     `json:"name"`
-	TenantID   string     `json:"tenant_id,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// DeviceTypeID and DeviceTypeVersionID bind the entity to a device type.
+	// With a device type bound, Atom validates Attributes against that
+	// version's schema on every write. Leaving DeviceTypeVersionID empty binds
+	// to the type's highest-numbered active version.
+	//
+	// Both are write-once-per-call in the sense that Atom coalesces them: an
+	// update that leaves them empty keeps the existing binding rather than
+	// clearing it. There is no way to unbind a device through Atom's API.
+	DeviceTypeID        string `json:"device_type_id,omitempty"`
+	DeviceTypeVersionID string `json:"device_type_version_id,omitempty"`
+
 	Status     string     `json:"status,omitempty"`
 	Attributes Attributes `json:"attributes,omitempty"`
 	CreatedAt  time.Time  `json:"created_at,omitempty"`
 	UpdatedAt  time.Time  `json:"updated_at,omitempty"`
+}
+
+// Measurement is one value a device of a given type reports.
+//
+// Rendered into the device type's JSON Schema, a measurement constrains the
+// device's *attributes*, not its telemetry — see BuildCapabilitySchema.
+type Measurement struct {
+	Name string `json:"name"`
+	Unit string `json:"unit,omitempty"`
+
+	// Access is "r" (default) or "rw". Advisory only: it renders to JSON
+	// Schema's readOnly annotation, which Atom's validator records but does
+	// not enforce.
+	Access string `json:"access,omitempty"`
+
+	// Type is a ValueType* constant, defaulting to ValueTypeNumber.
+	Type     string   `json:"type,omitempty"`
+	Required bool     `json:"required,omitempty"`
+	Min      *float64 `json:"min,omitempty"`
+	Max      *float64 `json:"max,omitempty"`
+	Enum     []string `json:"enum,omitempty"`
+}
+
+// Command is one instruction a device of a given type accepts. Declaring a
+// command does not route it: dispatch is unspecified and out of scope.
+type Command struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+
+	// Params maps parameter name to a ValueType* constant.
+	Params map[string]string `json:"params,omitempty"`
+}
+
+// CapabilityDocument is what a device type declares, in the terms callers
+// think in, so nobody hand-writes JSON Schema. BuildCapabilitySchema renders
+// it for storage and ParseCapabilityDocument reads it back.
+type CapabilityDocument struct {
+	Measurements []Measurement `json:"measurements,omitempty"`
+	Commands     []Command     `json:"commands,omitempty"`
+}
+
+// DeviceType is a named, versioned declaration of what a class of device
+// measures and accepts. Devices bind to a specific version of one.
+//
+// It maps to an Atom Profile with object_kind "entity" and kind "device". The
+// Atom-side name is never exposed here: "profile" collides with Bootstrap's
+// unrelated Profile, so this concept is Device Type on every Magistrala
+// surface.
+type DeviceType struct {
+	ID       string `json:"id,omitempty"`
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// Key identifies the type within a tenant and cannot be changed after
+	// creation.
+	Key         string    `json:"key"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+}
+
+// DeviceTypeVersion is one immutable revision of a device type's capability
+// document. Devices stay bound to the version they were created against, so a
+// new version never invalidates deployed devices.
+type DeviceTypeVersion struct {
+	ID           string `json:"id,omitempty"`
+	DeviceTypeID string `json:"device_type_id,omitempty"`
+	Version      int    `json:"version"`
+	Status       string `json:"status,omitempty"`
+
+	// Capabilities is the declaration, filled in on read.
+	Capabilities CapabilityDocument `json:"capabilities"`
+
+	// JSONSchema and UISchema are what Atom stores and validates against.
+	// They are exposed for advanced use; Capabilities is the documented path.
+	JSONSchema map[string]any `json:"json_schema,omitempty"`
+	UISchema   map[string]any `json:"ui_schema,omitempty"`
+
+	CreatedAt time.Time `json:"created_at,omitempty"`
+}
+
+type DeviceTypeList struct {
+	Items []DeviceType `json:"items"`
+	Total uint64       `json:"total"`
+}
+
+// DeviceTypeQuery filters a device type listing. TenantID is required: see
+// ListDeviceTypes for why global types are not exposed.
+type DeviceTypeQuery struct {
+	TenantID string
+	Status   string
+	Limit    uint64
+	Offset   uint64
 }
 
 type Group struct {
@@ -65,6 +171,10 @@ type Query struct {
 	Status   string
 	Limit    uint64
 	Offset   uint64
+
+	// DeviceTypeID restricts an entity listing to devices bound to one device
+	// type, across all of its versions.
+	DeviceTypeID string
 
 	// AttributesContains filters by JSONB containment — an entity must contain
 	// every key/value given here (array values match by containment, not equality).

--- a/pkg/permissions/config_test.go
+++ b/pkg/permissions/config_test.go
@@ -42,6 +42,28 @@ func TestDevicesEntityReplacesClients(t *testing.T) {
 	}
 }
 
+func TestDeviceTypesEntityBlock(t *testing.T) {
+	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
+	require.NoError(t, err)
+
+	ops, _, err := cfg.GetEntityPermissions("device_types")
+	require.NoError(t, err)
+
+	for _, op := range []string{"create", "view", "list", "update", "list_versions"} {
+		_, ok := ops[op]
+		require.True(t, ok, "device_types block must declare %s", op)
+	}
+
+	// Publishing a version is separately grantable from renaming the type.
+	perm, ok := ops["create_version"]
+	require.True(t, ok, "device_types block must declare create_version")
+	require.Equal(t, permissions.Permission("create_version_permission"), perm)
+
+	// Atom has no deleteProfile mutation — a type is retired, never deleted.
+	_, ok = ops["delete"]
+	require.False(t, ok, "device_types must not declare delete")
+}
+
 func TestNoGatewaysEntityBlock(t *testing.T) {
 	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Implements [MG-02](edge/prd/MG-02-device-type-client.md), the `pkg/atom` half of device types. A watermeter and a temperature probe are currently both an opaque `Client` with a free-form metadata map; Atom already implements exactly the missing concept (as `Profile`/`ProfileVersion`) and this package did not call any of it.

A **device type** is a named, versioned declaration of what a class of device measures and accepts. It maps to an Atom Profile with `object_kind = "entity"`, `kind = "device"`, and devices bind to a specific *version* of one. No Atom-side change was needed.

Naming: this is **Device Type** on every Magistrala-facing surface. Atom's `profile` appears only inside the GraphQL field names Atom requires (`createProfile`, `profileVersions`, `profileId`), aliased back to device-type names on the way out. Bootstrap's unrelated `Profile` from #3555 makes the collision a live hazard, so nothing above this package sees the word.

## Scope

- **`pkg/atom/types.go`** — `DeviceType`, `DeviceTypeVersion`, `Measurement`, `Command`, `CapabilityDocument`, `DeviceTypeList`, `DeviceTypeQuery`. `Entity` gains `DeviceTypeID`/`DeviceTypeVersionID`; `Query` gains `DeviceTypeID`.
- **`pkg/atom/device_types.go`** — the six methods the PRD lists (create, get, list, update, create-version, list-versions), plus `ActiveDeviceTypeVersion` and `BindDeviceType` (see judgement calls).
- **`pkg/atom/capability.go`** — `BuildCapabilitySchema` / `ParseCapabilityDocument`. Measurements and commands render to `json_schema` + `ui_schema` and read back, so no caller hand-writes or hand-parses JSON Schema.
- **`pkg/atom/schema_error.go`** — translates Atom's schema rejection into a typed `SchemaValidationError` carrying field, constraint and expected value.
- **`pkg/atom/client.go`** — entity create/update carry `profileId`/`profileVersionId`; `ListEntities` gains the `profileId` filter; the entity field selection is a shared constant so it cannot drift between callers; `IsConflict`/`IsNotFound` now use `errors.As` so they still answer through a wrapping error.

**Out of scope** per the PRD: HTTP/SDK/CLI surface (MG-10, stacked on this branch), command dispatch, migrating existing clients onto types, and attribute-default population on bind — binding is schema *validation* only, and there is a test asserting a bind invents no attributes.

## Design decisions

**The capability document lives in `ui_schema`, not `json_schema`.** Atom compiles `json_schema` with the `jsonschema` crate on every entity write, so a custom keyword there is a validator's problem; `ui_schema` is never compiled. `json_schema` therefore stays a pure validation schema, and `ParseCapabilityDocument` reads the declaration from `ui_schema` for an exact round trip, falling back to reconstructing measurements structurally from `json_schema` when a version's schema was written by hand.

**Generated schemas never set `additionalProperties: false`.** A Magistrala device carries housekeeping attributes no device type declares (`source`, `tags`, `metadata`, `gateways`, timestamps — see `EntityFromFields`). Closing the schema would reject every device write. There is a regression test for this.

**Measurements constrain metadata, not telemetry.** Atom validates entity *attributes* on write; messages never reach Atom. A declared measurement is therefore an attribute contract, documented as such on `BuildCapabilitySchema`. MG-10 surfaces this on the API.

**`Measurement` is wider than the PRD sketch.** The PRD's `Name`/`Unit`/`Access` cannot express any of the violation shapes the acceptance criteria ask for, so it also carries `Type`, `Required`, `Min`, `Max` and `Enum`. Per the PRD's expressiveness risk, the model is exercised against three device types beyond the watermeter — a multi-channel energy meter, a valve with enumerated states, and a concentrator that also meters — asserting each round-trips and that re-rendering a parsed declaration is idempotent. Nested structures still do not fit; the structural fallback skips them rather than failing.

## Judgement calls

1. **Global device types are not exposed.** The PRD left this open. Atom's `profiles` query filters on "this tenant" or nothing at all, and nothing at all returns *every* tenant's types — there is no "tenant plus global" filter, and a domain-scoped caller could not list globals anyway. So `CreateDeviceType` and `ListDeviceTypes` both require a tenant and say so, and a tenant-less listing is refused rather than silently crossing tenants.

2. **`CreateDeviceType` creates the type only.** Atom has no `deleteProfile`, so a combined create-type-and-version could not roll back a half-built type. Version 1 is a separate `CreateDeviceTypeVersion` call.

3. **Two methods beyond the PRD's six.** `ActiveDeviceTypeVersion` mirrors Atom's own selection rule (highest-numbered active version) and `BindDeviceType` is the bind path, which needs to exist for the next point and for MG-10.

## Findings about Atom worth knowing

These are all Atom behaviours, not changes made here. Each is reproduced faithfully in the test double and commented at the call site.

- **Atom has no `updateProfileVersion` mutation.** A version's status is fixed at creation. So "deprecate version 1" is not expressible server-side: the available mechanisms are deprecating the whole device type (`updateProfile(status:)`, which Atom does enforce against new bindings) and creating a version as `draft`/`deprecated` up front. Acceptance criterion 7 is covered at both levels, but it is worth knowing that version-level deprecation of an *already published* version needs an Atom change.
- **Atom does not status-check a caller-named version on bind.** With no version named it picks the highest active one and errors if there is none; with one named it binds it whatever its status. `BindDeviceType` checks first and returns `ErrDeviceTypeVersionNotBindable`, which is what actually makes a non-active version unbindable.
- **`updateEntity` validates against the *previously* bound version.** The schema is looked up by the entity's stored `profile_version_id`, so a call that changes the binding and the attributes together validates the new attributes against the old schema. Documented on `BindDeviceType`; the first write after a bind is what the new schema sees.
- **The validator's messages carry no instance path.** `jsonschema` 0.18's `Display` gives `"abc" is not of type "number"` with no field name — only `required` and `additionalProperties` name a property directly. For everything else the field is recovered by matching the rejected value against the attributes that were submitted, and is left unset when that is ambiguous, since naming the wrong field is worse than naming none.

## Open question for MG-10

Whether binding a type should auto-populate default attributes. MG-02 scopes binding as validation only and this PR does not populate anything; flagging it here so it is decided rather than falling out of the API design.

## Test plan

All seven acceptance criteria are covered by tests against an in-memory Atom stand-in that reproduces the real resolution rules above (`pkg/atom/device_types_test.go`), including a small JSON Schema validator worded exactly as the `jsonschema` crate words it, so the error translation is exercised against realistic input rather than hand-written strings.

- **AC1** capability document survives create-version → list-versions intact, commands included.
- **AC2** device bound to a type with conforming attributes succeeds and lands on the active version.
- **AC3** wrong type, missing required and out-of-range are each rejected with a typed error naming the field and constraint.
- **AC4** listing is tenant-scoped: another tenant's and a global type are both excluded, every listing carries `tenantId`, and a tenant-less listing is refused.
- **AC5** `ListEntities(DeviceTypeID:)` returns exactly the bound devices — not the other type's, not the untyped one.
- **AC6** version 2 tightens the schema; the device on version 1 stays on it and keeps writing, while a new device is held to version 2.
- **AC7** deprecated device type refuses new bindings and leaves the existing device readable and writable; a non-active version is refused on bind.
- Unit: capability round trip including no commands, no units, `rw` access, empty declaration and command-without-params; rejection of unusable declarations; the `ui_schema`/`json_schema` split; `additionalProperties` left open; structural fallback for hand-written schemas.
- Unit: error translation for nine validator message shapes, multi-violation splitting, multiple unexpected properties, ambiguous-value abstention, Rust/Go float formatting, unrecognised messages, and non-schema errors passing through untouched.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run` — 63 issues, all pre-existing and identical to the count on `edge-ph2` (verified by stashing); nothing new in `pkg/atom`
- `gofmt -l .` — empty
- `go test ./...` — all 46 packages pass, no regressions
- No generated mocks reference `pkg/atom`, so nothing to regenerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
