### PR TITLE
Seed default device types on domain creation

### DIFF
--- a/cli/atom_commands.go
+++ b/cli/atom_commands.go
@@ -4,8 +4,10 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/absmach/magistrala/pkg/atom"
 	"github.com/spf13/cobra"
 )
 
@@ -92,10 +94,6 @@ const (
     total
     items { ` + tenantFields + ` }
   }
-}`
-
-	createDomainMutation = `mutation CreateDomain($input: CreateTenantInput!) {
-  createTenant(input: $input) { ` + tenantFields + ` }
 }`
 
 	getChannelQuery = `query GetChannel($id: ID!) {
@@ -259,28 +257,40 @@ func newDomainsCmd(opts *rootOptions) *cobra.Command {
 func newDomainCreateCmd(opts *rootOptions) *cobra.Command {
 	var alias, attrs string
 
-	return newGQLCmd(opts, gqlCmdConfig{
-		use:   "create <name>",
-		short: "Create a domain",
-		args:  cobra.ExactArgs(1),
-		query: createDomainMutation,
-		field: respCreateTenant,
-		vars: func(args []string) (map[string]any, error) {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a domain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			if !requireAtomClient(cmd) {
+				return nil
+			}
 			attributes, err := parseJSONFlag(attrs)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			input := gqlInput{varName: args[0]}
-			input.setString(varAlias, alias)
-			input.setObject(varAttributes, attributes)
 
-			return map[string]any{varInput: input}, nil
+			tenant, err := atomClient.CreateTenant(cmd.Context(), atom.Tenant{
+				Name:       args[0],
+				Route:      alias,
+				Attributes: attributes,
+			})
+			if err != nil {
+				return err
+			}
+
+			raw, err := json.Marshal(tenant)
+			if err != nil {
+				return err
+			}
+			return writeOutput(cmd, raw)
 		},
-		flags: func(cmd *cobra.Command) {
-			cmd.Flags().StringVar(&alias, varAlias, "", "domain alias")
-			cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
-		},
-	})
+	}
+	cmd.Flags().StringVar(&alias, varAlias, "", "domain alias")
+	cmd.Flags().StringVar(&attrs, varAttributes, "", "JSON attributes")
+
+	return cmd
 }
 
 func newDomainListCmd(opts *rootOptions) *cobra.Command {

--- a/cli/atom_commands_test.go
+++ b/cli/atom_commands_test.go
@@ -108,3 +108,88 @@ func TestGroupCreateRejectsUnsupportedGroupType(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDomainCreateSeedsDefaultDeviceTypes(t *testing.T) {
+	clearAtomEnv(t)
+	createdKeys := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		switch {
+		case strings.Contains(req.Query, "createTenant"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createTenant": map[string]any{
+						"id":     "domain-1",
+						"name":   "Domain",
+						"route":  "domain",
+						"status": "active",
+					},
+				},
+			})
+		case strings.Contains(req.Query, "query DeviceTypes("):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"profiles": map[string]any{"total": 0, "items": []any{}},
+				},
+			})
+		case strings.Contains(req.Query, "mutation CreateDeviceType("):
+			input, ok := req.Variables[varInput].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected profile input: %#v", req.Variables[varInput])
+			}
+			key, _ := input["key"].(string)
+			createdKeys[key] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createProfile": map[string]any{
+						"id":        "profile-" + key,
+						"tenant_id": "domain-1",
+						"key":       key,
+						"name":      input["displayName"],
+						"status":    "active",
+					},
+				},
+			})
+		case strings.Contains(req.Query, "query DeviceTypeVersions("):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"profileVersions": []any{}},
+			})
+		case strings.Contains(req.Query, "mutation CreateDeviceTypeVersion("):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createProfileVersion": map[string]any{
+						"id":             "version-1",
+						"device_type_id": req.Variables["profileId"],
+						"version":        1,
+						"json_schema":    req.Variables[varInput].(map[string]any)["jsonSchema"],
+						"ui_schema":      req.Variables[varInput].(map[string]any)["uiSchema"],
+						"status":         "active",
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+	}))
+	defer server.Close()
+
+	err := runRootCmd(t,
+		"--graphql-url", server.URL+atomGraphQLPath,
+		"--token", "test-token",
+		cmdDomains, "create", "Domain",
+		"--alias", "domain",
+	)
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+
+	for _, key := range []string{"water-meter", "pressure-sensor", "energy-meter", "pump-controller"} {
+		if !createdKeys[key] {
+			t.Fatalf("default device type %q was not created: %+v", key, createdKeys)
+		}
+	}
+}

--- a/pkg/atom/api.go
+++ b/pkg/atom/api.go
@@ -63,6 +63,12 @@ func (c *Client) CreateTenant(ctx context.Context, tenant Tenant) (Tenant, error
 	err := c.graphQL(ctx, `mutation CreateTenant($input: CreateTenantInput!) {
 		createTenant(input: $input) { id name route: alias status tags attributes created_by: createdBy updated_by: updatedBy created_at: createdAt updated_at: updatedAt }
 	}`, map[string]any{atomInputKeyInput: tenantCreateInput(tenant)}, &out)
+	if err != nil {
+		return Tenant{}, err
+	}
+	if err := c.seedDefaultDeviceTypes(ctx, out.CreateTenant.ID); err != nil {
+		return Tenant{}, fmt.Errorf("seed default device types: %w", err)
+	}
 	return out.CreateTenant, err
 }
 

--- a/pkg/atom/client_test.go
+++ b/pkg/atom/client_test.go
@@ -303,6 +303,8 @@ func TestCurrentAtomCompatibilitySurface(t *testing.T) {
 }
 
 func TestCreateTenantMapsRouteToAlias(t *testing.T) {
+	createdKeys := map[string]bool{}
+	versionedTypes := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != atomGraphQLPath {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -314,29 +316,84 @@ func TestCreateTenantMapsRouteToAlias(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if !strings.Contains(payload.Query, "createTenant") || !strings.Contains(payload.Query, "route: alias") {
-			t.Fatalf("query does not map tenant alias to route: %s", payload.Query)
-		}
-		input, ok := payload.Variables["input"].(map[string]any)
-		if !ok {
-			t.Fatalf("unexpected input: %+v", payload.Variables["input"])
-		}
-		if input["alias"] != "d1" {
-			t.Fatalf("expected alias input from route, got: %+v", input)
-		}
-		if _, ok := input["route"]; ok {
-			t.Fatalf("input must not use Atom route field: %+v", input)
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{
-				"createTenant": map[string]any{
-					"id":     testTenantID,
-					"name":   "D1",
-					"route":  "d1",
-					"status": "active",
+
+		switch {
+		case strings.Contains(payload.Query, "createTenant"):
+			if !strings.Contains(payload.Query, "route: alias") {
+				t.Fatalf("query does not map tenant alias to route: %s", payload.Query)
+			}
+			input, ok := payload.Variables["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected input: %+v", payload.Variables["input"])
+			}
+			if input["alias"] != "d1" {
+				t.Fatalf("expected alias input from route, got: %+v", input)
+			}
+			if _, ok := input["route"]; ok {
+				t.Fatalf("input must not use Atom route field: %+v", input)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createTenant": map[string]any{
+						"id":     testTenantID,
+						"name":   "D1",
+						"route":  "d1",
+						"status": "active",
+					},
 				},
-			},
-		})
+			})
+		case strings.Contains(payload.Query, "query DeviceTypes("):
+			if payload.Variables["tenantId"] != testTenantID {
+				t.Fatalf("default device type list must be tenant scoped: %+v", payload.Variables)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"profiles": map[string]any{"total": 0, "items": []any{}},
+				},
+			})
+		case strings.Contains(payload.Query, "mutation CreateDeviceType("):
+			input, ok := payload.Variables["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected device type input: %+v", payload.Variables["input"])
+			}
+			key, _ := input["key"].(string)
+			createdKeys[key] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createProfile": map[string]any{
+						"id":        "profile-" + key,
+						"tenant_id": testTenantID,
+						"key":       key,
+						"name":      input["displayName"],
+						"status":    DeviceTypeStatusActive,
+					},
+				},
+			})
+		case strings.Contains(payload.Query, "query DeviceTypeVersions("):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"profileVersions": []any{}},
+			})
+		case strings.Contains(payload.Query, "mutation CreateDeviceTypeVersion("):
+			versionedTypes++
+			input, ok := payload.Variables["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("unexpected device type version input: %+v", payload.Variables["input"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"createProfileVersion": map[string]any{
+						"id":             fmt.Sprintf("version-%d", versionedTypes),
+						"device_type_id": payload.Variables["profileId"],
+						"version":        input["version"],
+						"json_schema":    input["jsonSchema"],
+						"ui_schema":      input["uiSchema"],
+						"status":         DeviceTypeVersionStatusActive,
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected GraphQL query: %s", payload.Query)
+		}
 	}))
 	defer srv.Close()
 
@@ -347,6 +404,17 @@ func TestCreateTenantMapsRouteToAlias(t *testing.T) {
 	}
 	if got.ID != testTenantID || got.Route != "d1" {
 		t.Fatalf("unexpected tenant: %+v", got)
+	}
+	if got, want := len(createdKeys), len(defaultDeviceTypes(testTenantID)); got != want {
+		t.Fatalf("expected %d default device types, got %d: %+v", want, got, createdKeys)
+	}
+	for _, key := range []string{"water-meter", "pressure-sensor", "energy-meter", "pump-controller"} {
+		if !createdKeys[key] {
+			t.Fatalf("default device type %q was not created: %+v", key, createdKeys)
+		}
+	}
+	if versionedTypes != len(defaultDeviceTypes(testTenantID)) {
+		t.Fatalf("expected every default device type to get a version, got %d", versionedTypes)
 	}
 }
 

--- a/pkg/atom/default_device_types.go
+++ b/pkg/atom/default_device_types.go
@@ -1,0 +1,138 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package atom
+
+import "context"
+
+type defaultDeviceType struct {
+	DeviceType DeviceType
+	Version    DeviceTypeVersion
+}
+
+// defaultDeviceTypes is the small catalogue every tenant starts with. The
+// versions deliberately avoid required measurements: Atom validates device
+// attributes, not telemetry messages, so a default type must not block creating
+// a device before attributes are populated.
+func defaultDeviceTypes(tenantID string) []defaultDeviceType {
+	return []defaultDeviceType{
+		defaultType(tenantID, "water-meter", "Water Meter", "Measures water consumption and flow.", measurements(
+			numberMeasurement("total_volume", "m3"),
+			numberMeasurement("flow_rate", "m3/h"),
+			numberMeasurement("battery", "%", withRange(0, 100)),
+		), intervalCommand()),
+		defaultType(tenantID, "pressure-sensor", "Pressure Sensor", "Measures line, wellhead, and casing pressure.", measurements(
+			numberMeasurement("pressure", "bar"),
+			numberMeasurement("wellhead_pressure", "psi"),
+			numberMeasurement("casing_pressure", "psi"),
+			numberMeasurement("battery", "%", withRange(0, 100)),
+		), intervalCommand()),
+		defaultType(tenantID, "energy-meter", "Energy Meter", "Measures electrical energy and power draw.", measurements(
+			numberMeasurement("energy", "kWh"),
+			numberMeasurement("power", "W"),
+			numberMeasurement("voltage", "V"),
+		), intervalCommand()),
+		defaultType(tenantID, "pump-controller", "Pump Controller", "Controls and monitors pump operation.", measurements(
+			booleanMeasurement("pump_running"),
+			numberMeasurement("pump_energy", "kWh"),
+			numberMeasurement("battery", "%", withRange(0, 100)),
+		), command("set_pump", "Set pump state.", map[string]string{"running": ValueTypeBoolean})),
+	}
+}
+
+func (c *Client) seedDefaultDeviceTypes(ctx context.Context, tenantID string) error {
+	existing, err := c.ListDeviceTypes(ctx, DeviceTypeQuery{TenantID: tenantID, Limit: 1000})
+	if err != nil {
+		return err
+	}
+	byKey := make(map[string]DeviceType, len(existing.Items))
+	for _, deviceType := range existing.Items {
+		byKey[deviceType.Key] = deviceType
+	}
+
+	for _, seed := range defaultDeviceTypes(tenantID) {
+		deviceType, ok := byKey[seed.DeviceType.Key]
+		if !ok {
+			created, err := c.CreateDeviceType(ctx, seed.DeviceType)
+			if err != nil {
+				return err
+			}
+			deviceType = created
+		}
+
+		versions, err := c.listDeviceTypeVersionsRaw(ctx, deviceType.ID)
+		if err != nil {
+			return err
+		}
+		if len(versions) > 0 {
+			continue
+		}
+		if _, err := c.CreateDeviceTypeVersion(ctx, deviceType.ID, seed.Version); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func defaultType(tenantID, key, name, description string, measurements []Measurement, commands ...Command) defaultDeviceType {
+	return defaultDeviceType{
+		DeviceType: DeviceType{
+			TenantID:    tenantID,
+			Key:         key,
+			Name:        name,
+			Description: description,
+			Status:      DeviceTypeStatusActive,
+		},
+		Version: DeviceTypeVersion{
+			Version: 1,
+			Status:  DeviceTypeVersionStatusActive,
+			Capabilities: CapabilityDocument{
+				Measurements: measurements,
+				Commands:     compactCommands(commands),
+			},
+		},
+	}
+}
+
+func measurements(measurements ...Measurement) []Measurement {
+	return measurements
+}
+
+type measurementOption func(*Measurement)
+
+func numberMeasurement(name, unit string, opts ...measurementOption) Measurement {
+	measurement := Measurement{Name: name, Unit: unit, Type: ValueTypeNumber, Access: MeasurementAccessRead}
+	for _, opt := range opts {
+		opt(&measurement)
+	}
+	return measurement
+}
+
+func booleanMeasurement(name string) Measurement {
+	return Measurement{Name: name, Type: ValueTypeBoolean, Access: MeasurementAccessRead}
+}
+
+func withRange(min, max float64) measurementOption {
+	return func(measurement *Measurement) {
+		measurement.Min = &min
+		measurement.Max = &max
+	}
+}
+
+func command(name, description string, params map[string]string) Command {
+	return Command{Name: name, Description: description, Params: params}
+}
+
+func intervalCommand() Command {
+	return command("set_interval", "Set telemetry reporting interval.", map[string]string{"seconds": ValueTypeInteger})
+}
+
+func compactCommands(commands []Command) []Command {
+	compacted := commands[:0]
+	for _, command := range commands {
+		if command.Name != "" {
+			compacted = append(compacted, command)
+		}
+	}
+	return compacted
+}


### PR DESCRIPTION
## Summary
- seed new Atom tenants with four default device types: Water Meter, Pressure Sensor, Energy Meter, and Pump Controller
- route Atom-backed CLI domain creation through pkg/atom so CLI-created domains get the same defaults
- add regression coverage for API/client and CLI domain creation seeding

## Tests
- GOCACHE=/tmp/magistrala-go-build go test ./pkg/atom ./cli