### PR TITLE
NOISSUE - Add users CLI command

### DIFF
--- a/cli/atom_fake_test.go
+++ b/cli/atom_fake_test.go
@@ -38,6 +38,8 @@ type fakeAtom struct {
 	typeSeq            int
 	versionSeq         int
 	updateEntityGQLErr string
+
+	passwords map[string]string
 }
 
 // mutateOnNthGet swaps id's attributes in after its nth GetEntity call,
@@ -81,6 +83,7 @@ func newFakeAtom(t *testing.T, seed ...atom.Entity) *fakeAtom {
 		getCount:     map[string]int{},
 		deviceTypes:  map[string]atom.DeviceType{},
 		typeVersions: map[string][]atom.DeviceTypeVersion{},
+		passwords:    map[string]string{},
 	}
 	for _, e := range seed {
 		fa.entities[e.ID] = e
@@ -108,6 +111,8 @@ func (fa *fakeAtom) handle(w http.ResponseWriter, r *http.Request) {
 		fa.handleUpdate(w, req)
 	case strings.Contains(req.Query, "mutation DeleteEntity"):
 		fa.handleDelete(w, req)
+	case strings.Contains(req.Query, "mutation CreatePassword"):
+		fa.handleCreatePassword(w, req)
 	case strings.Contains(req.Query, "query Entity("):
 		fa.handleGet(w, req)
 	case strings.Contains(req.Query, "query EntityExistence("):
@@ -322,6 +327,20 @@ func (fa *fakeAtom) handleDelete(w http.ResponseWriter, req gqlRequest) {
 	}
 	delete(fa.entities, id)
 	writeGQLData(fa.t, w, map[string]any{"deleteEntity": true})
+}
+
+// handleCreatePassword also handles a password change: createPassword is
+// the one mutation for both, matching pkg/atom.Client.CreatePassword's doc
+// comment.
+func (fa *fakeAtom) handleCreatePassword(w http.ResponseWriter, req gqlRequest) {
+	entityID, _ := req.Variables["entityId"].(string)
+	if _, ok := fa.entities[entityID]; !ok {
+		writeGQLError(fa.t, w, "entity not found")
+		return
+	}
+	password, _ := req.Variables["password"].(string)
+	fa.passwords[entityID] = password
+	writeGQLData(fa.t, w, map[string]any{"createPassword": true})
 }
 
 func (fa *fakeAtom) handleGet(w http.ResponseWriter, req gqlRequest) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -77,6 +77,7 @@ func NewRootCmd() *cobra.Command {
 		NewDevicesCmd(),
 		NewGatewaysCmd(),
 		NewDeviceTypesCmd(),
+		NewUsersCmd(),
 	)
 
 	return cmd

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -26,7 +26,7 @@ func TestRootCommandContainsAtomBackedCommands(t *testing.T) {
 	cmd := NewRootCmd()
 	for _, name := range []string{
 		"health", "login", "password", cmdWorkspaces, cmdChannels, cmdGroups,
-		"authz", "devices", "gateways", "devicetypes",
+		"authz", "devices", "gateways", "devicetypes", "users",
 	} {
 		if subcmd, _, err := cmd.Find([]string{name}); err != nil || subcmd == nil || subcmd.Name() != name {
 			t.Fatalf("expected command %q to be registered", name)

--- a/cli/users.go
+++ b/cli/users.go
@@ -1,0 +1,268 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/spf13/cobra"
+)
+
+// atomKindHuman is the literal Atom wire kind for CreateEntity/ListEntities.
+// pkg/atom's own atomKindHuman constant is unexported, so it is duplicated
+// here the same way cli/devices.go duplicates atomKindDevice.
+const atomKindHuman = "human"
+
+// Operation unique to users. The shared ones (create, get, update, delete,
+// enable, disable, all) come from utils.go's block.
+const userPassword = "password"
+
+const (
+	usageUserCreate   = "cli users create <JSON_user> [workspace_id]"
+	usageUserGet      = "cli users <user_id|all> get [workspace_id]"
+	usageUserUpdate   = "cli users <user_id> update <JSON_string>"
+	usageUserDelete   = "cli users <user_id> delete"
+	usageUserEnable   = "cli users <user_id> enable"
+	usageUserDisable  = "cli users <user_id> disable"
+	usageUserPassword = "cli users <user_id> password set <new_password>"
+)
+
+// NewUsersCmd wraps pkg/atom's generic entity API for entities of kind
+// "human" — see cli/devices.go for the same shape applied to devices. A
+// human is created without a password (createEntity has no password field);
+// "password set" is the follow-up that makes an admin-created account
+// loginable, wrapping atom.Client.CreatePassword.
+//
+// Self-service sign-up and login/logout/session-refresh are not covered
+// here: they are unauthenticated or session-scoped operations, not entity
+// management, and stay GraphQL-only per the API reference.
+func NewUsersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users <user_id|all|create> [operation] [args...]",
+		Short: "Users management",
+		Long: `Format:
+  users create <JSON_user> [workspace_id]
+  users <user_id|all> <operation> [args...]
+
+Operations (require user_id/all): get, update, delete, enable, disable, password
+
+A user is an Atom entity of kind "human". workspace_id is optional on create
+and "all get" — omit it to create/list a user with no workspace membership.
+
+createEntity has no password field, so a newly created user cannot log in
+until a password is set:
+  users <user_id> password set <new_password>
+
+Self-service sign-up, login, logout and session refresh are GraphQL-only —
+see the API reference — since they are not entity management.
+
+Examples:
+  users create '{"name":"Jane Doe"}' <workspace_id>
+  users all get <workspace_id>
+  users <user_id> get
+  users <user_id> update '{"name":"Jane Doe"}'
+  users <user_id> delete
+  users <user_id> enable
+  users <user_id> disable
+  users <user_id> password set <new_password>`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if !requireAtomClient(cmd) {
+				return
+			}
+			if len(args) == 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+
+			if args[0] == create {
+				handleUserCreate(cmd, args[1:])
+				return
+			}
+
+			if len(args) < 2 {
+				logUsageCmd(*cmd, "users <user_id|all> <get|update|delete|enable|disable|password> [args...]")
+				return
+			}
+
+			userID := args[0]
+			operation := args[1]
+			opArgs := args[2:]
+
+			switch operation {
+			case get:
+				handleUserGet(cmd, userID, opArgs)
+			case update:
+				handleUserUpdate(cmd, userID, opArgs)
+			case delete:
+				handleUserDelete(cmd, userID, opArgs)
+			case enable:
+				handleUserEnable(cmd, userID, opArgs)
+			case disable:
+				handleUserDisable(cmd, userID, opArgs)
+			case userPassword:
+				handleUserPassword(cmd, userID, opArgs)
+			default:
+				logErrorCmd(*cmd, fmt.Errorf("unknown operation: %s", operation))
+			}
+		},
+	}
+
+	return cmd
+}
+
+func handleUserCreate(cmd *cobra.Command, args []string) {
+	if len(args) < 1 || len(args) > 2 {
+		logUsageCmd(*cmd, usageUserCreate)
+		return
+	}
+
+	var user atom.Entity
+	if err := json.Unmarshal([]byte(args[0]), &user); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+	user.Kind = atomKindHuman
+	if len(args) == 2 {
+		user.TenantID = args[1]
+	}
+
+	created, err := atomClient.CreateEntity(cmd.Context(), user)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, created)
+}
+
+// handleUserGet's "all" branch lists users, optionally scoped to a
+// workspace — unlike devices, a tenant-less listing is a legitimate query
+// here since a self-registered user may not belong to any workspace yet.
+func handleUserGet(cmd *cobra.Command, userID string, args []string) {
+	if userID == all {
+		if len(args) > 1 {
+			logUsageCmd(*cmd, usageUserGet)
+			return
+		}
+
+		tenantID := ""
+		if len(args) == 1 {
+			tenantID = args[0]
+		}
+
+		q := atom.Query{
+			Kind:     atomKindHuman,
+			TenantID: tenantID,
+			Q:        Name,
+			Limit:    Limit,
+			Offset:   Offset,
+		}
+		l, err := atomClient.ListEntities(cmd.Context(), q)
+		if err != nil {
+			logErrorCmd(*cmd, err)
+			return
+		}
+
+		logJSONCmd(*cmd, l)
+		return
+	}
+
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageUserGet)
+		return
+	}
+
+	u, err := atomClient.GetEntity(cmd.Context(), userID)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, u)
+}
+
+func handleUserUpdate(cmd *cobra.Command, userID string, args []string) {
+	if len(args) != 1 {
+		logUsageCmd(*cmd, usageUserUpdate)
+		return
+	}
+
+	var user atom.Entity
+	if err := json.Unmarshal([]byte(args[0]), &user); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	updated, err := atomClient.UpdateEntity(cmd.Context(), userID, user)
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, updated)
+}
+
+func handleUserDelete(cmd *cobra.Command, userID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageUserDelete)
+		return
+	}
+
+	if err := atomClient.DeleteEntity(cmd.Context(), userID); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logOKCmd(*cmd)
+}
+
+func handleUserEnable(cmd *cobra.Command, userID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageUserEnable)
+		return
+	}
+
+	u, err := atomClient.UpdateEntity(cmd.Context(), userID, atom.Entity{Status: atomEntityStatusActive})
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, u)
+}
+
+func handleUserDisable(cmd *cobra.Command, userID string, args []string) {
+	if len(args) != 0 {
+		logUsageCmd(*cmd, usageUserDisable)
+		return
+	}
+
+	u, err := atomClient.UpdateEntity(cmd.Context(), userID, atom.Entity{Status: atomEntityStatusInactive})
+	if err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logJSONCmd(*cmd, u)
+}
+
+// handleUserPassword only implements "set": createPassword is also how an
+// existing password gets replaced (see the API reference's Set/Change
+// Password section) — there is no separate update mutation to wrap.
+func handleUserPassword(cmd *cobra.Command, userID string, args []string) {
+	if len(args) != 2 || args[0] != "set" {
+		logUsageCmd(*cmd, usageUserPassword)
+		return
+	}
+
+	if err := atomClient.CreatePassword(cmd.Context(), userID, args[1]); err != nil {
+		logErrorCmd(*cmd, err)
+		return
+	}
+
+	logOKCmd(*cmd)
+}

--- a/cli/users_test.go
+++ b/cli/users_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/absmach/magistrala/cli"
+	"github.com/absmach/magistrala/pkg/atom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsersCreateCmd(t *testing.T) {
+	fa := newFakeAtom(t)
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	userJSON := `{"name":"Jane Doe"}`
+	out := executeCommand(t, rootCmd, createCmd, userJSON, "workspace-1")
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "human", got.Kind)
+	assert.Equal(t, "Jane Doe", got.Name)
+	assert.Equal(t, "workspace-1", got.TenantID)
+
+	require.Len(t, fa.requests, 1)
+	input, _ := fa.requests[0].Variables["input"].(map[string]any)
+	assert.Equal(t, "human", input["kind"])
+}
+
+// TestUsersCreateCmdNoWorkspace pins that a user can be created with no
+// workspace membership at all -- unlike a device, a human need not belong
+// to a tenant (a self-registered account starts this way too).
+func TestUsersCreateCmdNoWorkspace(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, createCmd, `{"name":"Jane Doe"}`)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "human", got.Kind)
+	assert.Equal(t, "", got.TenantID)
+}
+
+func TestUsersGetCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human", Name: "Jane Doe", TenantID: "workspace-1"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", getCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "user-1", got.ID)
+	assert.Equal(t, "Jane Doe", got.Name)
+}
+
+func TestUsersGetAllCmd(t *testing.T) {
+	newFakeAtom(t,
+		atom.Entity{ID: "user-1", Kind: "human", TenantID: "workspace-1"},
+		atom.Entity{ID: "user-2", Kind: "human", TenantID: "workspace-1"},
+		atom.Entity{ID: "user-3", Kind: "human", TenantID: "workspace-2"},
+		atom.Entity{ID: "device-1", Kind: "device", TenantID: "workspace-1"},
+	)
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd, "workspace-1")
+
+	var got atom.EntityList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+}
+
+// TestUsersGetAllCmdNoWorkspace pins that "all get" with no workspace_id
+// lists across every tenant, rather than requiring one the way devices does.
+func TestUsersGetAllCmdNoWorkspace(t *testing.T) {
+	newFakeAtom(t,
+		atom.Entity{ID: "user-1", Kind: "human", TenantID: "workspace-1"},
+		atom.Entity{ID: "user-2", Kind: "human", TenantID: "workspace-2"},
+	)
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, allCmd, getCmd)
+
+	var got atom.EntityList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, uint64(2), got.Total)
+}
+
+func TestUsersUpdateCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human", Name: "old-name", TenantID: "workspace-1"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", updateCmd, `{"name":"new-name"}`)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "new-name", got.Name)
+}
+
+func TestUsersDeleteCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", deleteCmd)
+
+	assert.Contains(t, out, "ok")
+	_, exists := fa.entities["user-1"]
+	assert.False(t, exists)
+}
+
+// TestUsersEnableCmd pins the same trap as devices.go's equivalent test:
+// UpdateEntity's status wire value is Atom's vocabulary (active/inactive).
+func TestUsersEnableCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human", Status: "inactive"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", enableCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "active", got.Status)
+}
+
+func TestUsersDisableCmd(t *testing.T) {
+	newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human", Status: "active"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", disableCmd)
+
+	var got atom.Entity
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "inactive", got.Status)
+}
+
+func TestUsersPasswordSetCmd(t *testing.T) {
+	fa := newFakeAtom(t, atom.Entity{ID: "user-1", Kind: "human"})
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "user-1", "password", "set", "new-secret")
+
+	assert.Contains(t, out, "ok")
+	assert.Equal(t, "new-secret", fa.passwords["user-1"])
+}
+
+func TestUsersPasswordSetCmdUnknownUser(t *testing.T) {
+	newFakeAtom(t)
+	rootCmd := setFlags(cli.NewUsersCmd())
+
+	out := executeCommand(t, rootCmd, "missing-user", "password", "set", "new-secret")
+
+	assert.Contains(t, out, "error")
+	assert.Contains(t, out, "entity not found")
+}


### PR DESCRIPTION
## What does this do?

Adds a `users` CLI command. There was no CLI equivalent for user management:
`cli/users.go` existed before the Atom migration (#3532 removed it along with
`clients.go`/`domains.go`/`groups.go`), and restoring the CLI against Atom
GraphQL (#3578) was explicitly scoped as a first slice that didn't bring it
back — user management has since been GraphQL-only, or reachable through
`magistrala-ui`'s sign-up/login pages.

- Adds `users` wrapping `pkg/atom`'s generic entity API for kind `human`,
  mirroring `cli/devices.go`: `create`, `get`, `all get`, `update`, `delete`,
  `enable`, `disable`.
- Adds `password set` wrapping `atom.Client.CreatePassword`, since
  `createEntity` has no password field and an admin-created user needs one
  before they can log in.
- `workspace_id` is optional on `create` and `all get`, unlike devices — a
  human need not belong to a tenant (a self-registered account starts
  without one too).
- Registers `NewUsersCmd()` on the root command and extends
  `TestRootCommandContainsAtomBackedCommands` to cover it.

## Which issue(s) does this PR fix/relate to?

Follow-up gap left by #3563 / #3578 (CLI restore didn't include users).

## Have you included tests for your changes?

Yes.

- `cli/users_test.go`: create (with/without workspace), get, all-get
  (with/without workspace filter), update, delete, enable, disable,
  password set, password set against an unknown user.
- `cli/atom_fake_test.go`: added a `createPassword` handler to the fake
  Atom server so `password set` is covered without a live backend.
- `go build ./...`, `go vet ./cli/...`, `go test ./cli/...` all pass.
- Manually verified end-to-end against a local Atom instance with
  `make cli`: create → get → update → list-by-name → password set → login
  with the new password → disable → enable → delete → confirmed gone.

## Did you document any new/modified feature?

Not yet — the `magistrala-docs` "No CLI equivalent" callout on the Users API
page should be updated/removed once this merges. Happy to follow up with
that once this is reviewed.