### PR TITLE
Fix compose UI image to match the published ui-community name

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -739,7 +739,7 @@ MG_UI_BACKEND_INSTANCE_ID=
 MG_UI_BACKEND_URL=http://ui-backend:9097
 MG_UI_VERIFICATION_TLS=false
 MG_UI_CONTENT_TYPE=application/senml+json
-OTEL_SERVICE_NAME=ui-mg
+OTEL_SERVICE_NAME=ui-community
 OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
 
 # Object storage for images
@@ -774,7 +774,7 @@ MG_PUBLISH_PROXY_URL=http://nginx:80
 MG_READER_URL=http://timescale-reader:9011
 
 ### UI Configuration
-MG_UI_TYPE=mg
+MG_UI_TYPE=community
 MG_UI_DEVICE_TYPE=device
 MG_UI_BASE_PATH=/
 MG_NEXTAUTH_BASE_PATH=/api/auth

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -431,7 +431,7 @@ services:
       - magistrala-base-net
 
   ui:
-    image: ghcr.io/absmach/magistrala/ui-mg:${MG_RELEASE_TAG}
+    image: ghcr.io/absmach/magistrala/ui-community:${MG_RELEASE_TAG}
     container_name: magistrala-ui
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- `docker/docker-compose.yaml` hardcoded `ghcr.io/absmach/magistrala/ui-mg` for the `ui` service, but [magistrala-ui#1564](https://github.com/absmach/magistrala-ui/pull/1564) renames the published community image to `ghcr.io/absmach/magistrala/ui-community` to match its own compose file's `ui-${MG_UI_TYPE}` templating. Update the image reference here to match.
- `docker/.env` defaulted `MG_UI_TYPE=mg`, which isn't a valid UI type in magistrala-ui (valid values are `community`, `ee`, `propeller`) and doesn't match the community image this compose file pulls. Set it to `community`, and update `OTEL_SERVICE_NAME` from the same stale `ui-mg` value to `ui-community` for consistency.
- Without this, anyone running the documented `docker compose -f docker/docker-compose.yaml up` with the checked-in `.env` would fail to pull/start the `ui` container once the renamed image is published.

## Test plan
- [x] `docker compose -f docker/docker-compose.yaml --env-file .env config` — validates and resolves the `ui` service image to `ghcr.io/absmach/magistrala/ui-community:latest`