### PR TITLE
Wrap unsupported bootstrap binding type as a typed error

### DIFF
--- a/api/http/common.go
+++ b/api/http/common.go
@@ -170,6 +170,11 @@ func EncodeResponse(_ context.Context, w http.ResponseWriter, response any) erro
 	return json.NewEncoder(w).Encode(response)
 }
 
+// internalServerErrorMessage is returned for any error that reaches
+// EncodeError without being one of the typed magistrala errors below, so the
+// response body is always valid, parseable JSON instead of empty.
+const internalServerErrorMessage = "internal server error"
+
 // EncodeError encodes an error response.
 func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", ContentType)
@@ -243,6 +248,15 @@ func EncodeError(_ context.Context, err error, w http.ResponseWriter) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	default:
+		// err reached here without being classified as one of the typed
+		// magistrala errors above, so it carries no safe-to-expose message.
+		// Still write a JSON body (not just the status) so that every
+		// client parsing an error response as JSON - across every service
+		// using this shared encoder - gets a real message instead of an
+		// empty body that fails to parse.
 		w.WriteHeader(http.StatusInternalServerError)
+		if err := json.NewEncoder(w).Encode(map[string]string{"message": internalServerErrorMessage}); err != nil {
+			return
+		}
 	}
 }

--- a/api/http/common_test.go
+++ b/api/http/common_test.go
@@ -6,6 +6,7 @@ package http_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -313,6 +314,17 @@ func TestEncodeError(t *testing.T) {
 			err:     errors.NewInternalError(),
 			code:    http.StatusInternalServerError,
 			hasBody: false,
+		},
+		{
+			// A plain, unwrapped error (e.g. a service that forgot to wrap a
+			// resolver/repository error in one of the typed errors above)
+			// must still produce a valid JSON body, not an empty one: an
+			// empty body previously broke every client that parses error
+			// responses as JSON (SyntaxError: Unexpected end of JSON input).
+			desc:    "Untyped error - falls through to default",
+			err:     fmt.Errorf("some untyped error"),
+			code:    http.StatusInternalServerError,
+			hasBody: true,
 		},
 	}
 

--- a/bootstrap/atom_resolver.go
+++ b/bootstrap/atom_resolver.go
@@ -37,7 +37,7 @@ func (r *atomResolver) Resolve(ctx context.Context, req ResolveRequest) ([]Bindi
 		case "channel":
 			snapshot, err = r.resource(ctx, req.Enrollment.WorkspaceID, binding)
 		default:
-			err = fmt.Errorf("unsupported binding type %q", binding.Type)
+			err = errors.NewRequestError(fmt.Sprintf("unsupported binding type %q", binding.Type))
 		}
 		if err != nil {
 			return nil, err

--- a/bootstrap/atom_resolver_test.go
+++ b/bootstrap/atom_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/absmach/magistrala/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +44,19 @@ func TestAtomResolverEnforcesTenantAndAllowListsAttributes(t *testing.T) {
 		Requested:  []BindingRequest{{Slot: "device", Type: "device", ResourceID: "device-1"}},
 	})
 	require.Error(t, err)
+}
+
+func TestAtomResolverRejectsUnsupportedBindingTypeAsRequestError(t *testing.T) {
+	resolver := NewAtomResolver(atomReaderStub{})
+	_, err := resolver.Resolve(context.Background(), ResolveRequest{
+		Enrollment: Config{WorkspaceID: "tenant-1"},
+		Requested:  []BindingRequest{{Slot: "sensor", Type: "client", ResourceID: "device-1"}},
+	})
+	require.Error(t, err)
+	// Must be a typed, nestable error so it survives errors.Wrap in the
+	// caller and reaches EncodeError as a *RequestError (400 with a JSON
+	// body), instead of an opaque error that falls through to an empty-body
+	// 500 - see bootstrap.BindResources and api/http.EncodeError.
+	var reqErr *errors.RequestError
+	require.ErrorAs(t, err, &reqErr)
 }


### PR DESCRIPTION
## Summary
- `atomResolver.Resolve` returned a plain `fmt.Errorf` for an unrecognized binding type. Wrapped through `BindResources`, that error chain never became a nestable magistrala error, so `EncodeError` fell through to its `default` case: a `500` with **no body at all**. Any client parsing the error response as JSON (the UI included) saw a raw `SyntaxError: Unexpected end of JSON input` instead of the real problem.
- Fix: use `errors.NewRequestError` in the resolver so the error survives `errors.Wrap` and reaches `EncodeError` as a `*RequestError` — `400 Bad Request` with a real `{"message": ...}` body, which is also the semantically correct status for a client-supplied, invalid binding type.
- Also harden `EncodeError`'s `default` branch itself: any error that isn't one of the typed magistrala errors now still gets a generic JSON body instead of an empty one. This lives in the shared HTTP encoder used by every service, not just bootstrap, so it protects any future caller that forgets to wrap a returned error the same way.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./bootstrap/... ./api/...`
- [x] `go test ./bootstrap/... ./api/...` — all passing, including two new regression tests:
  - `TestAtomResolverRejectsUnsupportedBindingTypeAsRequestError` (bootstrap)
  - `TestEncodeError/Untyped_error_-_falls_through_to_default` (api/http)
- [x] Rebuilt the `bootstrap` service image locally and verified against the running dev stack: a bad binding type now returns `400 {"message":"unsupported binding type \"client\""}` instead of an empty `500`.