### PR TITLE
Fix bootstrap List/ListProfiles to check "read" instead of "list"

### DIFF
--- a/bootstrap/middleware/atom_authorization.go
+++ b/bootstrap/middleware/atom_authorization.go
@@ -61,9 +61,12 @@ func (am *atomAuthorizationMiddleware) UpdateCert(ctx context.Context, session a
 }
 
 func (am *atomAuthorizationMiddleware) List(ctx context.Context, session authn.Session, filter bootstrap.Filter, offset, limit uint64) (bootstrap.ConfigsPage, error) {
-	// Listing reads; requiring tenant write would make the read-only role
-	// that holds the registered tenant "list" capability unable to use it.
-	if err := am.tenant(ctx, session, "list"); err != nil {
+	// Listing reads, so it checks "read" rather than "write" or a distinct
+	// "list" capability. This matches alarms and re: their list operations
+	// resolve through permission.yaml to a "*_read_permission" string, which
+	// CapabilityName collapses to "read" — no tenant role is ever granted a
+	// standalone "list" capability.
+	if err := am.tenant(ctx, session, "read"); err != nil {
 		return bootstrap.ConfigsPage{}, err
 	}
 	return am.Service.List(ctx, session, filter, offset, limit)
@@ -112,8 +115,8 @@ func (am *atomAuthorizationMiddleware) UpdateProfile(ctx context.Context, sessio
 }
 
 func (am *atomAuthorizationMiddleware) ListProfiles(ctx context.Context, session authn.Session, offset, limit uint64, name string) (bootstrap.ProfilesPage, error) {
-	// See List: this reads, so it checks the tenant "list" capability.
-	if err := am.tenant(ctx, session, "list"); err != nil {
+	// See List: this reads, so it checks "read".
+	if err := am.tenant(ctx, session, "read"); err != nil {
 		return bootstrap.ProfilesPage{}, err
 	}
 	return am.Service.ListProfiles(ctx, session, offset, limit, name)


### PR DESCRIPTION
## Summary
- `bootstrap/middleware/atom_authorization.go`'s `List` and `ListProfiles` checked the tenant `"list"` capability directly via `am.tenant(ctx, session, "list")`. No tenant role is ever granted a standalone `"list"` capability in Atom — verified against a live instance, where `read`/`write`/`manage` all return `allowed: true` for the tenant-admin/owner role on a given tenant, but `list` always returns `{"allowed": false, "reason": "no matching allow policy"}`, regardless of subject or tenant.
- Alarms and re don't hit this because their list operations don't check a literal `"list"` capability either: `docker/permission.yaml` maps their `list` operation to `alarm_read_permission` / `rule_read_permission`, and `atom.CapabilityName()` collapses any permission string containing `"read"` to the `"read"` capability. Bootstrap has no `permission.yaml` entry and calls `atom.Authorize` with a hardcoded literal capability string, so it never got that indirection — it really did check `"list"`.
- Changes both calls to check `"read"` instead, matching the capability alarms/re actually end up checking.

Reported symptom: after fixing the `clients/...` → `devices/...` route rename (absmach/magistrala-sdk-ts#299, absmach/magistrala-ui#1565), the bootstrap page still failed with "failed to perform authorization over the entity" for every user on every tenant, including a freshly created tenant's own owner.

## Test plan
- [x] `go build ./bootstrap/...`
- [x] `go test ./bootstrap/...`
- [x] Replicated the `authzCheck` GraphQL mutation directly against a live Atom instance with the exact request shape bootstrap sends: `action=list` → denied ("no matching allow policy"), `action=read` → allowed, for the same subject/tenant.