### PR TITLE
Reject gateway chaining: a device may not be both is_gateway and declare gateways of its own

### DIFF
--- a/cli/devices.go
+++ b/cli/devices.go
@@ -114,6 +114,12 @@ func handleDeviceCreate(cmd *cobra.Command, args []string) {
 	device.Kind = atomKindDevice
 	device.TenantID = args[1]
 
+	// A new device has no id yet, so self-reference cannot arise here --
+	// only the is_gateway-plus-gateways combination can.
+	if err := validateGatewayChain(cmd, "", device); err != nil {
+		return
+	}
+
 	created, err := atomClient.CreateEntity(cmd.Context(), device)
 	if err != nil {
 		logErrorCmd(*cmd, err)
@@ -181,6 +187,10 @@ func handleDeviceUpdate(cmd *cobra.Command, deviceID string, args []string) {
 		return
 	}
 
+	if err := validateGatewayChain(cmd, deviceID, device); err != nil {
+		return
+	}
+
 	updated, err := atomClient.UpdateEntity(cmd.Context(), deviceID, device)
 	if err != nil {
 		logErrorCmd(*cmd, err)
@@ -193,6 +203,27 @@ func handleDeviceUpdate(cmd *cobra.Command, deviceID string, args []string) {
 	}
 
 	logJSONCmd(*cmd, updated)
+}
+
+// validateGatewayChain rejects a create/update payload that would leave the
+// device both a gateway and reachable through gateways of its own
+// (pkg/atom.ValidateGatewayChain, architecture.md §8 A15) -- this command
+// bypasses SetDeviceGateways entirely, so that check never runs unless
+// something here calls it too. deviceID is "" for create, where
+// self-reference cannot yet arise.
+//
+// Checked against exactly the payload being written, not a re-read of the
+// device: UpdateEntity replaces the whole attributes value rather than
+// merging (see fakeAtomDevices in pkg/atom's tests), so whatever this
+// payload sets for is_gateway and gateways is exactly what will be
+// persisted -- there is no stale prior state to additionally account for.
+func validateGatewayChain(cmd *cobra.Command, deviceID string, device atom.Entity) error {
+	isGateway, _ := device.Attributes[atom.AttributeIsGateway].(bool)
+	if err := atom.ValidateGatewayChain(deviceID, isGateway, atom.GatewaysDeclared(device)); err != nil {
+		logErrorCmd(*cmd, err)
+		return err
+	}
+	return nil
 }
 
 // markDeclaredGateways flags is_gateway on every id the just-written

--- a/cli/devices_test.go
+++ b/cli/devices_test.go
@@ -169,19 +169,47 @@ func TestDevicesCreateCmdFailsWhenMarkingDeclaredGatewaysFails(t *testing.T) {
 	assert.False(t, flagged, "gateway must not appear flagged when the flagging write itself failed")
 }
 
-// A device naming itself as one of its own gateways must end up with the
-// flag set: markDeclaredGateways runs against the entity the API just
-// returned, after the write, so there is no pre-write snapshot for the
-// primary update to clobber it with (the same class of bug P2 fixed in
-// SetDeviceGateways itself).
-func TestDevicesUpdateCmdPreservesSelfReferencedIsGatewayFlag(t *testing.T) {
+// A regression test for A15: a device naming itself as one of its own
+// gateways is the degenerate case of a gateway chain (self-reference would
+// make device-1 both a gateway, via MarkGateways, and a declarer of a
+// gateway of its own -- itself). The update must be rejected before it
+// reaches Atom, not written through as it was before A15.
+func TestDevicesUpdateCmdRejectsSelfReference(t *testing.T) {
 	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", TenantID: "domain-1"})
 	rootCmd := setFlags(cli.NewDevicesCmd())
 
-	executeCommand(t, rootCmd, "device-1", updateCmd, `{"attributes":{"gateways":["device-1"]}}`)
+	out := executeCommand(t, rootCmd, "device-1", updateCmd, `{"attributes":{"gateways":["device-1"]}}`)
 
-	updated := fa.entities["device-1"]
-	assert.Equal(t, true, updated.Attributes["is_gateway"], "expected device-1's own is_gateway to survive naming itself as a gateway, got: %+v", updated.Attributes)
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "cannot declare its own gateways")
+	require.Empty(t, fa.requests, "a rejected write must never reach Atom")
+}
+
+// A regression test for A15: the create and update commands unmarshal
+// arbitrary Entity JSON and write it straight through, so is_gateway and
+// gateways can be set together in one payload -- exactly the combination
+// SetDeviceGateways's own ValidateGatewayChain rejects. This command must
+// reject it too, before ever calling CreateEntity/UpdateEntity.
+func TestDevicesCreateCmdRejectsGatewayDeclaringItsOwnGateways(t *testing.T) {
+	fa := newFakeAtom(t)
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, createCmd, `{"name":"pump-1","attributes":{"is_gateway":true,"gateways":["gw-1"]}}`, "domain-1")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "cannot declare its own gateways")
+	require.Empty(t, fa.requests, "a rejected write must never reach Atom")
+}
+
+func TestDevicesUpdateCmdRejectsGatewayDeclaringItsOwnGateways(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "device-1", Kind: "device", Attributes: atom.Attributes{"is_gateway": true}})
+	rootCmd := setFlags(cli.NewDevicesCmd())
+
+	out := executeCommand(t, rootCmd, "device-1", updateCmd, `{"attributes":{"is_gateway":true,"gateways":["gw-1"]}}`)
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "cannot declare its own gateways")
+	require.Empty(t, fa.requests, "a rejected write must never reach Atom")
 }
 
 func TestDevicesCmdUsageOnMissingArgs(t *testing.T) {

--- a/edge/architecture.md
+++ b/edge/architecture.md
@@ -861,6 +861,7 @@ something else, including the reversals.
 | A9 | Declared device↔gateway association | 🔴 | MG-15 | ⚠️ Superseded by A10 |
 | A10 | Group or relation? | 🔴 | MG-09, MG-15 | ✅ **Relation** — `gateways []` on the device |
 | A11 | What kind of thing is a Gateway? | 🟡 | model-wide | ✅ **Device with a proxy role** — reachability, not containment |
+| A15 | Can a gateway declare gateways of its own? | 🔴 | MG-09, UI-01 | ✅ **No — gateways do not chain**; enforced at write time |
 | B1 | Pending device data | ⚪ | — | ⚠️ **Superseded by A7+A8** — accept, late-bind |
 | B2 | Revocation window | 🟡 | MG-08 | open |
 | B3 | Admin bypass mechanism | 🟡 | MG-08 | ✅ **Explicit capability check** |
@@ -1590,6 +1591,75 @@ leaves it open.
 
 **Notes:** A staging decision, not a reversal of the model. The design above stays
 the target.
+
+---
+
+#### A15 🔴 Can a gateway declare gateways of its own?
+
+**Narrows:** A12's composability — a gateway may still report its own
+telemetry directly, per §2.2 consequence 4; what this rules out is a gateway
+being *reachable through* another gateway.
+
+Nothing in phase 1 forbade it. `gateways []` is 0..N on **any** device (§2.3),
+and a Gateway is just a Device (§2.1) — so by the letter of the model, gateway
+A could declare `gateways: ["B"]` where B is also `is_gateway: true`, and the
+implementation agreed: `pkg/atom/devices.go`'s `SetDeviceGateways` had no check
+against it, and explicitly special-cased the degenerate instance of it — a
+device naming *itself* — as supported, working behavior (the pre-A15 `P2` path,
+re-reading the device after `MarkGateways` specifically so a self-referential
+`is_gateway` write would not be clobbered).
+
+**The product decision: reject it.** A gateway may not carry a non-empty
+`gateways []` of its own — including naming itself. Two reasons:
+
+- **The relation is a reachability path (§2.1), and a gateway's own reachability
+  is not staged.** Every purpose the relation serves — commissioning record,
+  fault correlation, downlink hint, UI — assumes the *far* end is a leaf device
+  that cannot represent itself otherwise. A gateway already can: it holds
+  credentials and connects directly (§2.2 consequence 4). Chaining adds a
+  topology (and a downlink-routing question, §2.2 consequence 6) the model
+  never designed for, for a case the capability model does not need — a
+  concentrator-meter's own telemetry is already covered by A12 without chaining.
+- **It was never exercised deliberately.** The self-reference path existed
+  because nothing rejected it, not because a deployment needed it. Closing it
+  now, before MG-09 freezes the public API (its own words: "widest blast radius
+  in the programme"), is cheaper than closing it after the SDK and every client
+  ship against the wider contract.
+
+**DECIDED: gateways do not chain.** A device may not simultaneously carry
+`is_gateway: true` and a non-empty `gateways []`. Enforced at write time by
+`pkg/atom.ValidateGatewayChain`, called from both existing writers of these
+attributes — `SetDeviceGateways` and the CLI's device create/update commands —
+per the invariant contract on `AttributeGateways`. Self-reference is rejected
+by the same check, since it is the case where the two facts land in one call.
+
+**Consequences**
+
+- **Does not touch A12.** A gateway that also reports its own measurements —
+  the composite device UI-01's criterion 4 exists to guard — is unaffected: it
+  connects directly and never populates its own `gateways []`. Only *upstream*
+  gateways of a gateway are rejected.
+- **Magistrala-only.** Atom has no notion of "gateway" (ATOM-05) — `is_gateway`
+  and `gateways` are Magistrala-side attribute conventions on a generic
+  `device` entity, so nothing in Atom changes.
+- **Two write paths today, both updated.** `pkg/atom/devices.go`
+  (`SetDeviceGateways`) and `cli/devices.go` (create/update, which bypass
+  `SetDeviceGateways` entirely per the existing `P3` note). A future writer —
+  MG-09's HTTP API/SDK, not yet built — must call `ValidateGatewayChain` too,
+  the same obligation `AttributeGateways`'s doc comment already states for
+  `MarkGateways`.
+- **No migration performed here.** Existing data was only ever reachable
+  through the CLI (no UI or API enforced anything before this). Nothing in
+  this change sweeps or corrects devices already in that state; it only stops
+  new writes from creating it.
+
+**Decision:** Gateways do not chain — `is_gateway` and non-empty `gateways []`
+are mutually exclusive on one device, self-reference included
+
+**Notes:** A restriction relative to what phase 1 specified, not an
+implementation bug fix — the pre-A15 code was behaving as designed. Reached
+after `magistrala-ui`'s UI-side gateway-promotion logic diverged from the Go
+model and needed one of the two changed to match.
 
 ---
 

--- a/pkg/atom/constants.go
+++ b/pkg/atom/constants.go
@@ -100,11 +100,6 @@ const (
 
 const (
 	atomAttributeCreatedAt = "created_at"
-	// atomAttributeIsGateway marks a device as a gateway (spec §8 A12) — a
-	// gateway is not a separate entity kind, just a device with this set.
-	// See AttributeGateways (devices.go) for the invariant this must be
-	// kept in step with, and by whom.
-	atomAttributeIsGateway = "is_gateway"
 	atomAttributeMetadata  = "metadata"
 	atomAttributeRoute     = "route"
 	atomAttributeSource    = "source"

--- a/pkg/atom/devices.go
+++ b/pkg/atom/devices.go
@@ -15,21 +15,41 @@ import (
 // matches expectedCurrent — the caller's view was stale, so nothing was written.
 var ErrGatewaysConflict = errors.New("atom: device gateways changed since last read")
 
+// ErrGatewayCannotHaveGateways means the write being validated would leave a
+// device both a gateway and reachable through gateways of its own. Decided:
+// gateways do not chain -- a device with AttributeIsGateway set may not
+// declare AttributeGateways, and vice versa. See ValidateGatewayChain.
+var ErrGatewayCannotHaveGateways = errors.New("atom: a gateway cannot declare its own gateways")
+
 // AttributeGateways is a device's own list of the gateways it relays
-// through (spec §8 A12). INVARIANT: every id named here must have
-// attributes.is_gateway set on its own entity -- readAuthorizer's R1 scope
-// leg trusts a held device's publisher identity unconditionally whenever
-// is_gateway is false, so an id named here without it reopens finding 02's
-// cross-tenant leak (Q1). Nothing enforces this at the type level: every
-// writer of this attribute must call MarkGateways with the ids it names
-// immediately after writing, or use GatewaysDeclared to find them. As of
-// this writing the writers are SetDeviceGateways (this file) and the CLI's
-// device create/update commands (cli/devices.go) -- a new one (another
-// service, the SDK, a future API handler) must do the same or this
-// invariant silently breaks for it. Exported (T2) so that new writer can
-// actually find this contract in godoc, rather than needing to already
-// know an unexported identifier exists to look for it.
+// through (spec §8 A12). Two invariants apply, and nothing enforces either
+// at the type level -- every writer of this attribute (and of
+// AttributeIsGateway) is responsible for upholding both itself:
+//
+//  1. Every id named here must have AttributeIsGateway set on its own
+//     entity -- readAuthorizer's R1 scope leg trusts a held device's
+//     publisher identity unconditionally whenever is_gateway is false, so
+//     an id named here without it reopens finding 02's cross-tenant leak
+//     (Q1). Call MarkGateways with the ids it names immediately after
+//     writing, or use GatewaysDeclared to find them.
+//  2. A device may not carry both this attribute (non-empty) and
+//     AttributeIsGateway=true -- gateways do not chain (architecture.md §8
+//     A15). Call ValidateGatewayChain with the values about to be persisted
+//     before writing them.
+//
+// As of this writing the writers are SetDeviceGateways (this file) and the
+// CLI's device create/update commands (cli/devices.go) -- a new one
+// (another service, the SDK, a future API handler) must do the same or
+// these invariants silently break for it. Exported (T2) so that a new
+// writer can actually find this contract in godoc, rather than needing to
+// already know an unexported identifier exists to look for it.
 const AttributeGateways = "gateways"
+
+// AttributeIsGateway marks a device as a gateway (spec §8 A12) — a gateway
+// is not a separate entity kind, just a device with this set. Exported
+// alongside AttributeGateways: see its doc comment above for the two
+// invariants this attribute is half of.
+const AttributeIsGateway = "is_gateway"
 
 // SetDeviceGateways replaces a device's entire gateway list, preserving its
 // other attributes. expectedCurrent must match what DeviceGateways would
@@ -51,32 +71,38 @@ func (c *Client) SetDeviceGateways(ctx context.Context, deviceID string, gateway
 	if err := c.checkGatewaysCurrent(ctx, device, expectedCurrent); err != nil {
 		return err
 	}
+	isGateway, _ := device.Attributes[AttributeIsGateway].(bool)
+	if err := ValidateGatewayChain(deviceID, isGateway, gatewayIDs); err != nil {
+		return err
+	}
 
 	if err := c.MarkGateways(ctx, gatewayIDs); err != nil {
 		return err
 	}
 
-	// Re-read rather than reuse the snapshot taken above (P2): a device can
-	// name itself as one of its own gateways, in which case MarkGateways
-	// just wrote deviceID's own is_gateway through a separate call. Writing
-	// back the pre-mark snapshot here would silently discard that -- the
-	// same instant, no unrelated write in between required to trigger it.
+	// Re-read rather than reuse the snapshot taken above (S1): MarkGateways
+	// can take a while -- a batched read plus up to one UpdateEntity per
+	// unflagged gateway -- the widest gap this function has ever had
+	// between checking and writing, so a concurrent edit to deviceID's own
+	// attributes (this call's own gateways write aside) can land in it.
+	// ValidateGatewayChain above already rejects deviceID naming itself in
+	// gatewayIDs, so unlike before that check existed, MarkGateways can no
+	// longer have written to deviceID itself as a side effect here -- this
+	// re-read exists solely to narrow the race window, not to recover a
+	// self-write.
 	device, err = c.GetEntity(ctx, deviceID)
 	if err != nil {
 		return err
 	}
-	// Re-check against this re-read too (S1): MarkGateways can take a
-	// while -- a batched read plus up to one UpdateEntity per unflagged
-	// gateway -- the widest gap this function has ever had between
-	// checking and writing. The check above only covers the read at the
-	// top; without checking again here, a concurrent SetDeviceGateways
-	// landing in that window is visible in this re-read but gets silently
-	// overwritten by the write below regardless -- exactly the outcome
-	// ErrGatewaysConflict exists to report. This still cannot close the
-	// race against a genuinely concurrent edit landing after this second
-	// check — Atom has no compare-and-swap — but it shrinks the
-	// uncovered window back down to the same check-to-write gap that
-	// existed before MarkGateways was introduced.
+	// Re-check against this re-read too (S1): the check above only covers
+	// the read at the top; without checking again here, a concurrent
+	// SetDeviceGateways landing in that window is visible in this re-read
+	// but gets silently overwritten by the write below regardless --
+	// exactly the outcome ErrGatewaysConflict exists to report. This still
+	// cannot close the race against a genuinely concurrent edit landing
+	// after this second check — Atom has no compare-and-swap — but it
+	// shrinks the uncovered window back down to the same check-to-write gap
+	// that existed before MarkGateways was introduced.
 	if err := c.checkGatewaysCurrent(ctx, device, expectedCurrent); err != nil {
 		return err
 	}
@@ -85,6 +111,31 @@ func (c *Client) SetDeviceGateways(ctx context.Context, deviceID string, gateway
 	attrs[AttributeGateways] = gatewayIDs
 	_, err = c.UpdateEntity(ctx, deviceID, Entity{Attributes: attrs})
 	return err
+}
+
+// ValidateGatewayChain rejects a write that would leave deviceID both a
+// gateway and reachable through gateways of its own (architecture.md §8
+// A15: gateways do not chain). isGateway and gatewayIDs are the
+// AttributeIsGateway and AttributeGateways values the write in progress is
+// about to persist for deviceID -- not necessarily what is stored today.
+//
+// Self-reference -- deviceID present in gatewayIDs -- is rejected by the
+// same rule: MarkGateways would flag deviceID itself is_gateway as a side
+// effect of writing gatewayIDs, which is exactly the state this guards
+// against, whether or not isGateway was already true going in.
+func ValidateGatewayChain(deviceID string, isGateway bool, gatewayIDs []string) error {
+	if len(gatewayIDs) == 0 {
+		return nil
+	}
+	if isGateway {
+		return ErrGatewayCannotHaveGateways
+	}
+	for _, id := range gatewayIDs {
+		if id == deviceID {
+			return ErrGatewayCannotHaveGateways
+		}
+	}
+	return nil
 }
 
 // checkGatewaysCurrent reports ErrGatewaysConflict if device's live gateway
@@ -158,12 +209,12 @@ func (c *Client) MarkGateways(ctx context.Context, gatewayIDs []string) error {
 		if err := json.Unmarshal(data, &gateway); err != nil {
 			return err
 		}
-		if isGateway, _ := gateway.Attributes[atomAttributeIsGateway].(bool); isGateway {
+		if isGateway, _ := gateway.Attributes[AttributeIsGateway].(bool); isGateway {
 			continue
 		}
 
 		attrs := cloneAttributes(gateway.Attributes)
-		attrs[atomAttributeIsGateway] = true
+		attrs[AttributeIsGateway] = true
 		if _, err := c.UpdateEntity(ctx, id, Entity{Attributes: attrs}); err != nil {
 			return err
 		}

--- a/pkg/atom/devices_test.go
+++ b/pkg/atom/devices_test.go
@@ -286,7 +286,7 @@ func TestSetDeviceGatewaysFlagsNewlyLinkedGateway(t *testing.T) {
 	}
 
 	gw := fa.entities["gw-new"]
-	isGateway, _ := gw.Attributes[atomAttributeIsGateway].(bool)
+	isGateway, _ := gw.Attributes[AttributeIsGateway].(bool)
 	if !isGateway {
 		t.Fatalf("expected gw-new to be flagged is_gateway after being linked, got: %+v", gw.Attributes)
 	}
@@ -346,7 +346,7 @@ func TestSetDeviceGatewaysMarksGatewaysInOneBatchedRoundTrip(t *testing.T) {
 	}
 
 	for _, id := range gatewayIDs {
-		isGateway, _ := fa.entities[id].Attributes[atomAttributeIsGateway].(bool)
+		isGateway, _ := fa.entities[id].Attributes[AttributeIsGateway].(bool)
 		if !isGateway {
 			t.Fatalf("expected %s to be flagged is_gateway, got: %+v", id, fa.entities[id].Attributes)
 		}
@@ -364,33 +364,65 @@ func TestSetDeviceGatewaysMarksGatewaysInOneBatchedRoundTrip(t *testing.T) {
 	}
 }
 
-// A regression test for P2: a device naming itself as one of its own
-// gateways must end up with both its gateways list and its own is_gateway
-// flag set. markGateways sets is_gateway on device-1 through a separate
-// call than the one that writes device-1's gateways list; reusing the
-// snapshot read before markGateways ran -- rather than re-reading -- would
-// silently discard that flag when the gateways list is written back.
-func TestSetDeviceGatewaysPreservesSelfReferencedIsGatewayFlag(t *testing.T) {
+// A regression test for A15: gateways do not chain, and self-reference is
+// the degenerate case of that -- a device naming itself as one of its own
+// gateways would, via MarkGateways, become a gateway that also declares a
+// gateway of its own (itself). SetDeviceGateways must reject this before
+// MarkGateways ever runs, not silently honor it as before A15.
+func TestSetDeviceGatewaysRejectsSelfReference(t *testing.T) {
 	fa, srv := newFakeAtomDevices(t,
 		Entity{ID: "device-1", Kind: atomKindDevice, Attributes: Attributes{"source": "magistrala"}},
 	)
 
 	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
-	if err := client.SetDeviceGateways(context.Background(), "device-1", []string{"device-1"}, nil); err != nil {
-		t.Fatalf("set device gateways failed: %v", err)
+	err := client.SetDeviceGateways(context.Background(), "device-1", []string{"device-1"}, nil)
+	if !errors.Is(err, ErrGatewayCannotHaveGateways) {
+		t.Fatalf("expected ErrGatewayCannotHaveGateways, got %v", err)
 	}
+	if fa.updateCalls != 0 {
+		t.Fatalf("a rejected self-reference must not write, got %d update calls", fa.updateCalls)
+	}
+	unchanged := fa.entities["device-1"]
+	if _, isGateway := unchanged.Attributes[AttributeIsGateway]; isGateway {
+		t.Fatalf("device-1 must not be flagged is_gateway when the write was rejected, got: %+v", unchanged.Attributes)
+	}
+}
 
-	updated := fa.entities["device-1"]
-	isGateway, _ := updated.Attributes[atomAttributeIsGateway].(bool)
-	if !isGateway {
-		t.Fatalf("expected device-1's own is_gateway to survive naming itself as a gateway, got: %+v", updated.Attributes)
+// A regression test for A15: a device already flagged is_gateway may not be
+// given upstream gateways of its own -- gateways do not chain.
+func TestSetDeviceGatewaysRejectsGatewayDeclaringItsOwnGateways(t *testing.T) {
+	fa, srv := newFakeAtomDevices(t,
+		Entity{ID: "gw-1", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+		Entity{ID: "gw-2", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true}},
+	)
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	err := client.SetDeviceGateways(context.Background(), "gw-1", []string{"gw-2"}, nil)
+	if !errors.Is(err, ErrGatewayCannotHaveGateways) {
+		t.Fatalf("expected ErrGatewayCannotHaveGateways, got %v", err)
 	}
-	got := attrStrings(updated.Attributes, AttributeGateways)
-	if !sameStringSet(got, []string{"device-1"}) {
-		t.Fatalf("expected device-1's gateways list to be written, got: %+v", got)
+	if fa.updateCalls != 0 {
+		t.Fatalf("a rejected chain must not write, got %d update calls", fa.updateCalls)
 	}
-	if updated.Attributes["source"] != "magistrala" {
-		t.Fatalf("write must preserve unrelated attributes, got: %+v", updated.Attributes)
+	got := attrStrings(fa.entities["gw-1"].Attributes, AttributeGateways)
+	if len(got) != 0 {
+		t.Fatalf("gw-1's gateways must be unchanged, got: %+v", got)
+	}
+}
+
+// Clearing a gateway's (empty) gateway list is not chaining and must still
+// be allowed regardless of is_gateway.
+func TestSetDeviceGatewaysAllowsClearingAGatewaysEmptyList(t *testing.T) {
+	fa, srv := newFakeAtomDevices(t,
+		Entity{ID: "gw-1", Kind: atomKindDevice, Attributes: Attributes{"is_gateway": true, "gateways": []string{}}},
+	)
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	if err := client.SetDeviceGateways(context.Background(), "gw-1", nil, nil); err != nil {
+		t.Fatalf("clearing an already-empty gateway list must succeed, got: %v", err)
+	}
+	if fa.updateCalls != 1 {
+		t.Fatalf("expected exactly one write, got %d", fa.updateCalls)
 	}
 }
 

--- a/pkg/atom/external_id.go
+++ b/pkg/atom/external_id.go
@@ -93,7 +93,7 @@ func (c *Client) EntityDeviceInfo(ctx context.Context, ids []string) (map[string
 		if err := json.Unmarshal(data, &entity); err != nil {
 			return nil, nil, err
 		}
-		isGateway, _ := entity.Attributes[atomAttributeIsGateway].(bool)
+		isGateway, _ := entity.Attributes[AttributeIsGateway].(bool)
 		out[id] = DeviceInfo{ExternalID: entity.ExternalID, IsGateway: isGateway}
 	}
 	return out, unreadable, nil


### PR DESCRIPTION
## Summary

- Adds `pkg/atom.ValidateGatewayChain`: a device may not simultaneously carry `is_gateway: true` and a non-empty `gateways []` — a gateway may still report its own telemetry directly (A12's composite device is unaffected), but it may not itself be reachable through another gateway. Self-reference is rejected by the same rule.
- Enforced at both existing writers of these attributes: `SetDeviceGateways` (`pkg/atom/devices.go`) and the CLI's device create/update commands (`cli/devices.go`), which bypass `SetDeviceGateways` entirely.
- Exports `AttributeIsGateway` alongside the already-exported `AttributeGateways`, so a future writer (MG-09's HTTP API/SDK, not yet built) can find both halves of the contract.
- Records the decision as **A15** in `edge/architecture.md`'s decision log, including why it doesn't touch A12/ATOM-05 and why it's Magistrala-only (Atom has no notion of "gateway" — `is_gateway`/`gateways` are attribute conventions on a generic `device` entity).

## Why

`magistrala-ui`'s Access-page review flagged that its UI-side gateway-promotion logic already prohibits nested gateway topology, but nothing on this side enforced the same rule — `SetDeviceGateways` had no check against it, and even special-cased a device naming itself as one of its own gateways as supported, working behavior. This closes that gap so the two repos agree, before MG-09 freezes the public API shape.

No data migration is included: existing data was only ever reachable through the CLI (nothing on the UI or API side enforced anything before this), so this only stops new writes from creating the state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./pkg/atom/... ./cli/... ./readers/...` — updated existing self-reference tests to assert rejection instead of tolerance, added new tests for the chain-rejection and clearing-an-empty-list cases