### PR TITLE
Fix readers 500 on out-of-range from/to time bounds

### DIFF
--- a/api/http/util/errors.go
+++ b/api/http/util/errors.go
@@ -214,6 +214,10 @@ var (
 	// ErrMissingTo indicates missing to value.
 	ErrMissingTo = errors.NewRequestError("missing to time value")
 
+	// ErrInvalidTimeRange indicates a from/to value outside the range a
+	// stored timestamp can represent.
+	ErrInvalidTimeRange = errors.NewRequestError("invalid time range")
+
 	// ErrEmptyMessage indicates empty message.
 	ErrEmptyMessage = errors.NewRequestError("empty message")
 

--- a/readers/api/grpc/errors.go
+++ b/readers/api/grpc/errors.go
@@ -13,6 +13,10 @@ import (
 
 // encodeError maps a service error onto the gRPC status the reader returns.
 func encodeError(err error) error {
+	if _, ok := err.(*errors.RequestError); ok {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	switch {
 	case errors.Contains(err, nil):
 		return nil

--- a/readers/api/grpc/errors_test.go
+++ b/readers/api/grpc/errors_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package grpc
+
+import (
+	"testing"
+
+	apiutil "github.com/absmach/magistrala/api/http/util"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestEncodeErrorMapsRequestErrorsToInvalidArgument(t *testing.T) {
+	err := encodeError(apiutil.ErrInvalidTimeRange)
+
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/readers/api/grpc/request.go
+++ b/readers/api/grpc/request.go
@@ -4,7 +4,6 @@
 package grpc
 
 import (
-	"math"
 	"slices"
 	"strings"
 	"time"
@@ -26,24 +25,6 @@ const (
 
 var validAggregations = []string{aggregationMax, aggregationMin, aggregationAvg, aggregationSum, aggregationCount}
 
-// minStorableTime and maxStorableTime bound the from/to page metadata to
-// what the stored "time" column -- a BIGINT of Unix nanoseconds (see
-// consumers/writers/timescale and readers/postgres migrations) -- can
-// represent. Binding an out-of-range float64 against that int64 column
-// fails in the database driver rather than here, which the HTTP layer
-// surfaces as a 500; validating it up front turns that into a normal
-// request error instead.
-var (
-	minStorableTime = float64(math.MinInt64)
-	maxStorableTime = float64(math.MaxInt64)
-)
-
-// validTimeRange reports whether v -- an optional (zero-means-unset) from/to
-// bound -- fits in the stored timestamp's int64 range.
-func validTimeRange(v float64) bool {
-	return v == 0 || (v >= minStorableTime && v <= maxStorableTime)
-}
-
 type readMessagesReq struct {
 	chanID    string
 	workspace string
@@ -62,7 +43,7 @@ func (req readMessagesReq) validate() error {
 		return apiutil.ErrLimitSize
 	}
 
-	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+	if !readers.ValidTimeRange(req.pageMeta.From) || !readers.ValidTimeRange(req.pageMeta.To) {
 		return apiutil.ErrInvalidTimeRange
 	}
 
@@ -137,7 +118,7 @@ func (req deviceViewReq) validate() error {
 		return apiutil.ErrLimitSize
 	}
 
-	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+	if !readers.ValidTimeRange(req.pageMeta.From) || !readers.ValidTimeRange(req.pageMeta.To) {
 		return apiutil.ErrInvalidTimeRange
 	}
 

--- a/readers/api/grpc/request.go
+++ b/readers/api/grpc/request.go
@@ -4,6 +4,7 @@
 package grpc
 
 import (
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -25,6 +26,24 @@ const (
 
 var validAggregations = []string{aggregationMax, aggregationMin, aggregationAvg, aggregationSum, aggregationCount}
 
+// minStorableTime and maxStorableTime bound the from/to page metadata to
+// what the stored "time" column -- a BIGINT of Unix nanoseconds (see
+// consumers/writers/timescale and readers/postgres migrations) -- can
+// represent. Binding an out-of-range float64 against that int64 column
+// fails in the database driver rather than here, which the HTTP layer
+// surfaces as a 500; validating it up front turns that into a normal
+// request error instead.
+var (
+	minStorableTime = float64(math.MinInt64)
+	maxStorableTime = float64(math.MaxInt64)
+)
+
+// validTimeRange reports whether v -- an optional (zero-means-unset) from/to
+// bound -- fits in the stored timestamp's int64 range.
+func validTimeRange(v float64) bool {
+	return v == 0 || (v >= minStorableTime && v <= maxStorableTime)
+}
+
 type readMessagesReq struct {
 	chanID    string
 	workspace string
@@ -41,6 +60,10 @@ func (req readMessagesReq) validate() error {
 
 	if req.pageMeta.Limit < 1 || req.pageMeta.Limit > maxLimitSize {
 		return apiutil.ErrLimitSize
+	}
+
+	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+		return apiutil.ErrInvalidTimeRange
 	}
 
 	if req.pageMeta.Comparator != "" &&
@@ -112,6 +135,10 @@ func (req deviceViewReq) validate() error {
 
 	if req.pageMeta.Limit < 1 || req.pageMeta.Limit > maxLimitSize {
 		return apiutil.ErrLimitSize
+	}
+
+	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+		return apiutil.ErrInvalidTimeRange
 	}
 
 	return nil

--- a/readers/api/grpc/request_internal_test.go
+++ b/readers/api/grpc/request_internal_test.go
@@ -5,6 +5,7 @@ package grpc
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -157,14 +158,25 @@ func TestDeviceViewReqValidateRejectsOutOfRangeTimeBounds(t *testing.T) {
 	tooLarge := valid
 	tooLarge.pageMeta.To = 9999999999999999999
 	require.Error(t, tooLarge.validate())
+
+	roundedMaxInt64 := valid
+	roundedMaxInt64.pageMeta.To = float64(math.MaxInt64)
+	require.Error(t, roundedMaxInt64.validate())
 }
 
 // Same bound, on the plain ReadMessages request.
 func TestReadMessagesReqValidateRejectsOutOfRangeTimeBounds(t *testing.T) {
-	req := readMessagesReq{
-		chanID:    "channel",
-		workspace: "workspace",
-		pageMeta:  readers.PageMetadata{Limit: 10, To: 9999999999999999999},
+	for _, value := range []float64{
+		float64(math.MaxInt64),
+		9999999999999999999,
+	} {
+		t.Run("", func(t *testing.T) {
+			req := readMessagesReq{
+				chanID:    "channel",
+				workspace: "workspace",
+				pageMeta:  readers.PageMetadata{Limit: 10, To: value},
+			}
+			require.Error(t, req.validate())
+		})
 	}
-	require.Error(t, req.validate())
 }

--- a/readers/api/grpc/request_internal_test.go
+++ b/readers/api/grpc/request_internal_test.go
@@ -139,3 +139,32 @@ func TestDeviceViewReqValidateRejectsMalformedPublisherID(t *testing.T) {
 	}
 	require.NoError(t, serial.validate())
 }
+
+// A from/to bound outside the int64 range of the stored "time" column must
+// be rejected as a request error: the column is a BIGINT of Unix
+// nanoseconds, and binding an out-of-range float64 against it fails in the
+// database driver rather than here.
+func TestDeviceViewReqValidateRejectsOutOfRangeTimeBounds(t *testing.T) {
+	valid := deviceViewReq{
+		chanID:            "channel",
+		workspace:         "workspace",
+		filterVal:         "1dcf1a0e-7a9d-4b1e-8d5f-9c2e6a3b4d01",
+		filterIsPublisher: true,
+		pageMeta:          readers.PageMetadata{Limit: 10, From: 100, To: 200},
+	}
+	require.NoError(t, valid.validate())
+
+	tooLarge := valid
+	tooLarge.pageMeta.To = 9999999999999999999
+	require.Error(t, tooLarge.validate())
+}
+
+// Same bound, on the plain ReadMessages request.
+func TestReadMessagesReqValidateRejectsOutOfRangeTimeBounds(t *testing.T) {
+	req := readMessagesReq{
+		chanID:    "channel",
+		workspace: "workspace",
+		pageMeta:  readers.PageMetadata{Limit: 10, To: 9999999999999999999},
+	}
+	require.Error(t, req.validate())
+}

--- a/readers/api/http/deviceview_test.go
+++ b/readers/api/http/deviceview_test.go
@@ -308,6 +308,45 @@ func TestDeviceViewReqValidateRejectsMalformedPublisherID(t *testing.T) {
 	require.NoError(t, serial.validate())
 }
 
+// A from/to bound outside the int64 range of the stored "time" column must
+// be rejected as a request error, not reach the repository: the column is a
+// BIGINT of Unix nanoseconds, and binding an out-of-range float64 against it
+// fails in the database driver, which previously surfaced as a 500 instead
+// of a 400.
+func TestDeviceViewReqValidateRejectsOutOfRangeTimeBounds(t *testing.T) {
+	valid := deviceViewReq{
+		chanID:            e2eChanID,
+		token:             "token",
+		workspace:         e2eWorkspace,
+		filterVal:         "1dcf1a0e-7a9d-4b1e-8d5f-9c2e6a3b4d01",
+		filterIsPublisher: true,
+		pageMeta:          readers.PageMetadata{Limit: 10, From: 100, To: 200},
+	}
+	require.NoError(t, valid.validate())
+
+	tooLargeTo := valid
+	tooLargeTo.pageMeta.To = 9999999999999999999
+	require.Error(t, tooLargeTo.validate())
+
+	tooLargeFrom := valid
+	tooLargeFrom.pageMeta.From = -9999999999999999999
+	require.Error(t, tooLargeFrom.validate())
+}
+
+// End-to-end repro of the reported bug: a valid publisher id with an
+// unparseable-by-the-database `to` must not reach the repository at all.
+func TestListGatewayDevicesRejectsOutOfRangeTimeBounds(t *testing.T) {
+	deps := newDeviceViewDeps(t, true)
+	// No authn/repo expectations: validate() must reject before either is reached.
+
+	req := gatewayDevicesReq("1dcf1a0e-7a9d-4b1e-8d5f-9c2e6a3b4d01")
+	req.pageMeta.To = 9999999999999999999
+
+	_, err := deps.gatewayDevicesEP(context.Background(), req)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid time range")
+}
+
 // The unbounded form must not be the easy one to call: omitting both from
 // and to bounds the query to the last 24h rather than the whole table.
 func TestDecodeGatewayDevicesAppliesDefaultWindow(t *testing.T) {

--- a/readers/api/http/requests.go
+++ b/readers/api/http/requests.go
@@ -4,7 +4,6 @@
 package http
 
 import (
-	"math"
 	"regexp"
 	"slices"
 	"strings"
@@ -16,24 +15,6 @@ import (
 )
 
 const maxLimitSize = 1000
-
-// minStorableTime and maxStorableTime bound the from/to query parameters to
-// what the stored "time" column -- a BIGINT of Unix nanoseconds (see
-// consumers/writers/timescale and readers/postgres migrations) -- can
-// represent. from/to are decoded as float64 (api/http/util.ReadNumQuery), so
-// an out-of-range value such as `to=9999999999999999999` parses without
-// error and would otherwise only fail once the database driver tries to bind
-// it against that int64 column, surfacing as a 500 instead of a 400.
-var (
-	minStorableTime = float64(math.MinInt64)
-	maxStorableTime = float64(math.MaxInt64)
-)
-
-// validTimeRange reports whether v -- an optional (zero-means-unset) from/to
-// bound -- fits in the stored timestamp's int64 range.
-func validTimeRange(v float64) bool {
-	return v == 0 || (v >= minStorableTime && v <= maxStorableTime)
-}
 
 var validAggregations = []string{"MAX", "MIN", "AVG", "SUM", "COUNT"}
 
@@ -73,7 +54,7 @@ func (req listMessagesReq) validate() error {
 		return apiutil.ErrInvalidFormat
 	}
 
-	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+	if !readers.ValidTimeRange(req.pageMeta.From) || !readers.ValidTimeRange(req.pageMeta.To) {
 		return apiutil.ErrInvalidTimeRange
 	}
 
@@ -153,7 +134,7 @@ func (req deviceViewReq) validate() error {
 		return apiutil.ErrLimitSize
 	}
 
-	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+	if !readers.ValidTimeRange(req.pageMeta.From) || !readers.ValidTimeRange(req.pageMeta.To) {
 		return apiutil.ErrInvalidTimeRange
 	}
 

--- a/readers/api/http/requests.go
+++ b/readers/api/http/requests.go
@@ -4,6 +4,7 @@
 package http
 
 import (
+	"math"
 	"regexp"
 	"slices"
 	"strings"
@@ -15,6 +16,24 @@ import (
 )
 
 const maxLimitSize = 1000
+
+// minStorableTime and maxStorableTime bound the from/to query parameters to
+// what the stored "time" column -- a BIGINT of Unix nanoseconds (see
+// consumers/writers/timescale and readers/postgres migrations) -- can
+// represent. from/to are decoded as float64 (api/http/util.ReadNumQuery), so
+// an out-of-range value such as `to=9999999999999999999` parses without
+// error and would otherwise only fail once the database driver tries to bind
+// it against that int64 column, surfacing as a 500 instead of a 400.
+var (
+	minStorableTime = float64(math.MinInt64)
+	maxStorableTime = float64(math.MaxInt64)
+)
+
+// validTimeRange reports whether v -- an optional (zero-means-unset) from/to
+// bound -- fits in the stored timestamp's int64 range.
+func validTimeRange(v float64) bool {
+	return v == 0 || (v >= minStorableTime && v <= maxStorableTime)
+}
 
 var validAggregations = []string{"MAX", "MIN", "AVG", "SUM", "COUNT"}
 
@@ -52,6 +71,10 @@ func (req listMessagesReq) validate() error {
 
 	if req.pageMeta.Format != "" && !validFormat.MatchString(req.pageMeta.Format) {
 		return apiutil.ErrInvalidFormat
+	}
+
+	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+		return apiutil.ErrInvalidTimeRange
 	}
 
 	if req.pageMeta.Comparator != "" &&
@@ -128,6 +151,10 @@ func (req deviceViewReq) validate() error {
 
 	if req.pageMeta.Limit < 1 || req.pageMeta.Limit > maxLimitSize {
 		return apiutil.ErrLimitSize
+	}
+
+	if !validTimeRange(req.pageMeta.From) || !validTimeRange(req.pageMeta.To) {
+		return apiutil.ErrInvalidTimeRange
 	}
 
 	return nil

--- a/readers/api/http/transport_test.go
+++ b/readers/api/http/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http/httptest"
 	"testing"
 
@@ -122,15 +123,22 @@ func TestDecodeListWithoutDeviceIDFilterLeavesItUnset(t *testing.T) {
 // decodeList's ReadNumQuery decodes it fine (it's a valid float64), so the
 // rejection has to happen in validate().
 func TestListMessagesRejectsOutOfRangeTimeBounds(t *testing.T) {
-	deps := newTestDeps(t)
-	// No authn/repo expectations: validate() must reject before either is reached.
+	for _, value := range []float64{
+		float64(math.MaxInt64),
+		9999999999999999999,
+	} {
+		t.Run("", func(t *testing.T) {
+			deps := newTestDeps(t)
+			// No authn/repo expectations: validate() must reject before either is reached.
 
-	req := tokenReq("", nil)
-	req.pageMeta.To = 9999999999999999999
+			req := tokenReq("", nil)
+			req.pageMeta.To = value
 
-	_, err := deps.endpoint(context.Background(), req)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "invalid time range")
+			_, err := deps.endpoint(context.Background(), req)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "invalid time range")
+		})
+	}
 }
 
 func tokenReq(publisher string, publishers []string) listMessagesReq {

--- a/readers/api/http/transport_test.go
+++ b/readers/api/http/transport_test.go
@@ -116,6 +116,23 @@ func TestDecodeListWithoutDeviceIDFilterLeavesItUnset(t *testing.T) {
 	assert.Nil(t, req.pageMeta.Publishers)
 }
 
+// A from/to value outside the int64 range of the stored "time" column (e.g.
+// a client sending `to=9999999999999999999`) must be rejected as a request
+// error before it reaches the repository, not surface as a database error.
+// decodeList's ReadNumQuery decodes it fine (it's a valid float64), so the
+// rejection has to happen in validate().
+func TestListMessagesRejectsOutOfRangeTimeBounds(t *testing.T) {
+	deps := newTestDeps(t)
+	// No authn/repo expectations: validate() must reject before either is reached.
+
+	req := tokenReq("", nil)
+	req.pageMeta.To = 9999999999999999999
+
+	_, err := deps.endpoint(context.Background(), req)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid time range")
+}
+
 func tokenReq(publisher string, publishers []string) listMessagesReq {
 	return listMessagesReq{
 		chanID:    e2eChanID,

--- a/readers/window.go
+++ b/readers/window.go
@@ -3,7 +3,10 @@
 
 package readers
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // DeviceViewDefaultWindow bounds an MG-15 observed-device query, and is also
 // the width DefaultTimeWindow falls back to when a caller supplies neither
@@ -20,6 +23,22 @@ import "time"
 // the default would get an empty roster for the last 24h; supply from/to
 // explicitly in your own unit.
 const DeviceViewDefaultWindow = 24 * time.Hour
+
+// minStorableTime and maxStorableTime bound from/to values to timestamps that
+// can safely be represented as int64 Unix nanoseconds. Timescale stores time
+// as BIGINT, so binding values outside this range can otherwise fail in the
+// database driver or wrap instead of returning a request error.
+var (
+	minStorableTime = float64(math.MinInt64)
+	maxStorableTime = float64(math.MaxInt64)
+)
+
+// ValidTimeRange reports whether v fits in the stored timestamp's int64 range.
+// MaxInt64 is not exactly representable as float64: it rounds to 2^63, one past
+// the largest int64, so the upper bound must be strict.
+func ValidTimeRange(v float64) bool {
+	return v == 0 || (v >= minStorableTime && v < maxStorableTime)
+}
 
 // DefaultTimeWindow fills in whichever of the two bounds the caller left at
 // zero so the resulting query is always bounded to DeviceViewDefaultWindow:

--- a/readers/window_test.go
+++ b/readers/window_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package readers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidTimeRangeRejectsRoundedMaxInt64Boundary(t *testing.T) {
+	assert.True(t, ValidTimeRange(0))
+	assert.True(t, ValidTimeRange(float64(math.MinInt64)))
+	assert.False(t, ValidTimeRange(float64(math.MaxInt64)))
+	assert.False(t, ValidTimeRange(9999999999999999999))
+}


### PR DESCRIPTION
## Summary

- Reader `from`/`to` query parameters are decoded as `float64` and, until now, were never bounds-checked before being bound against the stored `time` column, which is a `BIGINT` of Unix nanoseconds (see `consumers/writers/timescale/init.go`).
- A value outside the `int64` range (e.g. `to=9999999999999999999`, ~1e19) parses fine as a `float64` at decode time, but the database driver fails to encode it against the `int8` column, and that failure surfaced as a generic `HTTP 500 {"message":"internal server error"}` instead of a `400`.
- Most visibly reproducible on `GET /{workspaceId}/channels/{channelId}/devices` (the gateway roster / observed-gateway-devices endpoint), but the same root cause affects the plain messages-list endpoint and the gRPC reader API (`ReadMessages`, `ListGatewayDevices`, `ListDeviceGateways`), since they all share the same `PageMetadata.From/To` float64 fields feeding the same SQL/binding path in both `readers/postgres` and `readers/timescale`.

## Fix

- Added a shared `validTimeRange` bounds check (`math.MinInt64`..`math.MaxInt64`) to the `validate()` methods of `listMessagesReq`/`deviceViewReq` (HTTP, `readers/api/http/requests.go`) and `readMessagesReq`/`deviceViewReq` (gRPC, `readers/api/grpc/request.go`), so an out-of-range value is now rejected as a normal `400` request error before it ever reaches the repository/database.
- Added `apiutil.ErrInvalidTimeRange` ("invalid time range") in `api/http/util/errors.go`.
- Repro confirmed against a real Postgres/Timescale container before the fix: the driver returned `unable to encode 1e+19 into binary format for int8 (OID 20): ... is greater than maximum value for int64`, which the service wrapped and returned as a 500.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./readers/... ./api/...`
- [x] `go test ./readers/... ./api/http/...` (includes the dockertest-backed `readers/postgres` and `readers/timescale` suites against real Postgres/Timescale containers)
- [x] Added regression tests:
  - `readers/api/http/transport_test.go`: `TestListMessagesRejectsOutOfRangeTimeBounds`
  - `readers/api/http/deviceview_test.go`: `TestDeviceViewReqValidateRejectsOutOfRangeTimeBounds`, `TestListGatewayDevicesRejectsOutOfRangeTimeBounds` (end-to-end repro of the reported case: valid publisher UUID + out-of-range `to`)
  - `readers/api/grpc/request_internal_test.go`: `TestDeviceViewReqValidateRejectsOutOfRangeTimeBounds`, `TestReadMessagesReqValidateRejectsOutOfRangeTimeBounds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159k7r536nikLaj36GdVbtu