### PR TITLE
Add Atom self password change client

### DIFF
--- a/apidocs/graphql/README.md
+++ b/apidocs/graphql/README.md
@@ -143,6 +143,20 @@ mutation {
 }
 ```
 
+### Change Your Own Password
+
+Self-service password changes require the caller to prove knowledge of the
+current password:
+
+```graphql
+mutation {
+  changeOwnPassword(
+    currentPassword: "old-p@ssw0rd"
+    newPassword: "new-s3cur3-p@ssw0rd"
+  )
+}
+```
+
 ### Create A Device
 
 ```graphql

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,6 +58,14 @@ Tenant-scoped credentials can pass either a tenant ID or alias:
 ./build/cli login user@example.com secret --tenant-alias <workspace_alias>
 ```
 
+## Password
+
+Authenticated users must provide their current password when changing it:
+
+```bash
+./build/cli --token "$ATOM_USER_TOKEN" password change <current_password> <new_password>
+```
+
 ## Workspaces
 
 Workspaces map to Atom tenants.

--- a/cli/atom_commands.go
+++ b/cli/atom_commands.go
@@ -36,6 +36,7 @@ const (
 // Top-level response fields selected out of the GraphQL data object.
 const (
 	respLogin          = "login"
+	respChangePassword = "changeOwnPassword"
 	respTenant         = "tenant"
 	respTenants        = "tenants"
 	respCreateTenant   = "createTenant"
@@ -259,6 +260,38 @@ func newLoginCmd(opts *rootOptions) *cobra.Command {
 			cmd.Flags().StringVar(&kind, varKind, "password", "credential kind")
 		},
 	})
+}
+
+func newPasswordCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{Use: "password", Short: "Manage the authenticated user's password"}
+	cmd.AddCommand(newPasswordChangeCmd(opts))
+
+	return cmd
+}
+
+func newPasswordChangeCmd(opts *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "change <current_password> <new_password>",
+		Short: "Change the authenticated user's password",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			if _, err := opts.authedClient(); err != nil {
+				return err
+			}
+			if !requireAtomClient(cmd) {
+				return nil
+			}
+
+			if err := atomClient.ChangeOwnPassword(cmd.Context(), args[0], args[1]); err != nil {
+				return err
+			}
+			logOKCmd(*cmd)
+
+			return nil
+		},
+	}
 }
 
 func newWorkspacesCmd(opts *rootOptions) *cobra.Command {

--- a/cli/atom_commands_test.go
+++ b/cli/atom_commands_test.go
@@ -109,6 +109,33 @@ func TestGroupCreateRejectsUnsupportedGroupType(t *testing.T) {
 	}
 }
 
+func TestPasswordChangeUsesVerifiedSelfMutation(t *testing.T) {
+	clearAtomEnv(t)
+	server, req := recordingServer(t, `{"data":{"`+respChangePassword+`":true}}`)
+
+	err := runRootCmd(t,
+		"--graphql-url", server.URL+atomGraphQLPath,
+		"--token", "test-token",
+		"password", "change", "old-password", "new-password",
+	)
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+
+	if !strings.Contains(req.Query, "changeOwnPassword") {
+		t.Errorf("query does not change own password: %s", req.Query)
+	}
+	if strings.Contains(req.Query, "createPassword") {
+		t.Errorf("password change must not create a replacement credential directly: %s", req.Query)
+	}
+	if req.Variables["currentPassword"] != "old-password" {
+		t.Errorf("unexpected current password variable: %#v", req.Variables["currentPassword"])
+	}
+	if req.Variables["newPassword"] != "new-password" {
+		t.Errorf("unexpected new password variable: %#v", req.Variables["newPassword"])
+	}
+}
+
 func TestWorkspaceCreateSeedsDefaultDeviceTypes(t *testing.T) {
 	clearAtomEnv(t)
 	createdKeys := map[string]bool{}

--- a/cli/root.go
+++ b/cli/root.go
@@ -67,6 +67,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		NewHealthCmd(),
 		newLoginCmd(opts),
+		newPasswordCmd(opts),
 		newWorkspacesCmd(opts),
 		newGraphQLChannelsCmd(opts),
 		newGraphQLGroupsCmd(opts),

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -22,8 +22,8 @@ func TestRootCommandContainsAtomBackedCommands(t *testing.T) {
 	clearAtomEnv(t)
 	cmd := NewRootCmd()
 	for _, name := range []string{
-		"health", "login", cmdWorkspaces, cmdChannels, cmdGroups, "authz",
-		"devices", "gateways", "devicetypes",
+		"health", "login", "password", cmdWorkspaces, cmdChannels, cmdGroups,
+		"authz", "devices", "gateways", "devicetypes",
 	} {
 		if subcmd, _, err := cmd.Find([]string{name}); err != nil || subcmd == nil || subcmd.Name() != name {
 			t.Fatalf("expected command %q to be registered", name)

--- a/pkg/atom/api.go
+++ b/pkg/atom/api.go
@@ -739,6 +739,12 @@ func (c *Client) CreatePassword(ctx context.Context, entityID, password string) 
 	}`, map[string]any{atomInputKeyEntityID: entityID, "password": password}, nil)
 }
 
+func (c *Client) ChangeOwnPassword(ctx context.Context, currentPassword, newPassword string) error {
+	return c.graphQL(ctx, `mutation ChangeOwnPassword($currentPassword: String!, $newPassword: String!) {
+		changeOwnPassword(currentPassword: $currentPassword, newPassword: $newPassword)
+	}`, map[string]any{"currentPassword": currentPassword, "newPassword": newPassword}, nil)
+}
+
 func (c *Client) CreateUnscopedAccessToken(ctx context.Context, entityID, name, description string) (AccessTokenResponse, error) {
 	var out struct {
 		CreateAccessToken AccessTokenResponse `json:"createAccessToken"`

--- a/pkg/atom/client_test.go
+++ b/pkg/atom/client_test.go
@@ -601,6 +601,38 @@ func TestRevealSharedKey(t *testing.T) {
 	}
 }
 
+func TestChangeOwnPassword(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != atomGraphQLPath {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(payload.Query, "changeOwnPassword") {
+			t.Fatalf("query does not change own password: %s", payload.Query)
+		}
+		if payload.Variables["currentPassword"] != "old-password" || payload.Variables["newPassword"] != "new-password" {
+			t.Fatalf("unexpected variables: %+v", payload.Variables)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"changeOwnPassword": true,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{URL: srv.URL, Timeout: time.Second})
+	if err := client.ChangeOwnPassword(context.Background(), "old-password", "new-password"); err != nil {
+		t.Fatalf("change own password failed: %v", err)
+	}
+}
+
 func TestListCredentials(t *testing.T) {
 	createdAt := "2026-06-30T10:15:30Z"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add a `ChangeOwnPassword` helper to the Go Atom GraphQL client
- cover the GraphQL request shape in `pkg/atom` tests
- document the self-service `changeOwnPassword` mutation alongside admin password creation

## Related work
- Pairs with Atom PR 90, which adds the server-side mutation and current-password verification.
- Used by magistrala-ui PR 1538 for Profile > Password.

## Verification
- go test ./pkg/atom
