### PR TITLE
CLI device-type support (MG-11 phase-2 slice)

### DIFF
--- a/auth/pat.go
+++ b/auth/pat.go
@@ -77,29 +77,31 @@ type EntityType uint32
 // never become load-bearing by accident later. 2 (former ClientsType) is
 // retired, not reused, so no future constant silently inherits old meaning.
 const (
-	GroupsType    EntityType = 0
-	ChannelsType  EntityType = 1
-	BootstrapType EntityType = 3
-	DashboardType EntityType = 4
-	MessagesType  EntityType = 5
-	DomainsType   EntityType = 6
-	UsersType     EntityType = 7
-	RulesType     EntityType = 8
-	ReportsType   EntityType = 9
-	DevicesType   EntityType = 10
+	GroupsType      EntityType = 0
+	ChannelsType    EntityType = 1
+	BootstrapType   EntityType = 3
+	DashboardType   EntityType = 4
+	MessagesType    EntityType = 5
+	DomainsType     EntityType = 6
+	UsersType       EntityType = 7
+	RulesType       EntityType = 8
+	ReportsType     EntityType = 9
+	DevicesType     EntityType = 10
+	DeviceTypesType EntityType = 11
 )
 
 const (
-	GroupsScopeStr   = "groups"
-	ChannelsScopeStr = "channels"
-	DevicesScopeStr  = "devices"
-	BootstrapStr     = "bootstrap"
-	DashboardsStr    = "dashboards"
-	MessagesStr      = "messages"
-	DomainsStr       = "domains"
-	UsersStr         = "users"
-	RulesScopeStr    = "rules"
-	ReportsScopeStr  = "reports"
+	GroupsScopeStr      = "groups"
+	ChannelsScopeStr    = "channels"
+	DevicesScopeStr     = "devices"
+	DeviceTypesScopeStr = "device_types"
+	BootstrapStr        = "bootstrap"
+	DashboardsStr       = "dashboards"
+	MessagesStr         = "messages"
+	DomainsStr          = "domains"
+	UsersStr            = "users"
+	RulesScopeStr       = "rules"
+	ReportsScopeStr     = "reports"
 )
 
 func (et EntityType) String() string {
@@ -110,6 +112,8 @@ func (et EntityType) String() string {
 		return ChannelsScopeStr
 	case DevicesType:
 		return DevicesScopeStr
+	case DeviceTypesType:
+		return DeviceTypesScopeStr
 	case BootstrapType:
 		return BootstrapStr
 	case DashboardType:
@@ -137,6 +141,8 @@ func ParseEntityType(et string) (EntityType, error) {
 		return ChannelsType, nil
 	case DevicesScopeStr:
 		return DevicesType, nil
+	case DeviceTypesScopeStr:
+		return DeviceTypesType, nil
 	case BootstrapStr:
 		return BootstrapType, nil
 	case DashboardsStr:
@@ -179,7 +185,7 @@ func (et *EntityType) UnmarshalText(data []byte) (err error) {
 
 func IsValidOperationForEntity(entityType EntityType, operation string) bool {
 	switch entityType {
-	case DevicesType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
+	case DevicesType, DeviceTypesType, ChannelsType, GroupsType, BootstrapType, DomainsType, RulesType, ReportsType:
 		return true
 	case DashboardType:
 		return operation == OpDashboardShare || operation == OpDashboardUnshare

--- a/auth/pat_test.go
+++ b/auth/pat_test.go
@@ -32,6 +32,11 @@ func TestEntityTypeString(t *testing.T) {
 			expected: "devices",
 		},
 		{
+			desc:     "Device types entity type",
+			et:       auth.DeviceTypesType,
+			expected: "device_types",
+		},
+		{
 			desc:     "Bootstrap entity type",
 			et:       auth.BootstrapType,
 			expected: "bootstrap",
@@ -94,6 +99,12 @@ func TestParseEntityType(t *testing.T) {
 			desc:     "Parse devices",
 			et:       "devices",
 			expected: auth.DevicesType,
+			err:      false,
+		},
+		{
+			desc:     "Parse device types",
+			et:       "device_types",
+			expected: auth.DeviceTypesType,
 			err:      false,
 		},
 		{
@@ -164,6 +175,12 @@ func TestEntityTypeMarshalJSON(t *testing.T) {
 			desc:     "Marshal devices",
 			et:       auth.DevicesType,
 			expected: []byte(`"devices"`),
+			err:      nil,
+		},
+		{
+			desc:     "Marshal device types",
+			et:       auth.DeviceTypesType,
+			expected: []byte(`"device_types"`),
 			err:      nil,
 		},
 		{
@@ -334,5 +351,62 @@ func TestEntityTypeUnmarshalText(t *testing.T) {
 				assert.Equal(t, tc.expected, et, "UnmarshalText() = %v, expected %v", et, tc.expected)
 			}
 		})
+	}
+}
+
+// TestEntityTypeRoundTrip pins every declared EntityType against all four of
+// its representations at once. String(), ParseEntityType, JSON and text are
+// written separately, so a new variant added to one and forgotten in another
+// only shows up here.
+func TestEntityTypeRoundTrip(t *testing.T) {
+	cases := []struct {
+		et   auth.EntityType
+		name string
+	}{
+		{auth.GroupsType, "groups"},
+		{auth.ChannelsType, "channels"},
+		{auth.BootstrapType, "bootstrap"},
+		{auth.DashboardType, "dashboards"},
+		{auth.MessagesType, "messages"},
+		{auth.DomainsType, "domains"},
+		{auth.UsersType, "users"},
+		{auth.RulesType, "rules"},
+		{auth.ReportsType, "reports"},
+		{auth.DevicesType, "devices"},
+		{auth.DeviceTypesType, "device_types"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.name, tc.et.String())
+
+			parsed, err := auth.ParseEntityType(tc.name)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.et, parsed)
+
+			marshalled, err := tc.et.MarshalJSON()
+			assert.NoError(t, err)
+			assert.Equal(t, []byte(`"`+tc.name+`"`), marshalled)
+
+			var fromJSON auth.EntityType
+			assert.NoError(t, fromJSON.UnmarshalJSON(marshalled))
+			assert.Equal(t, tc.et, fromJSON)
+
+			text, err := tc.et.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, []byte(tc.name), text)
+
+			var fromText auth.EntityType
+			assert.NoError(t, fromText.UnmarshalText(text))
+			assert.Equal(t, tc.et, fromText)
+		})
+	}
+}
+
+// TestDeviceTypesOperationsAreValid mirrors devices: device types accept any
+// operation, unlike dashboards and messages which accept a fixed pair.
+func TestDeviceTypesOperationsAreValid(t *testing.T) {
+	for _, op := range []string{"view", "update", "create_version", "list_versions"} {
+		assert.True(t, auth.IsValidOperationForEntity(auth.DeviceTypesType, op), "operation %s must be valid for device_types", op)
 	}
 }

--- a/cli/atom_fake_test.go
+++ b/cli/atom_fake_test.go
@@ -32,6 +32,12 @@ type fakeAtom struct {
 	getCount    map[string]int
 	mutateAtGet map[string]int
 	mutateAttrs map[string]atom.Attributes
+
+	deviceTypes        map[string]atom.DeviceType
+	typeVersions       map[string][]atom.DeviceTypeVersion
+	typeSeq            int
+	versionSeq         int
+	updateEntityGQLErr string
 }
 
 // mutateOnNthGet swaps id's attributes in after its nth GetEntity call,
@@ -46,9 +52,36 @@ func (fa *fakeAtom) mutateOnNthGet(id string, n int, attrs atom.Attributes) {
 	fa.mutateAttrs[id] = attrs
 }
 
+// seedDeviceType registers a device type, and seedDeviceTypeVersion one of its
+// versions. They are methods rather than newFakeAtom arguments so the entity
+// seeding signature the device and gateway tests use stays unchanged.
+func (fa *fakeAtom) seedDeviceType(deviceTypes ...atom.DeviceType) {
+	for _, dt := range deviceTypes {
+		fa.deviceTypes[dt.ID] = dt
+	}
+}
+
+func (fa *fakeAtom) seedDeviceTypeVersion(versions ...atom.DeviceTypeVersion) {
+	for _, v := range versions {
+		fa.typeVersions[v.DeviceTypeID] = append(fa.typeVersions[v.DeviceTypeID], v)
+	}
+}
+
+// failEntityUpdate makes the next UpdateEntity answer with a GraphQL error,
+// which is how Atom reports a device type schema rejection.
+func (fa *fakeAtom) failEntityUpdate(message string) {
+	fa.updateEntityGQLErr = message
+}
+
 func newFakeAtom(t *testing.T, seed ...atom.Entity) *fakeAtom {
 	t.Helper()
-	fa := &fakeAtom{t: t, entities: map[string]atom.Entity{}, getCount: map[string]int{}}
+	fa := &fakeAtom{
+		t:            t,
+		entities:     map[string]atom.Entity{},
+		getCount:     map[string]int{},
+		deviceTypes:  map[string]atom.DeviceType{},
+		typeVersions: map[string][]atom.DeviceTypeVersion{},
+	}
 	for _, e := range seed {
 		fa.entities[e.ID] = e
 	}
@@ -66,6 +99,8 @@ func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
 	fa.requests = append(fa.requests, req)
 	w.Header().Set("Content-Type", "application/json")
 
+	// CreateDeviceTypeVersion is matched before CreateDeviceType, whose name is
+	// a prefix of it.
 	switch {
 	case strings.Contains(req.Query, "mutation CreateEntity"):
 		fa.handleCreate(w, req)
@@ -77,9 +112,154 @@ func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
 		fa.handleGet(w, req)
 	case strings.Contains(req.Query, "query Entities("):
 		fa.handleList(w, req)
+	case strings.Contains(req.Query, "mutation CreateDeviceTypeVersion"):
+		fa.handleCreateDeviceTypeVersion(w, req)
+	case strings.Contains(req.Query, "mutation CreateDeviceType"):
+		fa.handleCreateDeviceType(w, req)
+	case strings.Contains(req.Query, "mutation UpdateDeviceType"):
+		fa.handleUpdateDeviceType(w, req)
+	case strings.Contains(req.Query, "query DeviceTypeVersions("):
+		fa.handleListDeviceTypeVersions(w, req)
+	case strings.Contains(req.Query, "query DeviceTypes("):
+		fa.handleListDeviceTypes(w, req)
+	case strings.Contains(req.Query, "query DeviceType("):
+		fa.handleGetDeviceType(w, req)
 	default:
 		fa.t.Fatalf("unexpected graphql query: %s", req.Query)
 	}
+}
+
+func (fa *fakeAtom) handleCreateDeviceType(w http.ResponseWriter, req gqlRequest) {
+	input, _ := req.Variables["input"].(map[string]any)
+	fa.typeSeq++
+	dt := atom.DeviceType{
+		ID:          fmt.Sprintf("device-type-%d", fa.typeSeq),
+		TenantID:    strVal(input["tenantId"]),
+		Key:         strVal(input["key"]),
+		Name:        strVal(input["displayName"]),
+		Description: strVal(input["description"]),
+		Status:      "active",
+	}
+	if status := strVal(input["status"]); status != "" {
+		dt.Status = status
+	}
+	fa.deviceTypes[dt.ID] = dt
+	writeGQLData(fa.t, w, map[string]any{"createProfile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleGetDeviceType(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	dt, ok := fa.deviceTypes[id]
+	if !ok {
+		writeGQLError(fa.t, w, "device type not found")
+		return
+	}
+	writeGQLData(fa.t, w, map[string]any{"profile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleListDeviceTypes(w http.ResponseWriter, req gqlRequest) {
+	tenantID := strVal(req.Variables["tenantId"])
+	status := strVal(req.Variables["status"])
+
+	items := []map[string]any{}
+	for _, dt := range fa.deviceTypes {
+		if tenantID != "" && dt.TenantID != tenantID {
+			continue
+		}
+		if status != "" && dt.Status != status {
+			continue
+		}
+		items = append(items, deviceTypeJSON(dt))
+	}
+	writeGQLData(fa.t, w, map[string]any{"profiles": map[string]any{"items": items, "total": len(items)}})
+}
+
+func (fa *fakeAtom) handleUpdateDeviceType(w http.ResponseWriter, req gqlRequest) {
+	id, _ := req.Variables["id"].(string)
+	dt, ok := fa.deviceTypes[id]
+	if !ok {
+		writeGQLError(fa.t, w, "device type not found")
+		return
+	}
+	input, _ := req.Variables["input"].(map[string]any)
+	if name := strVal(input["displayName"]); name != "" {
+		dt.Name = name
+	}
+	if description := strVal(input["description"]); description != "" {
+		dt.Description = description
+	}
+	if status := strVal(input["status"]); status != "" {
+		dt.Status = status
+	}
+	fa.deviceTypes[id] = dt
+	writeGQLData(fa.t, w, map[string]any{"updateProfile": deviceTypeJSON(dt)})
+}
+
+func (fa *fakeAtom) handleCreateDeviceTypeVersion(w http.ResponseWriter, req gqlRequest) {
+	deviceTypeID := strVal(req.Variables["profileId"])
+	input, _ := req.Variables["input"].(map[string]any)
+	fa.versionSeq++
+
+	version := atom.DeviceTypeVersion{
+		ID:           fmt.Sprintf("device-type-version-%d", fa.versionSeq),
+		DeviceTypeID: deviceTypeID,
+		Version:      intVal(input["version"]),
+		Status:       "active",
+		JSONSchema:   mapVal(input["jsonSchema"]),
+		UISchema:     mapVal(input["uiSchema"]),
+	}
+	if status := strVal(input["status"]); status != "" {
+		version.Status = status
+	}
+	fa.typeVersions[deviceTypeID] = append(fa.typeVersions[deviceTypeID], version)
+	writeGQLData(fa.t, w, map[string]any{"createProfileVersion": deviceTypeVersionJSON(version)})
+}
+
+func (fa *fakeAtom) handleListDeviceTypeVersions(w http.ResponseWriter, req gqlRequest) {
+	deviceTypeID := strVal(req.Variables["profileId"])
+	items := []map[string]any{}
+	for _, version := range fa.typeVersions[deviceTypeID] {
+		items = append(items, deviceTypeVersionJSON(version))
+	}
+	writeGQLData(fa.t, w, map[string]any{"profileVersions": items})
+}
+
+func deviceTypeJSON(dt atom.DeviceType) map[string]any {
+	return map[string]any{
+		"id":          dt.ID,
+		"tenant_id":   dt.TenantID,
+		"key":         dt.Key,
+		"name":        dt.Name,
+		"description": dt.Description,
+		"status":      dt.Status,
+	}
+}
+
+func deviceTypeVersionJSON(v atom.DeviceTypeVersion) map[string]any {
+	return map[string]any{
+		"id":             v.ID,
+		"device_type_id": v.DeviceTypeID,
+		"version":        v.Version,
+		"json_schema":    v.JSONSchema,
+		"ui_schema":      v.UISchema,
+		"status":         v.Status,
+	}
+}
+
+func intVal(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}
+
+func mapVal(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
 }
 
 func (fa *fakeAtom) handleCreate(w http.ResponseWriter, req gqlRequest) {
@@ -98,6 +278,12 @@ func (fa *fakeAtom) handleCreate(w http.ResponseWriter, req gqlRequest) {
 }
 
 func (fa *fakeAtom) handleUpdate(w http.ResponseWriter, req gqlRequest) {
+	if message := fa.updateEntityGQLErr; message != "" {
+		fa.updateEntityGQLErr = ""
+		writeGQLError(fa.t, w, message)
+		return
+	}
+
 	id, _ := req.Variables["id"].(string)
 	e, ok := fa.entities[id]
 	if !ok {
@@ -110,6 +296,12 @@ func (fa *fakeAtom) handleUpdate(w http.ResponseWriter, req gqlRequest) {
 	}
 	if status := strVal(input["status"]); status != "" {
 		e.Status = status
+	}
+	if profileID := strVal(input["profileId"]); profileID != "" {
+		e.DeviceTypeID = profileID
+	}
+	if versionID := strVal(input["profileVersionId"]); versionID != "" {
+		e.DeviceTypeVersionID = versionID
 	}
 	if attrs, ok := input["attributes"].(map[string]any); ok {
 		e.Attributes = atom.Attributes(attrs)
@@ -185,12 +377,14 @@ func entityJSON(e atom.Entity) map[string]any {
 		attrs = map[string]any{}
 	}
 	return map[string]any{
-		"id":         e.ID,
-		"kind":       e.Kind,
-		"name":       e.Name,
-		"tenant_id":  e.TenantID,
-		"status":     e.Status,
-		"attributes": attrs,
+		"id":                     e.ID,
+		"kind":                   e.Kind,
+		"name":                   e.Name,
+		"tenant_id":              e.TenantID,
+		"device_type_id":         e.DeviceTypeID,
+		"device_type_version_id": e.DeviceTypeVersionID,
+		"status":                 e.Status,
+		"attributes":             attrs,
 	}
 }
 

--- a/cli/devicetypes.go
+++ b/cli/devicetypes.go
@@ -1,0 +1,313 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/spf13/cobra"
+)
+
+// Operations unique to device types. The shared ones (create, get, update,
+// all) come from channels.go's block.
+const (
+	deviceTypeVersions      = "versions"
+	deviceTypeCreateVersion = "create-version"
+	deviceTypeActiveVersion = "active-version"
+	deviceTypeBind          = "bind"
+)
+
+const (
+	usageDeviceTypeCreate        = "cli devicetypes create <JSON_device_type> <domain_id>"
+	usageDeviceTypeGet           = "cli devicetypes <device_type_id|all> get <domain_id>"
+	usageDeviceTypeUpdate        = "cli devicetypes <device_type_id> update <JSON_string>"
+	usageDeviceTypeVersions      = "cli devicetypes <device_type_id> versions"
+	usageDeviceTypeCreateVersion = "cli devicetypes <device_type_id> create-version <JSON_version>"
+	usageDeviceTypeActiveVersion = "cli devicetypes <device_type_id> active-version"
+	usageDeviceTypeBind          = "cli devicetypes <device_type_id> bind <device_id> [version_id]"
+)
+
+// NewDeviceTypesCmd wraps pkg/atom's device type API. There is deliberately no
+// delete operation: Atom has no deleteProfile mutation, so a device type is
+// retired by setting its status, not removed.
+func NewDeviceTypesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "devicetypes <device_type_id|all|create> [operation] [args...]",
+		Short: "Device types management",
+		Long: `Format:
+  devicetypes create <JSON_device_type> <domain_id>
+  devicetypes <device_type_id|all> <operation> [args...]
+
+Operations (require device_type_id/all): get, update, versions, create-version,
+active-version, bind
+
+Listing is always domain-scoped. Atom's device type filter is "this tenant" or
+"no filter at all", and no filter at all crosses tenants, so "all get" takes a
+domain_id.
+
+There is no delete: status carries retirement instead, and its three values
+(active, deprecated, disabled) do not reduce to an enable/disable pair, so it
+is set through update:
+  devicetypes <device_type_id> update '{"status":"deprecated"}'
+
+A version is immutable once created and its status is fixed at creation —
+create it with "status":"draft" to stage one without making it bindable.
+
+"bind" is the checked way to attach a device to a type: it refuses a type or
+version that is not active, which writing device_type_id through
+"devices <device_id> update" does not.
+
+Examples:
+  devicetypes create '{"key":"thermostat","name":"Thermostat"}' <domain_id>
+  devicetypes all get <domain_id>
+  devicetypes <device_type_id> get
+  devicetypes <device_type_id> update '{"name":"Thermostat","status":"deprecated"}'
+  devicetypes <device_type_id> versions
+  devicetypes <device_type_id> create-version '{"capabilities":{"measurements":[{"name":"temperature","type":"number","unit":"Cel"}]}}'
+  devicetypes <device_type_id> active-version
+  devicetypes <device_type_id> bind <device_id> <version_id>`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+
+			if args[0] == create {
+				handleDeviceTypeCreate(cmd, args[1:])
+				return
+			}
+
+			if len(args) < 2 {
+				logUsageCmd(*cmd, "devicetypes <device_type_id|all> <get|update|versions|create-version|active-version|bind> [args...]")
+				return
+			}
+
+			deviceTypeID := args[0]
+			operation := args[1]
+			opArgs := args[2:]
+
+			switch operation {
+			case get:
+				handleDeviceTypeGet(cmd, deviceTypeID, opArgs)
+			case update:
+				handleDeviceTypeUpdate(cmd, deviceTypeID, opArgs)
+			case deviceTypeVersions:
+				handleDeviceTypeVersions(cmd, deviceTypeID, opArgs)
+			case deviceTypeCreateVersion:
+				handleDeviceTypeCreateVersion(cmd, deviceTypeID, opArgs)
+			case deviceTypeActiveVersion:
+				handleDeviceTypeActiveVersion(cmd, deviceTypeID, opArgs)
+			case deviceTypeBind:
+				handleDeviceTypeBind(cmd, deviceTypeID, opArgs)
+			default:
+				logErrorCmd(*cmd, fmt.Errorf("unknown operation: %s", operation))
+			}
+		},
+	}
+
+	return cmd
+}
+
+func handleDeviceTypeCreate(cmd *cobra.Command, args []string) {
+	if len(args) != 2 {
+		logUsageCmd(*cmd, usageDeviceTypeCreate)
+		return
+	}
+
+	var deviceType atom.DeviceType
+	if err := json.Unmarshal([]byte(args[0]), &deviceType); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+	deviceType.TenantID = args[1]
+
+	created, err := atomClient.CreateDeviceType(cmd.Context(), deviceType)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleDeviceTypeGet's "all" branch needs the domain argument that a single
+// lookup does not: ListDeviceTypes refuses a tenant-less listing, since Atom
+// would answer it with every tenant's types.
+func handleDeviceTypeGet(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if deviceTypeID == all {
+		if len(args) != 1 || args[0] == "" {
+			logUsageCmd(*cmd, usageDeviceTypeGet)
+			return
+		}
+
+		q := atom.DeviceTypeQuery{
+			TenantID: args[0],
+			Status:   Status,
+			Limit:    Limit,
+			Offset:   Offset,
+		}
+		l, err := atomClient.ListDeviceTypes(cmd.Context(), q)
+		if err != nil {
+			logErrorCmd(*cmd, err)
+			return
+		}
+
+		logJSONCmd(*cmd, l)
+		return
+	}
+
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeGet)
+		return
+	}
+
+	dt, err := atomClient.GetDeviceType(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, dt)
+}
+
+func handleDeviceTypeUpdate(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageDeviceTypeUpdate)
+		return
+	}
+
+	var deviceType atom.DeviceType
+	if err := json.Unmarshal([]byte(args[0]), &deviceType); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	updated, err := atomClient.UpdateDeviceType(cmd.Context(), deviceTypeID, deviceType)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, updated)
+}
+
+func handleDeviceTypeVersions(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeVersions)
+		return
+	}
+
+	l, err := atomClient.ListDeviceTypeVersions(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, l)
+}
+
+// handleDeviceTypeCreateVersion takes a whole version rather than a bare
+// capability document so the CLI can also stage a draft and pin a version
+// number — both are fixed at creation, with no mutation to change them after.
+func handleDeviceTypeCreateVersion(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageDeviceTypeCreateVersion)
+		return
+	}
+
+	var version atom.DeviceTypeVersion
+	if err := json.Unmarshal([]byte(args[0]), &version); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	created, err := atomClient.CreateDeviceTypeVersion(cmd.Context(), deviceTypeID, version)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleDeviceTypeActiveVersion reports the version a bind picks when none is
+// named, which is otherwise only visible by reading the whole version list.
+func handleDeviceTypeActiveVersion(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageDeviceTypeActiveVersion)
+		return
+	}
+
+	version, err := atomClient.ActiveDeviceTypeVersion(cmd.Context(), deviceTypeID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, version)
+}
+
+// handleDeviceTypeBind lives here rather than under "devices" because binding
+// is a device type act — pkg/atom keeps BindDeviceType in device_types.go for
+// the same reason, and the type and version status checks it performs are what
+// separate it from an ordinary device update.
+func handleDeviceTypeBind(cmd *cobra.Command, deviceTypeID string, args []string) {
+	if len(args) < 1 || len(args) > 2 {
+		logUsageCmd(*cmd, usageDeviceTypeBind)
+		return
+	}
+
+	versionID := ""
+	if len(args) == 2 {
+		versionID = args[1]
+	}
+
+	device, err := atomClient.BindDeviceType(cmd.Context(), args[0], deviceTypeID, versionID)
+	if err != nil {
+		logDeviceTypeErrorCmd(cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, device)
+}
+
+// logDeviceTypeErrorCmd prints err, expanding a device type schema rejection
+// into one line per violation. SchemaValidationError's own message lists
+// "field: message" pairs but drops the constraint and the expected value,
+// which is the part that says what to write instead.
+//
+// Only bind can raise one: it writes the device through UpdateEntity, and Atom
+// validates the attributes already on the device — against the version bound
+// before this call, not the one being bound.
+func logDeviceTypeErrorCmd(cmd *cobra.Command, err error) {
+	schemaErr, ok := atom.AsSchemaValidationError(err)
+	if !ok {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("attributes rejected by the device type schema:")
+	for _, violation := range schemaErr.Violations {
+		field := violation.Field
+		if field == "" {
+			field = "<unidentified field>"
+		}
+		b.WriteString("\n  " + field)
+		if violation.Constraint != "" {
+			b.WriteString(" (" + violation.Constraint + ")")
+		}
+		b.WriteString(": " + violation.Message)
+		if violation.Expected != "" {
+			b.WriteString("; expected " + violation.Expected)
+		}
+	}
+
+	logErrorCmd(*cmd, errors.New(b.String()))
+}

--- a/cli/devicetypes_test.go
+++ b/cli/devicetypes_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceTypesCreateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	deviceTypeJSON := `{"key":"thermostat","name":"Thermostat","description":"wall unit"}`
+	out := executeCommand(t, rootCmd, createCmd, deviceTypeJSON, "domain-1")
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "thermostat", got.Key)
+	assert.Equal(t, "Thermostat", got.Name)
+	assert.Equal(t, "domain-1", got.TenantID)
+
+	// Atom stores device types as Profiles narrowed by object_kind/kind; a
+	// type created without that narrowing would not come back from a listing.
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "entity", input["objectKind"])
+	assert.Equal(t, "device", input["kind"])
+	assert.Equal(t, "domain-1", input["tenantId"])
+}
+
+func TestDeviceTypesGetCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Name: "Thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", getCmd)
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device-type-1", got.ID)
+	assert.Equal(t, "thermostat", got.Key)
+}
+
+func TestDeviceTypesGetAllCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(
+		atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"},
+		atom.DeviceType{ID: "device-type-2", TenantID: "domain-1", Key: "valve", Status: "active"},
+		atom.DeviceType{ID: "device-type-3", TenantID: "domain-2", Key: "meter", Status: "active"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd, "domain-1")
+
+	var got atom.DeviceTypeList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+}
+
+// TestDeviceTypesGetAllRequiresDomain pins the trap: Atom answers a
+// tenant-less device type listing with every tenant's types, so the CLI must
+// refuse rather than pass the query through.
+func TestDeviceTypesGetAllRequiresDomain(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd)
+
+	assert.Contains(t, out, "usage")
+	assert.Empty(t, fa.requests, "no listing may reach Atom without a domain")
+}
+
+func TestDeviceTypesUpdateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Name: "Thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", updateCmd, `{"name":"Thermostat mk2","status":"deprecated"}`)
+
+	var got atom.DeviceType
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "Thermostat mk2", got.Name)
+	// Retirement runs through update: Atom has no delete for device types.
+	assert.Equal(t, "deprecated", got.Status)
+}
+
+func TestDeviceTypesCreateVersionCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	capabilities := `{"capabilities":{"measurements":[{"name":"temperature","type":"number","unit":"Cel","access":"rw","required":true}],"commands":[{"name":"reboot"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, capabilities)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, 1, got.Version, "first version numbers itself")
+	assert.Equal(t, "active", got.Status)
+
+	// The capability document round-trips through the stored schemas.
+	require.Len(t, got.Capabilities.Measurements, 1)
+	assert.Equal(t, "temperature", got.Capabilities.Measurements[0].Name)
+	assert.Equal(t, "Cel", got.Capabilities.Measurements[0].Unit)
+	require.Len(t, got.Capabilities.Commands, 1)
+	assert.Equal(t, "reboot", got.Capabilities.Commands[0].Name)
+
+	properties, _ := got.JSONSchema["properties"].(map[string]any)
+	assert.Contains(t, properties, "temperature")
+}
+
+// TestDeviceTypesCreateVersionDraftCmd covers the reason the argument is a
+// whole version rather than a bare capability document: a version's status is
+// fixed at creation, so staging a draft is only possible here.
+func TestDeviceTypesCreateVersionDraftCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	body := `{"status":"draft","capabilities":{"measurements":[{"name":"humidity","type":"number"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, body)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "draft", got.Status)
+}
+
+func TestDeviceTypesCreateVersionRejectsBadCapabilityCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	body := `{"capabilities":{"measurements":[{"name":"temperature","type":"tesseract"}]}}`
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd, body)
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "unsupported value type")
+	assert.Empty(t, fa.requests, "an unrenderable capability document never reaches Atom")
+}
+
+func TestDeviceTypesVersionsCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(
+		atom.DeviceTypeVersion{ID: "version-2", DeviceTypeID: "device-type-1", Version: 2, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "deprecated"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", versionsCmd)
+
+	var got []atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, 1, got[0].Version, "versions come back oldest first")
+	assert.Equal(t, 2, got[1].Version)
+}
+
+func TestDeviceTypesActiveVersionCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(
+		atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-2", DeviceTypeID: "device-type-1", Version: 2, Status: "active"},
+		atom.DeviceTypeVersion{ID: "version-3", DeviceTypeID: "device-type-1", Version: 3, Status: "draft"},
+	)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", activeVersionCmd)
+
+	var got atom.DeviceTypeVersion
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	// The draft is higher-numbered but not bindable.
+	assert.Equal(t, "version-2", got.ID)
+}
+
+func TestDeviceTypesBindCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "active"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1", "version-1")
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "device-type-1", got.DeviceTypeID)
+	assert.Equal(t, "version-1", got.DeviceTypeVersionID)
+}
+
+// TestDeviceTypesBindRejectsDeprecatedVersion pins what bind buys over an
+// ordinary device update: Atom binds a caller-named version whatever its
+// status, so deprecating one would not stop new bindings without this check.
+func TestDeviceTypesBindRejectsDeprecatedVersion(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.seedDeviceTypeVersion(atom.DeviceTypeVersion{ID: "version-1", DeviceTypeID: "device-type-1", Version: 1, Status: "deprecated"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1", "version-1")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "version is not active")
+
+	device := fa.entities["device-1"]
+	assert.Empty(t, device.DeviceTypeID, "a refused bind must not write the device")
+}
+
+func TestDeviceTypesBindRejectsDeprecatedType(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "deprecated"})
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "device type is not active")
+}
+
+// TestDeviceTypesBindSurfacesSchemaViolations checks that a schema rejection
+// reaches the operator with the field and the constraint intact, rather than
+// as the validator's raw sentence.
+func TestDeviceTypesBindSurfacesSchemaViolations(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
+	fa.seedDeviceType(atom.DeviceType{ID: "device-type-1", TenantID: "domain-1", Key: "thermostat", Status: "active"})
+	fa.failEntityUpdate("attributes failed profile schema validation: 'temperature' is a required property; Additional properties are not allowed ('colour' was unexpected)")
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", bindCmd, "device-1")
+
+	assert.Contains(t, out, "rejected by the device type schema")
+	assert.Contains(t, out, "temperature (required)")
+	assert.Contains(t, out, "colour (additionalProperties)")
+}
+
+func TestDeviceTypesCmdUsageOnMissingArgs(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", createVersionCmd)
+
+	assert.Contains(t, out, "usage")
+}
+
+func TestDeviceTypesCmdUnknownOperation(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDeviceTypesCmd())
+
+	out := executeCommand(t, rootCmd, "device-type-1", deleteCmd)
+
+	assert.Contains(t, out, "unknown operation: delete")
+}

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -16,13 +16,17 @@ import (
 // get, update, delete, enable, disable) — can't reference those directly
 // from this external test package.
 const (
-	createCmd  = "create"
-	getCmd     = "get"
-	updateCmd  = "update"
-	deleteCmd  = "delete"
-	enableCmd  = "enable"
-	disableCmd = "disable"
-	allCmd     = "all"
+	createCmd        = "create"
+	getCmd           = "get"
+	updateCmd        = "update"
+	deleteCmd        = "delete"
+	enableCmd        = "enable"
+	disableCmd       = "disable"
+	allCmd           = "all"
+	versionsCmd      = "versions"
+	createVersionCmd = "create-version"
+	activeVersionCmd = "active-version"
+	bindCmd          = "bind"
 )
 
 func executeCommand(t *testing.T, root *cobra.Command, args ...string) string {

--- a/docker/permission.yaml
+++ b/docker/permission.yaml
@@ -32,6 +32,22 @@ devices:
     - remove_members: remove_role_users_permission
     - remove_all_members: remove_role_users_permission
 
+# Device types carry no delete: Atom has no deleteProfile mutation, so a type
+# is retired by setting its status through update, never removed. Versions are
+# immutable once created, so creating one is the only version write — and it
+# gets its own permission because publishing a version changes what every
+# future device of the type validates against, which is a larger act than
+# renaming the type. No roles_operations: device types have no role surface,
+# matching the alarm block.
+device_types:
+  operations:
+    - create: create_permission
+    - view: read_permission
+    - list: read_permission
+    - update: update_permission
+    - create_version: create_version_permission
+    - list_versions: read_permission
+
 channels:
   operations:
     - view: read_permission

--- a/pkg/permissions/config_test.go
+++ b/pkg/permissions/config_test.go
@@ -42,6 +42,28 @@ func TestDevicesEntityReplacesClients(t *testing.T) {
 	}
 }
 
+func TestDeviceTypesEntityBlock(t *testing.T) {
+	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
+	require.NoError(t, err)
+
+	ops, _, err := cfg.GetEntityPermissions("device_types")
+	require.NoError(t, err)
+
+	for _, op := range []string{"create", "view", "list", "update", "list_versions"} {
+		_, ok := ops[op]
+		require.True(t, ok, "device_types block must declare %s", op)
+	}
+
+	// Publishing a version is separately grantable from renaming the type.
+	perm, ok := ops["create_version"]
+	require.True(t, ok, "device_types block must declare create_version")
+	require.Equal(t, permissions.Permission("create_version_permission"), perm)
+
+	// Atom has no deleteProfile mutation — a type is retired, never deleted.
+	_, ok = ops["delete"]
+	require.False(t, ok, "device_types must not declare delete")
+}
+
 func TestNoGatewaysEntityBlock(t *testing.T) {
 	cfg, err := permissions.ParsePermissionsFile(permissionsFilePath)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Finishes [MG-11](edge/prd/MG-11-surface-plumbing.md)'s acceptance criterion 3 — *"⏸ Phase 2 — CLI can manage device types and versions"* — now that [MG-02](https://github.com/absmach/magistrala/pull/3583) exists. **Stacked on `mg-02-device-type-client`**, so this diff is only the surface on top of it.

MG-11 (#3575) shipped `cli/devices.go` and `cli/gateways.go` but deferred the third planned file, `cli/devicetypes.go`, because `pkg/atom` had no device type methods yet. MG-02 added them and nothing calls them. This connects the two.

### The MG-10 dependency was wrong

MG-11's PRD says the `DeviceTypesType` PAT scope and the `device_types:` permission block "wait for MG-10", a planned `pkg/sdk` + HTTP surface. MG-10 rests on a false premise: there is no `pkg/sdk` `Device` type and no HTTP service for entity CRUD anywhere in this repo — the old one was deleted, nothing is replacing it, and the UI and CLI both call Atom directly. MG-11 nonetheless added the `DevicesType` scope and the `devices:` block with no HTTP surface in existence, which is the proof they never depended on one. The `device_types` equivalents follow that same precedent here rather than waiting for something that is not being built.

## Scope

- **`cli/devicetypes.go`** — `create`, `get`, `all get`, `update`, `versions`, `create-version`, `active-version`, `bind`, following `cli/devices.go`'s shape and `cli/atom.go`'s package-level client.
- **`auth/pat.go`** — `DeviceTypesType EntityType = 11` and `DeviceTypesScopeStr = "device_types"`, wired through `String()`, `ParseEntityType()` and `IsValidOperationForEntity()`. Value pinned explicitly, per the comment already on the block.
- **`docker/permission.yaml`** — a `device_types:` block.
- Tests in `cli/devicetypes_test.go`, `auth/pat_test.go`, `pkg/permissions/config_test.go`, plus device type handling in the shared `cli/atom_fake_test.go` stand-in.

**Not here:** `apidocs/openapi/device-types.yaml` (see below), and no PRD status lines were touched.

## Design decisions

**No `delete`.** Atom has no `deleteProfile` mutation, so a device type is retired by setting its status and never removed. The CLI has no delete operation and the permission block declares none — inventing one would document a capability that cannot exist.

**No `enable`/`disable` pair either.** A device type has three statuses (active, deprecated, disabled), which do not reduce to a two-way toggle the way a device's active/inactive does. Status goes through `update '{"status":"deprecated"}'`, which covers all three honestly.

**Listing always takes a domain.** `ListDeviceTypes` refuses a tenant-less query because Atom's filter is "this tenant" or "no filter at all", and no filter at all crosses tenants. The CLI refuses before the call rather than passing it through — `devicetypes all get` with no `domain_id` prints usage and sends nothing, and there is a test asserting no request reaches Atom.

**`create-version` takes a whole version, not a bare capability document.** The suggested shape was `create-version <type_id> <JSON_capability_document>`. It unmarshals into `atom.DeviceTypeVersion` instead — same raw-JSON-blob convention as `devices create <JSON_device>` → `atom.Entity`, one level of nesting deeper (`{"capabilities":{"measurements":[…]}}`). The reason is that a version's status is fixed at creation (Atom has no `updateProfileVersion`), so accepting only the capability document would make MG-02's documented draft-staging path unreachable from the CLI. `TestDeviceTypesCreateVersionDraftCmd` covers it.

## Judgement calls

**1. `bind` is a `devicetypes` subcommand, not `devices bind`.**

`devicetypes <device_type_id> bind <device_id> [version_id]`, in one place rather than two. Reasoning: `pkg/atom` keeps `BindDeviceType` in `device_types.go`, not `client.go`, because what distinguishes it from a raw entity write is entirely device-type logic — it refuses a non-active type or version. Following the library's own organisation keeps this PR purely additive (`cli/devices.go` is untouched) and keeps the schema-error handling next to the one command that can trigger it. Two spellings of one write would be worse for a CLI than either single choice.

The distinction is documented in the command's help, since `devices <device_id> update '{"device_type_id":…}'` still writes the binding unchecked — Atom binds a caller-named version whatever its status, so deprecating a version does not stop new bindings without this check. `TestDeviceTypesBindRejectsDeprecatedVersion` pins exactly that.

**2. No `apidocs/openapi/device-types.yaml`. Deliberate.**

MG-11 added `devices.yaml` documenting a `/devices` API on port 9006 that no service in this repo serves, which is real precedent for adding one here. I did not, and the difference is how each file came to be: `devices.yaml` is a **rename** of `clients.yaml` (git records it as `apidocs/openapi/{clients.yaml => devices.yaml}`), carrying an existing document through a terminology change so the docs set stayed self-consistent. A `device-types.yaml` would not be a rename — it would be a newly authored contract for routes that have never existed, for a concept whose only client is a GraphQL one. Renaming a stale document preserves the status quo; authoring a new one asserts an API exists. If a device type HTTP surface is ever built, its spec should be written against the real routes rather than reverse-engineered from a placeholder. Happy to add it if the preference is uniformity across the docs folder.

**3. No `create_device_types`/`list_device_types` operation remap in `Scope.UnmarshalJSON`.**

`DevicesType` remaps a scope's `create`/`list` to `create_devices`/`list_devices` because those are domain-level operation names. Their counterparts in the `domains:` block are still spelled `create_clients`/`list_clients` (MG-11 did not rename them), so adding a third pair for device types would deepen an inconsistency for an entity with no authorization consumer yet. Instead the `device_types:` block declares `create` and `list` directly, so a `device_types`-scoped PAT resolves its operation names against its own block with no remap. Flagging it as the asymmetry it is.

**4. `create_version` gets its own permission.**

`create_version: create_version_permission`, following MG-11's own reasoning for `set_gateways_permission`: publishing a version changes what every future device of that type validates against, which is a materially different act from renaming the type, and least-privilege grants should be able to separate them. Everything else maps to the standard read/update/create permissions.

**5. No `roles_operations` on `device_types`.**

Device types have no role surface in MG-02 — Atom Profiles have no roles. The `alarm:` block is the existing precedent for an entity block with operations only.

## Test plan

`cli/devicetypes_test.go` follows `cli/devices_test.go`'s shape, driving the real cobra commands against `cli/atom_fake_test.go`'s in-memory Atom, extended here with `Profile`/`ProfileVersion` handling and `seedDeviceType`/`seedDeviceTypeVersion` helpers (`newFakeAtom`'s entity-seeding signature is unchanged, so the device and gateway tests are untouched).

- create — round-trips, and the wire input carries `objectKind: entity` / `kind: device`, without which the type would not come back from a listing
- get, update — including retirement via `{"status":"deprecated"}`
- `all get` tenant-scoped — other tenants excluded; a missing domain prints usage **and sends no request**
- create-version — capability document round-trips through `json_schema`/`ui_schema` with commands intact and the first version numbering itself; draft staging; an unrenderable declaration is rejected before it reaches Atom
- versions — returned oldest-first
- active-version — skips a higher-numbered draft for the highest active version
- bind — writes both `device_type_id` and `device_type_version_id`; refuses a deprecated version and a deprecated type, and leaves the device unwritten when it refuses
- schema validation — a rejection surfaces as `temperature (required)` / `colour (additionalProperties)` rather than the validator's raw sentence. `SchemaValidationError`'s own `Error()` lists `field: message` but drops the constraint and the expected value, which is the part that says what to write instead
- unknown operation and missing arguments

`auth/pat_test.go` gains `TestEntityTypeRoundTrip`, which pins every declared `EntityType` against all four representations at once (`String()`, `ParseEntityType`, JSON, text) — per MG-11's test plan note that the four are written separately and must agree. `device_types` is also added to the three existing tables that already carried `devices`.

`pkg/permissions/config_test.go` gains `TestDeviceTypesEntityBlock`, asserting the block parses, declares its operations, gives `create_version` its own permission, and declares no `delete`. `pkg/permissions/entities.go` is config-driven on string entity keys, so no code change was needed — verified by reading it, not assumed.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run` — 63 issues, identical to the count MG-02 reported as its pre-existing baseline; none in any file this PR adds or modifies (the `cli/` hits are `config.go`, `provision.go` and `utils.go`, all untouched)
- `gofmt -l .` — empty
- `go test ./...` — full suite passes, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
