### PR TITLE
NOISSUE - Provision a real workspace for the bootstrap API CI test

### DIFF
--- a/.github/workflows/api-tests.yaml
+++ b/.github/workflows/api-tests.yaml
@@ -110,6 +110,45 @@ jobs:
           export USER_TOKEN=$(curl -fsS -X POST "$ATOM_LOGIN_URL" -H "Content-Type: application/json" -d "{\"identifier\":\"$USER_IDENTITY\",\"secret\":\"$USER_SECRET\",\"kind\":\"password\"}" | jq -er .token)
           echo "USER_TOKEN=$USER_TOKEN" >> $GITHUB_ENV
 
+      # The bootstrap.yaml examples reference a fixed placeholder workspaceID
+      # that doesn't exist in a fresh Atom instance, and Atom denies every
+      # request scoped to a tenant/resource it has no role assignment for
+      # (there is no automatic superadmin bypass). This provisions a real
+      # workspace, a role that covers every action the bootstrap service's
+      # tenant- and resource-scoped checks require, and one real config and
+      # profile so the {configID}/{profileID}-scoped operations resolve
+      # against an object Atom actually knows about instead of the spec's
+      # placeholder IDs.
+      - name: Provision Bootstrap test workspace
+        if: steps.changes.outputs.bootstrap == 'true' && hashFiles('bootstrap/api/**') != ''
+        run: |
+          gql() {
+            curl -fsS http://localhost/graphql -H "Authorization: Bearer $USER_TOKEN" -H 'Content-Type: application/json' --data @-
+          }
+
+          ADMIN_ID="00000000-0000-0000-0000-000000000001"
+          TENANT_ACTIONS='["3f0d052a-0c7a-4a0b-b582-bd63307e761a","7f28fa61-065d-45ee-9362-e34225e07ece","237db9ef-c385-4ac2-856b-23757a43cf59","aa1e4196-a6ca-4830-a291-ff6fc0a90903"]'
+          RESOURCE_ACTIONS='["aa1e4196-a6ca-4830-a291-ff6fc0a90903","7f28fa61-065d-45ee-9362-e34225e07ece","203e7303-c02c-43f9-8938-543fa1fd8339","3f0d052a-0c7a-4a0b-b582-bd63307e761a"]'
+
+          WORKSPACE_ID=$(jq -n '{query:"mutation CreateWorkspace($input: CreateTenantInput!) { createTenant(input: $input) { id } }",variables:{input:{name:("ci-bootstrap-" + (now|tostring))}}}' | gql | jq -er '.data.createTenant.id')
+
+          PB_TENANT=$(jq -n --arg t "$WORKSPACE_ID" --argjson a "$TENANT_ACTIONS" '{query:"mutation CreateBlock($input: CreatePermissionBlockInput!) { createPermissionBlock(input: $input) { id } }",variables:{input:{tenantId:$t,scopeMode:"object",objectKind:"tenant",objectId:$t,effect:"allow",actionIds:$a}}}' | gql | jq -er '.data.createPermissionBlock.id')
+          PB_CONFIG=$(jq -n --arg t "$WORKSPACE_ID" --argjson a "$RESOURCE_ACTIONS" '{query:"mutation CreateBlock($input: CreatePermissionBlockInput!) { createPermissionBlock(input: $input) { id } }",variables:{input:{tenantId:$t,scopeMode:"object_type",objectKind:"resource",objectType:"resource:bootstrap_config",effect:"allow",actionIds:$a}}}' | gql | jq -er '.data.createPermissionBlock.id')
+          PB_PROFILE=$(jq -n --arg t "$WORKSPACE_ID" --argjson a "$RESOURCE_ACTIONS" '{query:"mutation CreateBlock($input: CreatePermissionBlockInput!) { createPermissionBlock(input: $input) { id } }",variables:{input:{tenantId:$t,scopeMode:"object_type",objectKind:"resource",objectType:"resource:bootstrap_profile",effect:"allow",actionIds:$a}}}' | gql | jq -er '.data.createPermissionBlock.id')
+
+          ROLE_ID=$(jq -n --arg t "$WORKSPACE_ID" '{query:"mutation CreateRole($input: CreateRoleInput!) { createRole(input: $input) { id } }",variables:{input:{name:"ci-bootstrap-tester",description:"CI smoke test role",tenantId:$t}}}' | gql | jq -er '.data.createRole.id')
+
+          jq -n --arg r "$ROLE_ID" --argjson ids "[\"$PB_TENANT\",\"$PB_CONFIG\",\"$PB_PROFILE\"]" '{query:"mutation Attach($roleId: ID!, $permissionBlockIds: [ID!]!) { replaceRolePermissionBlocks(roleId: $roleId, permissionBlockIds: $permissionBlockIds) }",variables:{roleId:$r,permissionBlockIds:$ids}}' | gql > /dev/null
+
+          jq -n --arg s "$ADMIN_ID" --arg r "$ROLE_ID" --arg t "$WORKSPACE_ID" '{query:"mutation Assign($input: CreateRoleAssignmentInput!) { createRoleAssignment(input: $input) { id } }",variables:{input:{subjectKind:"entity",subjectId:$s,roleId:$r,tenantId:$t}}}' | gql > /dev/null
+
+          CONFIG_ID=$(curl -fsS -X POST "$BOOTSTRAP_URL/$WORKSPACE_ID/clients/configs" -H "Authorization: Bearer $USER_TOKEN" -H 'Content-Type: application/json' -d '{"external_id":"ci-ext-id","external_key":"ci-ext-key","name":"ci-config"}' | jq -er .id)
+          PROFILE_ID=$(curl -fsS -X POST "$BOOTSTRAP_URL/$WORKSPACE_ID/clients/bootstrap/profiles" -H "Authorization: Bearer $USER_TOKEN" -H 'Content-Type: application/json' -d '{"name":"ci-profile"}' | jq -er .id)
+
+          echo "BOOTSTRAP_WORKSPACE_ID=$WORKSPACE_ID" >> $GITHUB_ENV
+          echo "BOOTSTRAP_CONFIG_ID=$CONFIG_ID" >> $GITHUB_ENV
+          echo "BOOTSTRAP_PROFILE_ID=$PROFILE_ID" >> $GITHUB_ENV
+
       - name: Run Bootstrap API tests
         if: steps.changes.outputs.bootstrap == 'true' && hashFiles('bootstrap/api/**') != ''
         uses: schemathesis/action@v3.0.0
@@ -117,7 +156,12 @@ jobs:
           schema: apidocs/openapi/bootstrap.yaml
           base-url: ${{ env.BOOTSTRAP_URL }}
           checks: all
-          args: '--header "Authorization: Bearer ${{ env.USER_TOKEN }}" --suppress-health-check=filter_too_much --exclude-checks=positive_data_acceptance --phases=examples'
+          # DELETE is excluded because both DELETE operations in this spec
+          # (config, profile) share the same --set-path fixture ID as every
+          # other {configID}/{profileID} operation in the same run; once a
+          # DELETE test case fires, later operations that reuse that ID
+          # legitimately 403 against a now-nonexistent resource.
+          args: '--header "Authorization: Bearer ${{ env.USER_TOKEN }}" --suppress-health-check=filter_too_much --exclude-checks=positive_data_acceptance --exclude-method=DELETE --set-path "workspaceID=${{ env.BOOTSTRAP_WORKSPACE_ID }}" --set-path "configID=${{ env.BOOTSTRAP_CONFIG_ID }}" --set-path "profileID=${{ env.BOOTSTRAP_PROFILE_ID }}" --phases=examples'
           coverage-artifact-name: schema-coverage-bootstrap
           coverage-pr-comment: false
 

--- a/apidocs/openapi/bootstrap.yaml
+++ b/apidocs/openapi/bootstrap.yaml
@@ -500,6 +500,7 @@ paths:
                 properties:
                   binding_slots:
                     type: array
+                    nullable: true
                     items:
                       $ref: "#/components/schemas/BindingSlot"
         "401":


### PR DESCRIPTION
## Summary

Follow-up to #3600 — the Bootstrap API schemathesis job (`Run Bootstrap API tests` in `.github/workflows/api-tests.yaml`) has actually been failing since the bootstrap service was first added (confirmed on #3555's own CI run, before any client/device renaming existed), not because of anything in #3600.

**Root cause:** `apidocs/openapi/bootstrap.yaml`'s `WorkspaceID` parameter example is a fixed placeholder UUID (`bb7edb32-2eac-4aad-aebe-ed96fe073879`) that doesn't exist in the fresh Atom instance CI spins up each run. Every workspace-scoped request gets denied — Atom has no automatic superadmin bypass; even the seeded `admin` user needs an explicit role assignment before any tenant/resource authorization check passes. I confirmed this by reproducing the exact failure locally, then working out and validating the real fix against a live stack.

## Fix

Adds a `Provision Bootstrap test workspace` step (after login, before the schemathesis run) that:
1. Creates a real Atom tenant via `createTenant`.
2. Creates permission blocks covering the tenant-scoped (`list`/`write`/`create`/`read`) and resource-scoped (`read`/`write`/`delete`/`list` on `resource:bootstrap_config` and `resource:bootstrap_profile`) actions the bootstrap service's `AtomAuthorizationMiddleware` actually checks.
3. Creates a role, attaches the blocks, and assigns it to the admin entity.
4. Creates one real bootstrap config and one real bootstrap profile — the `{configID}`/`{profileID}`-scoped operations need Atom to recognize an actual object, not just the tenant.
5. Feeds all three real IDs into schemathesis via `--set-path` instead of the spec's placeholder values.

`--exclude-method=DELETE` is added because both DELETE operations in this spec (config, profile) share the same `--set-path` fixture ID as every other operation scoped to that parameter — once schemathesis's DELETE test case fires, later operations reusing that ID correctly get denied (the resource is gone). This is a smoke/contract test, not exhaustive CRUD lifecycle testing, so excluding DELETE from this pass is the pragmatic tradeoff versus a more complex per-operation fixture scheme.

Also fixes a real, pre-existing bug this same test run caught: `apidocs/openapi/bootstrap.yaml`'s profile-slots response declared `binding_slots` as a plain array, but the server legitimately returns `null` for a profile with no slots defined (`profileSlotsRes.BindingSlots` has no `omitempty`) — added `nullable: true`.

## Test plan

- [x] Reproduced the original failure locally (fresh workspace UUID → 403 on every bootstrap endpoint), confirmed it matches CI's failure exactly
- [x] Confirmed via a direct `authzCheck` GraphQL call that the seeded admin has no policy on any tenant without an explicit role assignment (no superadmin bypass)
- [x] Built and ran the full docker-compose stack locally (`make all`, `make dockers_dev`, `make provision_atom_tokens`, `make run_latest_ci`, `make run_addons`), replicating the CI recipe
- [x] Extracted the exact new workflow step script and ran it verbatim against the live stack
- [x] Ran the actual `apidocs/openapi/bootstrap.yaml` schema with the resulting real IDs via `schemathesis run ... --set-path ...`: **18 passed, 0 failed, 4 skipped** (skips are pre-existing operations with no example in the schema, unrelated to this fix)
- [x] `go build ./...` (workflow/spec-only change, no Go code touched)